### PR TITLE
[WIP/RFC] Generator for Julia bindings

### DIFF
--- a/src/spec/Makefile
+++ b/src/spec/Makefile
@@ -101,6 +101,9 @@ test: ../vulkan/vulkan.h ../vulkan/vk_platform.h
 vk.json: tojson.py vk.xml
 	$(PYTHON) tojson.py vk.xml > $@
 
+vk.jl: $(VKH_DEPENDS)
+	$(PYTHON) genvk.py $(GENOPTS) $@
+
 ################################################
 
 # Documentation targets

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -630,9 +630,14 @@ class JlOutputGenerator(OutputGenerator):
                 lastType = self.makeJlType(text, tail)
             elif (elem.tag == 'name'):
                 if (tail == '['):
+                    # FIXME: pipelineCacheUUID[VK_UUID_SIZE];
+                    print(text)
+                    print(tail)
                     lastType = 'Vector{'+lastType+'}'
+                elif (tail.startswith('[')): # Fixed sized member
+                    n = tail[1]
+                    lastType = 'NTuple{' + n + ', ' + lastType +'}'
                 elif (tail != ''):
-                    # todo handle fixed array lengths
                     print(tail)
                     continue
 

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -755,6 +755,15 @@ class JlOutputGenerator(OutputGenerator):
                     return [None, None]
             return [None, value]
 
+        elif ('bitpos' in elem.keys()):
+            value = elem.get('bitpos')
+            numVal = int(value, 0)
+            numVal = 1 << numVal
+            value = '0x%08x' % numVal
+            return [numVal, value]
+        elif ('offset' in elem.keys()):
+            print('Skipping offset enum: ' +  elem.get('name'))
+            return [None, None]
         else:
             print(elem.keys())
             return [None, None]

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -609,7 +609,29 @@ class JlOutputGenerator(OutputGenerator):
         category = typeElem.get('category')
         if (category == 'struct'):
             self.genStruct(typeinfo, name)
-        # TODO: What else & how to handle unions
+        elif (category == 'union'): # TODO: Handle unions
+            print('Omitting union: ' + name)
+        else:
+            s = noneStr(typeElem.text).strip()
+            print(s)
+            if (s == 'typedef'):
+                lastType = ''
+                for elem in typeElem:
+                    text = noneStr(elem.text).strip()
+                    tail = noneStr(elem.tail).strip()
+                    if (elem.tag == 'type'):
+                        lastType = self.makeJlType(text, tail)
+                    elif (elem.tag == 'name' and text != ''):
+                        s = 'typealias ' + text + ' ' + lastType
+            elif s.startsWith('#include'):
+                yield # Skip includes
+            else:
+                for elem in typeElem:
+                    if (elem.tag == 'apientry'):
+                        s += noneStr(elem.tail)
+                    else:
+                        s += noneStr(elem.text)#noneStr(elem.text) + noneStr(elem.tail)
+                print(s)
 
     def genStruct(self, typeinfo, name):
         OutputGenerator.genStruct(self, typeinfo, name)
@@ -631,8 +653,6 @@ class JlOutputGenerator(OutputGenerator):
             elif (elem.tag == 'name'):
                 if (tail == '['):
                     # FIXME: pipelineCacheUUID[VK_UUID_SIZE];
-                    print(text)
-                    print(tail)
                     lastType = 'Vector{'+lastType+'}'
                 elif (tail.startswith('[')): # Fixed sized member
                     n = tail[1]

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -630,9 +630,12 @@ class JlOutputGenerator(OutputGenerator):
                     if (text == 'VK_NULL_HANDLE'):
                         s = 'const ' + elem.text + ' = C_NULL' #TODO: Double check in vulkan.h this is just 0
                     elif (text == 'VK_DEFINE_HANDLE'):
-                        s = 'macro ' + elem.text + '(object)\n'
-                        # TODO: Correct that macro
+                        s  = 'macro ' + elem.text + '(object)\n'
+                        s += '  quote\n'
+                        s += '    typealias $object Ptr{Void}\n'
+                        s += '  end\n'
                         s += 'end'
+                        # TODO: Correct that macro
                     else:
                         return # skipping version defines
             elif s.startswith('typedef'): # Function pointers
@@ -647,9 +650,12 @@ class JlOutputGenerator(OutputGenerator):
                 if (s.startswith('//')):
                     return # skip another version define
                 elif(s.startswith('#if')):
