### PR TITLE
vkCmdResolveImage: Fix references to blitting

### DIFF
--- a/doc/specs/vulkan/chapters/copies.txt
+++ b/doc/specs/vulkan/chapters/copies.txt
@@ -470,11 +470,11 @@ include::../protos/vkCmdResolveImage.txt[]
     recorded.
   * pname:srcImage is the source image.
   * pname:srcImageLayout is the layout of the source image subresources for
-    the blit.
+    the resolve.
   * pname:dstImage is the destination image.
   * pname:dstImageLayout is the layout of the destination image subresources
-    for the blit.
-  * pname:regionCount is the number of regions to blit.
+    for the resolve.
+  * pname:regionCount is the number of regions to resolve.
   * pname:pRegions is a pointer to an array of slink:VkImageResolve
     structures specifying the regions to resolve.
 
@@ -516,4 +516,4 @@ pname:height and pname:depth.
 
 Resolves are done layer by layer starting with pname:baseArrayLayer member
 of pname:srcSubresource for the source and pname:dstSubresource for the
-destination. pname:layerCount layers are blitted to the destination image.
+destination. pname:layerCount layers are resolved to the destination image.


### PR DESCRIPTION
These look like copy-paste errors from vkCmdBlitImage into vkCmdResolveImage.