### PR TITLE
primsrast.txt: fix variable name. fixes #8

### DIFF
--- a/doc/specs/vulkan/chapters/primsrast.txt
+++ b/doc/specs/vulkan/chapters/primsrast.txt
@@ -87,7 +87,7 @@ as follows:
     is generated based on the value of the alpha component of the fragment's
     first color output as specified in the <<fragops-covg,Multisample
     Coverage>> section.
-  * pname:alphaToOne controls whether the value of the alpha component of
+  * pname:alphaToOneEnable controls whether the value of the alpha component of
     the fragment's first color output is replaced with one as described in
     <<fragops-covg,Multisample Coverage>>.
 


### PR DESCRIPTION
Fixed a naming error in the documentation to match vulkan.h