### PR TITLE
VkBufferImageCopy: Fix references to subresources

### DIFF
--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -1015,9 +1015,9 @@ maintained in the master branch of the Khronos Vulkan Github project.
                 <usage>  pname:imageExtent.height must: be a multiple of the block height or (pname:imageExtent.height + pname:imageOffset.y) must: equal the image subresource height</usage>
                 <usage>  pname:imageExtent.depth must: be a multiple of the block depth or (pname:imageExtent.depth + pname:imageOffset.z) must: equal the image subresource depth</usage>
                 <usage>pname:bufferOffset, pname:bufferRowLength, pname:bufferImageHeight and all members of pname:imageOffset and pname:imageExtent must: respect the image transfer granularity requirements of the queue family that it will be submitted against, as described in &lt;&lt;execution-physical-device-enumeration,Physical Device Enumeration&gt;&gt;</usage>
-                <usage>The pname:aspectMask member of pname:srcSubresource must: specify aspects present in the calling command's sname:VkImage parameter</usage>
-                <usage>The pname:aspectMask member of pname:pSubresource must: only have a single bit set</usage>
-                <usage>If the calling command's sname:VkImage parameter is of elink:VkImageType ename:VK_IMAGE_TYPE_3D, the pname:baseArrayLayer and pname:layerCount members of both pname:srcSubresource and pname:dstSubresource must: be `0` and `1`, respectively</usage>
+                <usage>The pname:aspectMask member of pname:imageSubresource must: specify aspects present in the calling command's sname:VkImage parameter</usage>
+                <usage>The pname:aspectMask member of pname:imageSubresource must: only have a single bit set</usage>
+                <usage>If the calling command's sname:VkImage parameter is of elink:VkImageType ename:VK_IMAGE_TYPE_3D, the pname:baseArrayLayer and pname:layerCount members of pname:imageSubresource must: be `0` and `1`, respectively</usage>
             </validity>
         </type>
         <type category="struct" name="VkImageResolve">


### PR DESCRIPTION
There is no pSubresource, srcSubresource, dstSubresource;
only imageSubresource.