-                    s = 'macro VK_DEFINE_NON_DISPATCHABLE_HANDLE(object)\nend'
+                    s  = 'macro VK_DEFINE_NON_DISPATCHABLE_HANDLE(object)\n'
+                    s += '  quote\n'
+                    s += '    typealias $object Ptr{Void}\n'
+                    s += '  end\n'
+                    s += 'end'
                     # TODO: macro for VK_DEFINE_NON_DISPATCHABLE_HANDLE
-                    return
                 elif(len(typeElem) > 0):
                     s = '@'
                     for elem in typeElem:

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -712,6 +712,27 @@ class JlOutputGenerator(OutputGenerator):
         else: # Vulkan types
             return text
 
+    def enumToValue(self, elem, needsNum):
+        name = elem.get('name')
+        if ('value' in elem.keys()):
+            value = elem.get('value')
+            if value.endswith('f'): # Julia Floats
+                value += '0'
+            elif value.startswith('(~'):
+                if value.endswith('U)'):
+                    value = 'typemax(UInt32)'
+                elif value.endswith('ULL)'):
+                    value = 'typemax(UInt64)'
+                else:
+                    print(value)
+                    return [None, None]
+            return [None, value]
+
+        else:
+            print(elem.keys())
+            return [None, None]
+
+
     def genCmd(self, cmdinfo, name):
         OutputGenerator.genCmd(self, cmdinfo, name)
 
@@ -730,9 +751,15 @@ class JlOutputGenerator(OutputGenerator):
 
         write(body, file=self.outFile)
 
+    # Really just a misnomer and these are constants
     def genEnum(self, enuminfo, name):
         OutputGenerator.genEnum(self, enuminfo, name)
-        # TODO: Create Julia enums
+        (_, value) = self.enumToValue(enuminfo.elem, False)
+        body = 'const ' + name + ' = ' + value # TODO: ensure type
+        write(body, file=self.outFile)
+
+    def genGroup(self,groupinfo, name):
+        body = '@enum('+name+',\n'
 
     def checkName(self, name):
         reserved = ['type']

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -602,6 +602,7 @@ class JlOutputGenerator(OutputGenerator):
 
     # def endFile(self):
     #    OutputGenerator.endFile(self)
+
     def genType(self, typeinfo, name):
         OutputGenerator.genType(self, typeinfo, name)
         typeElem = typeinfo.elem
@@ -633,11 +634,13 @@ class JlOutputGenerator(OutputGenerator):
             elif s.startswith('#include'):
                 return # Skip includes
             else:
+                return
                 for elem in typeElem:
                     if (elem.tag == 'apientry'):
                         s += noneStr(elem.tail)
                     else:
                         s += noneStr(elem.text)#noneStr(elem.text) + noneStr(elem.tail)
+            write(s, file=self.outFile)
 
     def genStruct(self, typeinfo, name):
         OutputGenerator.genStruct(self, typeinfo, name)
@@ -713,6 +716,7 @@ class JlOutputGenerator(OutputGenerator):
 
     def genEnum(self, enuminfo, name):
         OutputGenerator.genEnum(self, enuminfo, name)
+        # TODO: Create Julia enums
 
     def checkName(self, name):
         reserved = ['type']

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -647,12 +647,12 @@ class JlOutputGenerator(OutputGenerator):
                     if (text == 'VK_NULL_HANDLE'):
                         s = 'const ' + elem.text + ' = C_NULL' #TODO: Double check in vulkan.h this is just 0
                     elif (text == 'VK_DEFINE_HANDLE'):
+                        # Emit opaque pointer 
                         s  = 'macro ' + elem.text + '(object)\n'
                         s += '  quote\n'
                         s += '    typealias $object Ptr{Void}\n'
                         s += '  end\n'
                         s += 'end'
-                        # TODO: Correct that macro
                     else:
                         return # skipping version defines
             elif s.startswith('typedef'): # Function pointers
@@ -672,7 +672,7 @@ class JlOutputGenerator(OutputGenerator):
                     s += '    typealias $object Ptr{Void}\n'
                     s += '  end\n'
                     s += 'end'
-                    # TODO: macro for VK_DEFINE_NON_DISPATCHABLE_HANDLE
+                    # TODO: Support 32-bits
                 elif(len(typeElem) > 0):
                     s = '@'
                     for elem in typeElem:

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -589,6 +589,13 @@ class OutputGenerator:
         self.registry = registry
         #
 
+class JlOutputGenerator(OutputGenerator):
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
+
 # COutputGenerator - subclass of OutputGenerator.
 # Generates C-language API interfaces.
 #

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -684,7 +684,7 @@ class JlOutputGenerator(OutputGenerator):
 
     def genStruct(self, typeinfo, name):
         OutputGenerator.genStruct(self, typeinfo, name)
