### PR TITLE
drawing.txt: fix function name. fixes #11

### DIFF
--- a/doc/specs/vulkan/chapters/drawing.txt
+++ b/doc/specs/vulkan/chapters/drawing.txt
@@ -362,7 +362,7 @@ Drawing commands fall roughly into two categories:
     commands present a sequential code:vertexIndex to the vertex shader. The
     sequential index is generated automatically by the device.
   * Indexed drawing commands (fname:vkCmdDrawIndexed and
-    fname:vkCmdDrawIndexed) read index values from an _index buffer_ and use
+    fname:vkCmdDrawIndexedIndirect) read index values from an _index buffer_ and use
     this to compute the code:vertexIndex value for the vertex shader.
 
 An index buffer is bound to a command buffer by calling:


### PR DESCRIPTION
Fixed a naming error in the documentation in order not to repeat the same function name