### PR TITLE
Typo and naming fixes in the documentation

### DIFF
--- a/doc/specs/vulkan/chapters/drawing.txt
+++ b/doc/specs/vulkan/chapters/drawing.txt
@@ -362,7 +362,7 @@ Drawing commands fall roughly into two categories:
     commands present a sequential code:vertexIndex to the vertex shader. The
     sequential index is generated automatically by the device.
   * Indexed drawing commands (fname:vkCmdDrawIndexed and
-    fname:vkCmdDrawIndexed) read index values from an _index buffer_ and use
+    fname:vkCmdDrawIndexedIndirect) read index values from an _index buffer_ and use
     this to compute the code:vertexIndex value for the vertex shader.
 
 An index buffer is bound to a command buffer by calling:

--- a/doc/specs/vulkan/chapters/primsrast.txt
+++ b/doc/specs/vulkan/chapters/primsrast.txt
@@ -87,7 +87,7 @@ as follows:
     is generated based on the value of the alpha component of the fragment's
     first color output as specified in the <<fragops-covg,Multisample
     Coverage>> section.
-  * pname:alphaToOne controls whether the value of the alpha component of
+  * pname:alphaToOneEnable controls whether the value of the alpha component of
     the fragment's first color output is replaced with one as described in
     <<fragops-covg,Multisample Coverage>>.
 

--- a/doc/specs/vulkan/man/VkMemoryPropertyFlags.txt
+++ b/doc/specs/vulkan/man/VkMemoryPropertyFlags.txt
@@ -14,7 +14,7 @@ include::../flags/VkMemoryPropertyFlags.txt[]
 Constants
 ---------
 
-ename:VK_MEMORY_PROPERTY_DEVICE_ONLY::
+ename:VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT::
     Unless any other flag is used to enable other uses this constant
     identifies memory that's only accessible by the device.
 
@@ -22,14 +22,14 @@ ename:VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT::
     Identifies a memory pool that can be mapped into host memory address
     space and thus is accessible by the host.
 
-ename:VK_MEMORY_PROPERTY_HOST_NON_COHERENT_BIT::
+ename:VK_MEMORY_PROPERTY_HOST_COHERENT_BIT::
     Identifies a memory pool where accesses beteen the host and the
     coherency domain are not conherent. Memory with this property needs
     explicit use of flink:vkFlushMappedMemoryRanges after host writes to
     this type of memory, and use of flink:vkInvalidateMappedMemoryRanges
     before host reads from that memory.
 
-ename:VK_MEMORY_PROPERTY_HOST_UNCACHED_BIT::
+ename:VK_MEMORY_PROPERTY_HOST_CACHED_BIT::
     Identifies memory that is not cached by the host.
 
 ename:VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT::

--- a/doc/specs/vulkan/man/vkCmdDraw.txt
+++ b/doc/specs/vulkan/man/vkCmdDraw.txt
@@ -23,7 +23,7 @@ pname:vertexCount::
     The number of vertices passed to the graphics pipeline.
 
 pname:firstInstance::
-    The first instance of data to be passed to the graphice pipeline.
+    The first instance of data to be passed to the graphics pipeline.
 
 pname:instanceCount::
     The number of instances to be passed to the graphics pipeline.

--- a/doc/specs/vulkan/man/vkGetPhysicalDeviceMemoryProperties.txt
+++ b/doc/specs/vulkan/man/vkGetPhysicalDeviceMemoryProperties.txt
@@ -58,18 +58,18 @@ pname:propertyFlags member of the slink:VkMemoryType structure is defined as fol
 
 include::../enums/VkMemoryPropertyFlagBits.txt[]
 
-* ename:VK_MEMORY_PROPERTY_DEVICE_ONLY represents the case where no bits are set and signifies
+* ename:VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT represents the case where no bits are set and signifies
 that the memory is private to the device.
 
 * ename:VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT indicates that memory with this property is visible
 to the host. That is, a valid host address may be obtained and allocations from this memory
 type may be mapped.
 
-* ename:VK_MEMORY_PROPERTY_HOST_NON_COHERENT_BIT indicates that accesses to mapped memory of this
+* ename:VK_MEMORY_PROPERTY_HOST_COHERENT_BIT indicates that accesses to mapped memory of this
 type is not coherent with accesses to the same memory by the device. Such access must be marhsalled
 using calls to flink:vkFlushMappedMemoryRanges or by unmapping the memory.
 
-* ename:VK_MEMORY_PROPERTY_HOST_UNCACHED_BIT indicates that data stored in memory of this type is not
+* ename:VK_MEMORY_PROPERTY_HOST_CACHED_BIT indicates that data stored in memory of this type is not
 cached by the host and as such, it is likely that reads from such regions by the host will
 be suboptimal.
 


### PR DESCRIPTION
A PR where I fix simple typos and naming errors that I find or which people report in issues.