-        body = 'type ' + name + '\n'
+        body = 'immutable ' + name + '\n'
         for member in typeinfo.elem.findall('.//member'):
             body += '  ' +self.makeJlParamDecl(member) + '\n'
         body += 'end\n'

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -809,17 +809,17 @@ class JlOutputGenerator(OutputGenerator):
         if len(paramTypes) == 1:
             typeString += ','
 
-        paramString = ''
-        for (n, p) in zip(paramNames, paramTypes):
-            paramString += n
-            if not p.startswith('Ptr'): # Emit no types for Ptr
-                paramString += ' :: ' + p
-            paramString += ', '
+        # paramString = ''
+        # for (n, p) in zip(paramNames, paramTypes):
+        #     paramString += n
+        #     if not p.startswith('Ptr'): # Emit no types for Ptr
+        #         paramString += ' :: ' + p
+        #     paramString += ', '
 
         names = ', '.join(paramNames)
 
         ccall = 'ccall((:' + name + ', libvulkan), ' + returnType + ', (' + typeString + '), ' + names + ')'
-        body = 'function ' + name + '(' + paramString + ')\n'
+        body = 'function ' + name + '(' + names + ')\n'
         body += '  ' + ccall + '\nend'
 
         write(body, file=self.outFile)

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -274,6 +274,24 @@ class DocGeneratorOptions(GeneratorOptions):
         self.alignFuncParam  = alignFuncParam
         self.expandEnumerants = expandEnumerants
 
+class JlGeneratorOptions(GeneratorOptions):
+    """Represents options during Jl interface generation"""
+    def __init__(self,
+                 filename = None,
+                 apiname = None,
+                 profile = None,
+                 versions = '.*',
+                 emitversions = '.*',
+                 defaultExtensions = None,
+                 addExtensions = None,
+                 removeExtensions = None,
+                 sortProcedure = regSortFeatures,
+                 prefixText = ""):
+        GeneratorOptions.__init__(self, filename, apiname, profile,
+                                  versions, emitversions, defaultExtensions,
+                                  addExtensions, removeExtensions, sortProcedure)
+        self.prefixText      = prefixText
+
 # OutputGenerator - base class for generating API interfaces.
 # Manages basic logic, logging, and output file control
 # Derived classes actually generate formatted output.
@@ -598,6 +616,16 @@ class JlOutputGenerator(OutputGenerator):
 
     def beginFile(self, genOpts):
         OutputGenerator.beginFile(self, genOpts)
+
+        # User-supplied prefix text, if any (list of strings)
+        if (genOpts.prefixText):
+            for s in genOpts.prefixText:
+                if (s == '/*' or s == '*/'):
+                    s = '#'* 80
+                elif s.startswith('**'):
+                    s = s.replace('**', '##', 1)
+
+                write(s, file=self.outFile)
         # TODO: write license
 
     # def endFile(self):

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -636,7 +636,7 @@ class JlOutputGenerator(OutputGenerator):
                     print(tail)
                     continue
 
-                paramdecl += text + ' :: ' + lastType
+                paramdecl += self.checkName(text) + ' :: ' + lastType
         return paramdecl
 
     def makeJlType(self, text, tail):
@@ -682,6 +682,12 @@ class JlOutputGenerator(OutputGenerator):
 
     def genEnum(self, enuminfo, name):
         OutputGenerator.genEnum(self, enuminfo, name)
+
+    def checkName(self, name):
+        reserved = ['type']
+        if name in reserved:
+            return '_'+name
+        return name
 
 
 

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -805,12 +805,22 @@ class JlOutputGenerator(OutputGenerator):
             paramNames.append(param)
             paramTypes.append(pType)
 
-        returnType = 'Void'
         typeString = ', '.join(paramTypes)
         if len(paramTypes) == 1:
             typeString += ','
 
-        body = '@vk_func(' + name + ', ' + returnType + ', (' + typeString +'))'
+        paramString = ''
+        for (n, p) in zip(paramNames, paramTypes):
+            paramString += n
+            if not p.startswith('Ptr'): # Emit no types for Ptr
+                paramString += ' :: ' + p
+            paramString += ', '
+
+        names = ', '.join(paramNames)
+
+        ccall = 'ccall((:' + name + ', libvulkan), ' + returnType + ', (' + typeString + '), ' + names + ')'
+        body = 'function ' + name + '(' + paramString + ')\n'
+        body += '  ' + ccall + '\nend'
 
         write(body, file=self.outFile)
 

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -611,7 +611,24 @@ class JlOutputGenerator(OutputGenerator):
         if (category == 'struct'):
             self.genStruct(typeinfo, name)
         elif (category == 'union'): # TODO: Handle unions
