### PR TITLE
vkCmdDraw.txt: fix typo

### DIFF
--- a/doc/specs/vulkan/man/vkCmdDraw.txt
+++ b/doc/specs/vulkan/man/vkCmdDraw.txt
@@ -23,7 +23,7 @@ pname:vertexCount::
     The number of vertices passed to the graphics pipeline.
 
 pname:firstInstance::
-    The first instance of data to be passed to the graphice pipeline.
+    The first instance of data to be passed to the graphics pipeline.
 
 pname:instanceCount::
     The number of instances to be passed to the graphics pipeline.


### PR DESCRIPTION
Fixed a typo in the specification