### PR TITLE
extensions.txt: fix inclusion of the vkEnumerateInstanceExtensionProperties validity block

### DIFF
--- a/doc/specs/vulkan/chapters/extensions.txt
+++ b/doc/specs/vulkan/chapters/extensions.txt
@@ -129,8 +129,9 @@ include::../protos/vkEnumerateInstanceExtensionProperties.txt[]
     in which properties of instance extensions available on this
     implementation are returned.
 
-include::../validity/protos/vkEnumerateInstanceExtensionProperties.txt[] Any
-instance extensions provided by the {apiname} implementation or by
+include::../validity/protos/vkEnumerateInstanceExtensionProperties.txt[]
+
+Any instance extensions provided by the {apiname} implementation or by
 implicitly enabled layers, but not by explicitly enabled layers, are
 returned when pname:pLayerName parameter is `NULL`. When pname:pLayerName is
 the name of a layer, the instance extensions provided by that layer are


### PR DESCRIPTION
The include:: directive itself was transcribed into the PDF, instead of the included block. This adds missing line breaks after that directive.