-            print('Omitting union: ' + name)
+            name = name.strip()
+            s = ''
+            if (name == 'VkClearValue'):
+                # TODO: What to do about depthStencil
+                s += 'immutable VkClearValue\n'
+                s += '  color :: VkClearColorValue\n'
+                s += 'end'
+                print('Emitting special case: ' + name)
+            elif (name == 'VkClearColorValue'):
+                # This could probably just be a type out of ColorTypes.jl
+                s += 'immutable VkClearColorValue{T <: Union{Float32, Int32, UInt32}}\n'
+                s += '  val :: NTuple{4, T}\n'
+                s += 'end'
+                print('Emitting special case: ' + name)
+            else:
+                print('Omitting union: ' + name)
+                return
+            write(s, file = self.outFile)
         else:
             s = noneStr(typeElem.text).strip()
             if (s == 'typedef'):

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -754,19 +754,8 @@ class JlOutputGenerator(OutputGenerator):
                     print(value)
                     return [None, None]
             return [None, value]
-
-        elif ('bitpos' in elem.keys()):
-            value = elem.get('bitpos')
-            numVal = int(value, 0)
-            numVal = 1 << numVal
-            value = '0x%08x' % numVal
-            return [numVal, value]
-        elif ('offset' in elem.keys()):
-            print('Skipping offset enum: ' +  elem.get('name'))
-            return [None, None]
         else:
-            print(elem.keys())
-            return [None, None]
+            return OutputGenerator.enumToValue(self, elem, needsNum)
 
 
     def genCmd(self, cmdinfo, name):

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -750,7 +750,7 @@ class JlOutputGenerator(OutputGenerator):
         mapping = {'void': 'Void',
                    'uint32_t': 'UInt32',
                    'uint64_t': 'UInt64',
-                   'char' : 'Char',
+                   'char' : 'Cchar',
                    'size_t': 'Csize_t',
                    'float': 'Cfloat',
                    'int32_t': 'Int32',

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -613,7 +613,6 @@ class JlOutputGenerator(OutputGenerator):
             print('Omitting union: ' + name)
         else:
             s = noneStr(typeElem.text).strip()
-            print(s)
             if (s == 'typedef'):
                 lastType = ''
                 for elem in typeElem:
@@ -623,15 +622,22 @@ class JlOutputGenerator(OutputGenerator):
                         lastType = self.makeJlType(text, tail)
                     elif (elem.tag == 'name' and text != ''):
                         s = 'typealias ' + text + ' ' + lastType
-            elif s.startsWith('#include'):
-                yield # Skip includes
+            elif s.startswith('#define'):
+                return # TODO: handle defines
+            elif s.startswith('typedef'): # Function pointers
+                name = ''
+                for elem in typeElem:
+                    if elem.tag == 'name':
+                        name = noneStr(elem.text).strip()
+                s = 'typealias ' + name + ' Ptr{Void}'
+            elif s.startswith('#include'):
+                return # Skip includes
             else:
                 for elem in typeElem:
                     if (elem.tag == 'apientry'):
                         s += noneStr(elem.tail)
                     else:
                         s += noneStr(elem.text)#noneStr(elem.text) + noneStr(elem.tail)
-                print(s)
 
     def genStruct(self, typeinfo, name):
         OutputGenerator.genStruct(self, typeinfo, name)

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -623,7 +623,7 @@ class JlOutputGenerator(OutputGenerator):
                         lastType = self.makeJlType(text, tail)
                     elif (elem.tag == 'name' and text != ''):
                         s = 'typealias ' + text + ' ' + lastType
-            elif s.startswith('#define'):
+            elif (s == '#define'):
                 for elem in typeElem:
                     text = noneStr(elem.text).strip()
                     # We need special casing here...
@@ -644,12 +644,18 @@ class JlOutputGenerator(OutputGenerator):
             elif s.startswith('#include'):
                 return # Skip includes
             else:
-                return
-                for elem in typeElem:
-                    if (elem.tag == 'apientry'):
-                        s += noneStr(elem.tail)
-                    else:
-                        s += noneStr(elem.text)#noneStr(elem.text) + noneStr(elem.tail)
+                if (s.startswith('//')):
+                    return # skip another version define
+                elif(s.startswith('#if')):
+                    # TODO: macro for VK_DEFINE_NON_DISPATCHABLE_HANDLE
+                    return
+                elif(len(typeElem) > 0):
+                    s = '@'
+                    for elem in typeElem:
+                        text = noneStr(elem.text).strip()
+                        tail = noneStr(elem.tail).strip()
+                        s += text + tail
+
             write(s, file=self.outFile)
 
     def genStruct(self, typeinfo, name):

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -647,6 +647,7 @@ class JlOutputGenerator(OutputGenerator):
                 if (s.startswith('//')):
                     return # skip another version define
                 elif(s.startswith('#if')):
+                    s = 'macro VK_DEFINE_NON_DISPATCHABLE_HANDLE(object)\nend'
                     # TODO: macro for VK_DEFINE_NON_DISPATCHABLE_HANDLE
                     return
                 elif(len(typeElem) > 0):

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -624,7 +624,17 @@ class JlOutputGenerator(OutputGenerator):
                     elif (elem.tag == 'name' and text != ''):
                         s = 'typealias ' + text + ' ' + lastType
             elif s.startswith('#define'):
-                return # TODO: handle defines
+                for elem in typeElem:
+                    text = noneStr(elem.text).strip()
+                    # We need special casing here...
+                    if (text == 'VK_NULL_HANDLE'):
+                        s = 'const ' + elem.text + ' = C_NULL' #TODO: Double check in vulkan.h this is just 0
+                    elif (text == 'VK_DEFINE_HANDLE'):
+                        s = 'macro ' + elem.text + '(object)\n'
+                        # TODO: Correct that macro
+                        s += 'end'
+                    else:
+                        return # skipping version defines
             elif s.startswith('typedef'): # Function pointers
                 name = ''
                 for elem in typeElem:

--- a/src/spec/genvk.py
+++ b/src/spec/genvk.py
@@ -23,7 +23,7 @@
 
 import sys, time, pdb, string, cProfile
 from reg import *
-from generator import write, CGeneratorOptions, COutputGenerator, DocGeneratorOptions, DocOutputGenerator, PyOutputGenerator, ValidityOutputGenerator, HostSynchronizationOutputGenerator
+from generator import write, CGeneratorOptions, COutputGenerator, DocGeneratorOptions, DocOutputGenerator, JlOutputGenerator, PyOutputGenerator, ValidityOutputGenerator, HostSynchronizationOutputGenerator
 
 # debug - start header generation in debugger
 # dump - dump registry after loading
@@ -232,6 +232,13 @@ buildList = [
         removeExtensions  =
             makeREstring([
             ]))
+    ],
+    # Generates Julia API bindings
+    [ JlOutputGenerator,
+      GeneratorOptions(
+          filename          = 'vk.jl',
+          apiname           = 'vulkan',
+          defaultExtensions = 'vulkan')
     ],
     # Vulkan 1.0 draft - core API validity files for spec
     # Overwrites validity subdirectories in spec source tree

