### PR TITLE
vkCmdCopyBuffer: Fix references to copySize

### DIFF
--- a/doc/specs/vulkan/validity/protos/vkCmdCopyBuffer.txt
+++ b/doc/specs/vulkan/validity/protos/vkCmdCopyBuffer.txt
@@ -16,8 +16,8 @@ endif::doctype-manpage[]
 * This command must: only be called outside of a render pass instance
 * The value of pname:regionCount must: be greater than `0`
 * Each of pname:commandBuffer, pname:srcBuffer and pname:dstBuffer must: have been created, allocated or retrieved from the same sname:VkDevice
-* The sum of the pname:srcOffset and pname:copySize members of a given element of pname:pRegions must: be less than or equal to the size of pname:srcBuffer
-* The sum of the pname:dstOffset and pname:copySize members of a given element of pname:pRegions must: be less than or equal to the size of pname:dstBuffer
+* The sum of the pname:srcOffset and pname:size members of a given element of pname:pRegions must: be less than or equal to the size of pname:srcBuffer
+* The sum of the pname:dstOffset and pname:size members of a given element of pname:pRegions must: be less than or equal to the size of pname:dstBuffer
 * The union of the source regions, and the union of the destination regions, specified by the elements of pname:pRegions, mustnot: overlap in memory
 * pname:srcBuffer must: have been created with pname:VK_BUFFER_USAGE_TRANSFER_SRC_BIT usage flag
 * pname:dstBuffer must: have been created with pname:VK_BUFFER_USAGE_TRANSFER_DST_BIT usage flag


### PR DESCRIPTION
The member is just called 'size'.