--- a/src/spec/genvk.py
+++ b/src/spec/genvk.py
@@ -23,7 +23,7 @@
 
 import sys, time, pdb, string, cProfile
 from reg import *
-from generator import write, CGeneratorOptions, COutputGenerator, DocGeneratorOptions, DocOutputGenerator, JlOutputGenerator, PyOutputGenerator, ValidityOutputGenerator, HostSynchronizationOutputGenerator
+from generator import write, JlGeneratorOptions, CGeneratorOptions, COutputGenerator, DocGeneratorOptions, DocOutputGenerator, JlOutputGenerator, PyOutputGenerator, ValidityOutputGenerator, HostSynchronizationOutputGenerator
 
 # debug - start header generation in debugger
 # dump - dump registry after loading
@@ -235,10 +235,12 @@ buildList = [
     ],
     # Generates Julia API bindings
     [ JlOutputGenerator,
-      GeneratorOptions(
+      JlGeneratorOptions(
           filename          = 'vk.jl',
           apiname           = 'vulkan',
-          defaultExtensions = 'vulkan')
+          defaultExtensions = 'vulkan',
+          prefixText        = prefixStrings + vkPrefixStrings,
+          )
     ],
     # Vulkan 1.0 draft - core API validity files for spec
     # Overwrites validity subdirectories in spec source tree


### PR DESCRIPTION
This is my current attempt to generate Julia bindings from vk.xml. This is still in progress and before it is mainlined it needs to be better documented and cleaned-up.

One of the big issue I am facing right now are Union types that are used in Vulkan, especially `VkClearValue` (the two union members have different size).
As pointed out in https://github.com/KhronosGroup/Vulkan-Docs/issues/6#issuecomment-187889611 we should split these community provided bindings into their own file. 
CC: @oddhack 

The generated code and Julia bindings can be found at https://github.com/JuliaGPU/Vulkan.jl/pull/1