### PR TITLE
Fixes for #101 (public issue 101)

### DIFF
--- a/doc/specs/vulkan/appendices/extensions.txt
+++ b/doc/specs/vulkan/appendices/extensions.txt
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-2016 The Khronos Group Inc.
 // Copyright notice at https://www.khronos.org/registry/speccopyright.html
 
-[appendix]
+[[extensions]]
 = Layers & Extensions
 
 Extensions to the {apiname} API can: be defined by authors, groups of
@@ -118,25 +118,28 @@ only for layers.
      an author prefix can: instead use a fully-qualified domain name (FQDN)
      in reverse-order as an author prefix, using all lower-case characters,
      and replacing +.+ (period) with `_` (underscore) characters. For
-     example, a layer written by the owner of www.3dxcl.com would use the
-     prefix `VK_LAYER_com_3dxcl_www_`. FQDNs must: be encoded in UTF-8.
+     example, a layer written by the owner of www.3dxcl.invalid would use
+     the prefix `VK_LAYER_invalid_3dxcl_www_`. FQDNs must: be encoded in
+     UTF-8.
+
+[NOTE]
+.Note
+====
+To avoid linking to a nonexistent domain, the reserved TLD +.invalid+ is
+used.
+====
 
 
-== Extension Command, Token, and Type Naming Conventions
+[[extensions-naming]]
+== Extension Command, Type, and Token Naming Conventions
 
-Extensions may: add new commands, tokens, and types, or collectively
-``objects'' to the {apiname} API. These objects also require globally unique
-names. These names shall conform to the following template:
+Extensions may: add new commands, types, and tokens, or collectively
+``objects'', to the {apiname} API. These objects are given globally unique
+names by appending the author prefix defined above for the extension name
+according to the following templates.
 
-["source","{basebackend@docbook:c++:cpp}",title=""]
-------------------------------------------------------------------------------
-vk<CommandName><ExtensionAuthorPrefix>
-------------------------------------------------------------------------------
-
-Where +ExtensionAuthorPrefix+ is equal to that of the prefixes defined above
-for extension names with the exception that a leading `_` (underscore) is
-added for non-Khronos extensions. For example, a Khronos-blessed extension
-could expose the following command:
+A command or type name simply appends the author prefix. For example, a
+Khronos-blessed extension could expose the following command:
 
 ["source","{basebackend@docbook:c++:cpp}",title=""]
 ------------------------------------------------------------------------------
@@ -150,14 +153,16 @@ A Google extension could expose the following command:
 void vkDoSomethingGOOGLE(void);
 ------------------------------------------------------------------------------
 
-A multi-author extension could expose the following type:
+And a multi-author extension could expose the following type:
 
 ["source","{basebackend@docbook:c++:cpp}",title=""]
 ------------------------------------------------------------------------------
 typedef struct VkSomeDataEXT;
 ------------------------------------------------------------------------------
 
-And a non-Khronos extension could expose this enumerant:
+Enumeration or constant token names are constructed by following the token
+name with `_` and the author prefix, so a non-Khronos extension could expose
+this enumerantion:
 
 ["source","{basebackend@docbook:c++:cpp}",title=""]
 ------------------------------------------------------------------------------
@@ -359,7 +364,7 @@ extensions. This includes the following:
 Extensions can: define their own enumeration types and assign any values to
 their enumerants that they like. Each enumeration has a private namespace,
 so collisions are not a problem. However, when extending existing
-enumeration object with new values, care must: be taken to preserve global
+enumeration objects with new values, care must: be taken to preserve global
 uniqueness of values. Enumerations which define new bitfields are treated
 specially as described in <<extensions-reserving-bitfield-values,Reserving
 Bitfield Values>> below.
@@ -450,9 +455,9 @@ the following definitions were in effect:
 == Extension Objects, Enums, and Typedefs
 
 Expanding on previous discussion, extensions can: add values to existing
-enums; and can: add their own objects, enums, typedefs, etc. This is done by
-adding to <<extensions-api-registry,+vk.xml+>>. All such additions will be
-included in the +vulkan.h+ header supplied by Khronos.
+enums; and can: add their own commands, enums, typedefs, etc. This is done
+by adding to <<extensions-api-registry,+vk.xml+>>. All such additions will
+be included in the +vulkan.h+ header supplied by Khronos.
 
 [NOTE]
 .Note
@@ -468,22 +473,23 @@ values to existing enums. The use of a +default:+ statement, within a
 == Extension Function Prototypes
 
 Function pointer declarations and function prototypes for all core {apiname}
-API functions are included in the +vulkan.h+ file. These come from the
+API commands are included in the +vulkan.h+ file. These come from the
 official XML specification of the {apiname} API hosted by Khronos.
 
 Function pointer declarations are also included in the +vulkan.h+ file for
-all extension functions. Function prototypes for extensions may: be included
-in +vulkan.h+. Extension functions that are part of the {apiname} ABI must:
-be flagged in the XML. Prototypes will be included in +vulkan.h+ for all
-extension functions that are part of the {apiname} ABI.
+all commands defined by registered extensions. Function prototypes for
+extensions may: be included in +vulkan.h+. Extension commands that are part
+of the {apiname} ABI must: be flagged in the XML. Function prototypes will
+be included in +vulkan.h+ for all extension commands that are part of the
+{apiname} ABI.
 
-An extension can: be considered platform specific, in which case, its
-objects, functions, etc. are protected by #ifdefs. This is orthogonal to
-whether a function is considered to be part of the {apiname} ABI.
+An extension can: be considered platform specific, in which case its
+interfaces in +vulkan.h+ are protected by #ifdefs. This is orthogonal to
+whether an extension command is considered to be part of the {apiname} ABI.
 
-The initial set of WSI extension functions are considered to be part of the
-{apiname} ABI. Prototypes for these WSI functions are included in the
-+vulkan.h+ provided by Khronos, though the platform-specific portions of
+The initial set of WSI extension commands are considered to be part of the
+{apiname} ABI. Function prototypes for these WSI commands are included in
+the +vulkan.h+ provided by Khronos, though the platform-specific portions of
 +vulkan.h+ are protected by #ifdefs.
 
 [NOTE]
@@ -498,26 +504,26 @@ these implementations.
 ====
 
 
-== Accessing Extension Function from Programs
+== Accessing Extension Functions from Programs
 
-The {apiname} API flink:vkGetInstanceProcAddr and flink:vkGetDeviceProcAddr
-functions (i.e. GPA functions) can: be used in order to obtain addresses for
-core and extension functions (per the description in
-<<initialization-functionpointers,Command Function Pointers>>). Various
-{apiname} API loaders can: be created on different platforms, which can:
-statically export some or all of the core {apiname} API functions, and which
-can: statically export some or all extension functions. If a loader
-statically exports a function, an application can: link against that
-function without needing to call a GPA function.
+flink:vkGetInstanceProcAddr and flink:vkGetDeviceProcAddr can: be used in
+order to obtain function pointer addresses for core and extension commands
+(per the description in <<initialization-functionpointers,Command Function
+Pointers>>). Different {apiname} API loaders can: choose to statically
+export functions for some or all of the core {apiname} API commands, and
+can: statically export functions for some or all extension commands. If a
+loader statically exports a function, an application can: link against that
+function without needing to call one of the ftext:vkGet*ProcAddr commands.
 
 [NOTE]
 .Note
 ====
-As mentioned above, the {apiname} API loader on Android, Linux, and Windows
-will export all core {apiname} API and WSI extension functions. The WSI
-functions are considered special, because they are required for many
+The Khronos-provided {apiname} API loader for Android, Linux, and Windows
+exports functions for all core {apiname} API and WSI extension commands. The
+WSI functions are considered special, because they are required for many
 applications.
 ====
+
 
 [[extensions-reserving-bitfield-values]]
 === Reserving Bitfield Values

--- a/doc/specs/vulkan/appendices/extensions.txt
+++ b/doc/specs/vulkan/appendices/extensions.txt
@@ -164,7 +164,7 @@ typedef struct VkSomeDataEXT;
 
 Enumeration or constant token names are constructed by following the token
 name with `_` and the author prefix, so a non-Khronos extension could expose
-this enumerantion:
+this enumeration:
 
 ["source","{basebackend@docbook:c++:cpp}",title=""]
 ------------------------------------------------------------------------------

--- a/doc/specs/vulkan/appendices/extensions.txt
+++ b/doc/specs/vulkan/appendices/extensions.txt
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-2016 The Khronos Group Inc.
 // Copyright notice at https://www.khronos.org/registry/speccopyright.html
 
+[appendix]
+
 [[extensions]]
 = Layers & Extensions
 

--- a/doc/specs/vulkan/chapters/devsandqueues.txt
+++ b/doc/specs/vulkan/chapters/devsandqueues.txt
@@ -324,8 +324,7 @@ The members of sname:VkDeviceCreateInfo have the following meanings:
   * pname:ppEnabledLayerNames is a pointer to an array of
     pname:enabledLayerCount null-terminated UTF-8 strings containing the
     names of layers to enable for the created device. See the
-    <<querying-layers-and-extensions,Querying Layers and Extensions>>
-    chapter for further details.
+    <<extended-functionality-layers,Layers>> section for further details.
   * pname:enabledExtensionCount is the number of device extensions to
     enable.
   * pname:ppEnabledExtensionNames is a pointer to an array of

--- a/doc/specs/vulkan/chapters/extensions.txt
+++ b/doc/specs/vulkan/chapters/extensions.txt
@@ -80,16 +80,17 @@ The definition of sname:VkLayerProperties is:
 
 include::../structs/VkLayerProperties.txt[]
 
-  * pname:layerName is a null-terminated string specifying the name of the
-    layer. Use this name in the pname:ppEnabledLayerNames array in the
-    sname:VkInstanceCreateInfo given to fname:vkCreateInstance to enable
-    this layer in the instance.
+  * pname:layerName is a null-terminated UTF-8 string specifying the name of
+    the layer. Use this name in the pname:ppEnabledLayerNames array passed
+    in the slink:VkInstanceCreateInfo and slink:VkDeviceCreateInfo
+    structures passed to flink:vkCreateInstance and flink:vkCreateDevice,
+    respectively, to enable this layer for an instance or device.
   * pname:apiVersion is the {apiname} version the layer was written to,
     encoded as described in the <<fundamentals-versionnum,API Version
     Numbers and Semantics>> section.
   * pname:implementationVersion is the version of this layer. It is an
     integer, increasing with backward compatible changes.
-  * pname:description is a null-terminated string providing additional
+  * pname:description is a null-terminated UTF-8 string providing additional
     details that can: be used by the application to identify the layer.
 
 include::../validity/structs/VkLayerProperties.txt[]

--- a/doc/specs/vulkan/chapters/features.txt
+++ b/doc/specs/vulkan/chapters/features.txt
@@ -1181,8 +1181,9 @@ different equations in the spec).
     For all bitmasks of type elink:VkSampleCountFlags above, the bits which
     can: be set include:
 +
+--
 include::../enums/VkSampleCountFlagBits.txt[]
-+
+
 The sample count limits defined above represent the minimum
 supported sample counts for each image type. Individual images may: support
 additional sample counts, which are queried using
@@ -1190,6 +1191,7 @@ flink:vkGetPhysicalDeviceImageFormatProperties. The sample
 count limits for images only apply to images created with the pname:tiling
 set to ename:VK_IMAGE_TILING_OPTIMAL. For ename:VK_IMAGE_TILING_LINEAR
 images the only supported sample count is ename:VK_SAMPLE_COUNT_1_BIT.
+--
 
 include::../validity/structs/VkPhysicalDeviceLimits.txt[]
 
@@ -1334,7 +1336,7 @@ the same whether or not the feature is enabled.
 |maxMemoryAllocationCount          |- |4096 | min
 |maxSamplerAllocationCount         |- |4000 | min
 |bufferImageGranularity            |- |131072 | max
-|sparseAddressSpaceSize            | 0 | 2 GB | min
+|sparseAddressSpaceSize            | 0 | 2^31^ | min
 |maxBoundDescriptorSets            |- |4 | min
 |maxPerStageDescriptorSamplers     |- |16 | min
 |maxPerStageDescriptorUniformBuffers|- |12 | min

--- a/doc/specs/vulkan/chapters/initialization.txt
+++ b/doc/specs/vulkan/chapters/initialization.txt
@@ -126,7 +126,8 @@ include::../structs/VkInstanceCreateInfo.txt[]
   * pname:enabledLayerCount is the number of global layers to enable.
   * pname:ppEnabledLayerNames is a pointer to an array of
     pname:enabledLayerCount null-terminated UTF-8 strings containing the
-    names of layers to enable.
+    names of layers to enable for the created instance. See the
+    <<extended-functionality-layers,Layers>> section for further details.
   * pname:enabledExtensionCount is the number of global extensions to
     enable.
   * pname:ppEnabledExtensionNames is a pointer to an array of

--- a/doc/specs/vulkan/chapters/interfaces.txt
+++ b/doc/specs/vulkan/chapters/interfaces.txt
@@ -539,7 +539,7 @@ that has a pname:binding equal to latexmath:[$b$] in pname:pSetLayouts[_s_]
 that was specified in slink:VkPipelineLayoutCreateInfo.
 
 The range of descriptor sets is between zero and
-pname:maxBoundDescriptorSets minus one, inclusive. If a descriptor set value
+pname:maxBoundDescriptorSets minus one. If a descriptor set value
 is statically used by an entry point there must: be an associated
 pname:pSetLayout in the corresponding pipeline layout as described in
 <<descriptorsets-pipelinelayout-consistency,Pipeline Layouts consistency>>.

--- a/doc/specs/vulkan/chapters/memory.txt
+++ b/doc/specs/vulkan/chapters/memory.txt
@@ -102,7 +102,7 @@ If pname:pOriginal is `NULL`, then pname:pfnReallocation must: behave
 similarly to tlink:PFN_vkAllocationFunction. If pname:size is zero, then
 pname:pfnReallocation must: behave similarly to tlink:PFN_vkFreeFunction.
 The contents of the original allocation from bytes zero to
-latexmath:[$\min(\textrm{original size, new size})-1$], inclusive, must: be
+latexmath:[$\min(\textrm{original size, new size})-1$] must: be
 preserved in the new allocation. If the new allocation is larger than the
 old allocation, then the contents of the additional space are undefined.
 If pname:pOriginal is non-`NULL`, pname:alignment must: be equal to the

--- a/doc/specs/vulkan/chapters/primsrast.txt
+++ b/doc/specs/vulkan/chapters/primsrast.txt
@@ -78,8 +78,8 @@ as follows:
   * pname:sampleShadingEnable specifies that fragment shading executes
     per-sample if ename:VK_TRUE, or per-fragment if ename:VK_FALSE, as
     described in <<primsrast-sampleshading,Sample Shading>>.
-  * pname:minSampleShading is the minimum number of unique samples to shade
-    for each fragment.
+  * pname:minSampleShading is the minimum fraction of sample shading, as
+    described in <<primsrast-sampleshading,Sample Shading>>.
   * pname:pSampleMask is a bitmask of static coverage information that is
     ANDed with the coverage information generated during rasterization, as
     described in <<fragops-samplemask,Sample Mask>>.
@@ -235,10 +235,9 @@ latexmath:[$\max(\lceil{minSampleShading \times rasterizationSamples}\rceil,
 is the minimum fraction of sample shading and pname:rasterizationSamples is
 the number of samples requested in
 slink:VkPipelineMultisampleStateCreateInfo. These are associated with the
-samples in an implementation-dependent manner. pname:minSampleShading must:
-be in the range latexmath:[$[0,1\]$]. When the sample shading fraction is
-1.0, a separate set of associated data are evaluated for each sample, and
-each set of values is evaluated at the sample location.
+samples in an implementation-dependent manner. When the sample shading
+fraction is 1.0, a separate set of associated data are evaluated for each
+sample, and each set of values is evaluated at the sample location.
 
 
 [[primsrast-points]]

--- a/doc/specs/vulkan/chapters/vertexpostproc.txt
+++ b/doc/specs/vulkan/chapters/vertexpostproc.txt
@@ -284,10 +284,11 @@ latexmath:[$
     \end{array}\right).
 $]
 
-Multiple viewports are available and are numbered zero up to the value of
-sname:VkPhysicalDeviceLimits::pname:maxViewports. The number of viewports
-used by a pipeline is controlled by the pname:viewportCount member of the
-sname:VkPipelineViewportStateCreateInfo structure used in pipeline creation:
+Multiple viewports are available, numbered zero up to
+sname:VkPhysicalDeviceLimits::pname:maxViewports minus one. The number of
+viewports used by a pipeline is controlled by the pname:viewportCount member
+of the sname:VkPipelineViewportStateCreateInfo structure used in pipeline
+creation:
 
 include::../structs/VkPipelineViewportStateCreateInfo.txt[]
 

--- a/doc/specs/vulkan/enums/VkCullModeFlagBits.txt
+++ b/doc/specs/vulkan/enums/VkCullModeFlagBits.txt
@@ -11,6 +11,6 @@ typedef enum VkCullModeFlagBits {
     VK_CULL_MODE_NONE = 0,
     VK_CULL_MODE_FRONT_BIT = 0x00000001,
     VK_CULL_MODE_BACK_BIT = 0x00000002,
-    VK_CULL_MODE_FRONT_AND_BACK = 0x3,
+    VK_CULL_MODE_FRONT_AND_BACK = 0x00000003,
 } VkCullModeFlagBits;
 ------------------------------------------------------------------------------

--- a/doc/specs/vulkan/enums/VkStencilFaceFlagBits.txt
+++ b/doc/specs/vulkan/enums/VkStencilFaceFlagBits.txt
@@ -10,6 +10,6 @@ endif::doctype-manpage[]
 typedef enum VkStencilFaceFlagBits {
     VK_STENCIL_FACE_FRONT_BIT = 0x00000001,
     VK_STENCIL_FACE_BACK_BIT = 0x00000002,
-    VK_STENCIL_FRONT_AND_BACK = 0x3,
+    VK_STENCIL_FRONT_AND_BACK = 0x00000003,
 } VkStencilFaceFlagBits;
 ------------------------------------------------------------------------------

--- a/doc/specs/vulkan/style/styleguide.txt
+++ b/doc/specs/vulkan/style/styleguide.txt
@@ -282,7 +282,7 @@ following table:
                   something that should be rendered like a structure name,
                   but is not actually one (e.g. is a wildcard or subset of
                   an actual structure name).
-| elink{cl}     | Formats the macro argument as a Vulkan enumerantion
+| elink{cl}     | Formats the macro argument as a Vulkan enumeration
                   name and links to the definition of that enumeration type.
                   Example: ename{cl}VkResult -> ename:VkResult.
 | ename{cl}     | Formats the macro argument as a Vulkan enumerant name.

--- a/doc/specs/vulkan/validity/protos/vkCmdCopyBuffer.txt
+++ b/doc/specs/vulkan/validity/protos/vkCmdCopyBuffer.txt
@@ -16,8 +16,8 @@ endif::doctype-manpage[]
 * This command must: only be called outside of a render pass instance
 * The value of pname:regionCount must: be greater than `0`
 * Each of pname:commandBuffer, pname:srcBuffer and pname:dstBuffer must: have been created, allocated or retrieved from the same sname:VkDevice
-* The sum of the pname:srcOffset and pname:size members of a given element of pname:pRegions must: be less than or equal to the size of pname:srcBuffer
-* The sum of the pname:dstOffset and pname:size members of a given element of pname:pRegions must: be less than or equal to the size of pname:dstBuffer
+* The sum of the pname:srcOffset and pname:copySize members of a given element of pname:pRegions must: be less than or equal to the size of pname:srcBuffer
+* The sum of the pname:dstOffset and pname:copySize members of a given element of pname:pRegions must: be less than or equal to the size of pname:dstBuffer
 * The union of the source regions, and the union of the destination regions, specified by the elements of pname:pRegions, mustnot: overlap in memory
 * pname:srcBuffer must: have been created with ename:VK_BUFFER_USAGE_TRANSFER_SRC_BIT usage flag
 * pname:dstBuffer must: have been created with ename:VK_BUFFER_USAGE_TRANSFER_DST_BIT usage flag

--- a/doc/specs/vulkan/validity/protos/vkEnumerateDeviceExtensionProperties.txt
+++ b/doc/specs/vulkan/validity/protos/vkEnumerateDeviceExtensionProperties.txt
@@ -11,7 +11,7 @@ endif::doctype-manpage[]
 * If pname:pLayerName is not `NULL`, pname:pLayerName must: be a null-terminated string
 * pname:pPropertyCount must: be a pointer to a basetype:uint32_t value
 * If the value referenced by pname:pPropertyCount is not `0`, and pname:pProperties is not `NULL`, pname:pProperties must: be a pointer to an array of pname:pPropertyCount sname:VkExtensionProperties structures
-* If pname:pLayerName is not `NULL`, it must: be the name of a layer available on the system
+* If pname:pLayerName is not `NULL`, it must: be the name of a device layer returned by flink:vkEnumerateDeviceLayerProperties
 ifndef::doctype-manpage[]
 ********************************************************************************
 endif::doctype-manpage[]

--- a/doc/specs/vulkan/validity/protos/vkEnumerateInstanceExtensionProperties.txt
+++ b/doc/specs/vulkan/validity/protos/vkEnumerateInstanceExtensionProperties.txt
@@ -10,7 +10,7 @@ endif::doctype-manpage[]
 * If pname:pLayerName is not `NULL`, pname:pLayerName must: be a null-terminated string
 * pname:pPropertyCount must: be a pointer to a basetype:uint32_t value
 * If the value referenced by pname:pPropertyCount is not `0`, and pname:pProperties is not `NULL`, pname:pProperties must: be a pointer to an array of pname:pPropertyCount sname:VkExtensionProperties structures
-* If pname:pLayerName is not `NULL`, it must: be the name of a layer available on the system
+* If pname:pLayerName is not `NULL`, it must: be the name of an instance layer returned by flink:vkEnumerateInstanceLayerProperties
 ifndef::doctype-manpage[]
 ********************************************************************************
 endif::doctype-manpage[]

--- a/doc/specs/vulkan/validity/structs/VkBufferImageCopy.txt
+++ b/doc/specs/vulkan/validity/structs/VkBufferImageCopy.txt
@@ -22,9 +22,9 @@ endif::doctype-manpage[]
 *   pname:imageExtent.height must: be a multiple of the block height or (pname:imageExtent.height + pname:imageOffset.y) must: equal the image subresource height
 *   pname:imageExtent.depth must: be a multiple of the block depth or (pname:imageExtent.depth + pname:imageOffset.z) must: equal the image subresource depth
 * pname:bufferOffset, pname:bufferRowLength, pname:bufferImageHeight and all members of pname:imageOffset and pname:imageExtent must: respect the image transfer granularity requirements of the queue family that it will be submitted against, as described in <<execution-physical-device-enumeration,Physical Device Enumeration>>
-* The pname:aspectMask member of pname:srcSubresource must: specify aspects present in the calling command's sname:VkImage parameter
-* The pname:aspectMask member of pname:pSubresource must: only have a single bit set
-* If the calling command's sname:VkImage parameter is of elink:VkImageType ename:VK_IMAGE_TYPE_3D, the pname:baseArrayLayer and pname:layerCount members of both pname:srcSubresource and pname:dstSubresource must: be `0` and `1`, respectively
+* The pname:aspectMask member of pname:imageSubresource must: specify aspects present in the calling command's sname:VkImage parameter
+* The pname:aspectMask member of pname:imageSubresource must: only have a single bit set
+* If the calling command's sname:VkImage parameter is of elink:VkImageType ename:VK_IMAGE_TYPE_3D, the pname:baseArrayLayer and pname:layerCount members of pname:imageSubresource must: be `0` and `1`, respectively
 ifndef::doctype-manpage[]
 ********************************************************************************
 endif::doctype-manpage[]

--- a/doc/specs/vulkan/validity/structs/VkPipelineMultisampleStateCreateInfo.txt
+++ b/doc/specs/vulkan/validity/structs/VkPipelineMultisampleStateCreateInfo.txt
@@ -14,6 +14,7 @@ endif::doctype-manpage[]
 * If pname:pSampleMask is not `NULL`, pname:pSampleMask must: be a pointer to an array of latexmath:[$\lceil{\mathit{rasterizationSamples} \over 32}\rceil$] basetype:VkSampleMask values
 * If the <<features-features-sampleRateShading,sample rate shading>> feature is not enabled, pname:sampleShadingEnable must: be ename:VK_FALSE
 * If the <<features-features-alphaToOne,alpha to one>> feature is not enabled, pname:alphaToOneEnable must: be ename:VK_FALSE
+* pname:minSampleShading must: be in the range latexmath:[$[0,1\]$]
 ifndef::doctype-manpage[]
 ********************************************************************************
 endif::doctype-manpage[]

--- a/doc/specs/vulkan/validity/structs/VkPipelineRasterizationStateCreateInfo.txt
+++ b/doc/specs/vulkan/validity/structs/VkPipelineRasterizationStateCreateInfo.txt
@@ -14,7 +14,7 @@ endif::doctype-manpage[]
 * pname:cullMode must: be a valid combination of elink:VkCullModeFlagBits values
 * pname:frontFace must: be a valid elink:VkFrontFace value
 * If the <<features-features-depthClamp,depth clamping>> feature is not enabled, the value of pname:depthClampEnable must: be ename:VK_FALSE
-* If the <<features-features-fillModeNonSolid,non-solid fill modes>> feature is not enabled, the value of pname:fillMode must: be ename:VK_POLYGON_MODE_FILL
+* If the <<features-features-fillModeNonSolid,non-solid fill modes>> feature is not enabled, the value of pname:polygonMode must: be ename:VK_POLYGON_MODE_FILL
 ifndef::doctype-manpage[]
 ********************************************************************************
 endif::doctype-manpage[]

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -1248,7 +1248,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
             <member><type>float</type>                  <name>lineWidth</name></member>
             <validity>
                 <usage>If the &lt;&lt;features-features-depthClamp,depth clamping&gt;&gt; feature is not enabled, the value of pname:depthClampEnable must: be ename:VK_FALSE</usage>
-                <usage>If the &lt;&lt;features-features-fillModeNonSolid,non-solid fill modes&gt;&gt; feature is not enabled, the value of pname:fillMode must: be ename:VK_POLYGON_MODE_FILL</usage>
+                <usage>If the &lt;&lt;features-features-fillModeNonSolid,non-solid fill modes&gt;&gt; feature is not enabled, the value of pname:polygonMode must: be ename:VK_POLYGON_MODE_FILL</usage>
             </validity>
         </type>
         <type category="struct" name="VkPipelineMultisampleStateCreateInfo">
@@ -1264,6 +1264,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
             <validity>
                 <usage>If the &lt;&lt;features-features-sampleRateShading,sample rate shading&gt;&gt; feature is not enabled, pname:sampleShadingEnable must: be ename:VK_FALSE</usage>
                 <usage>If the &lt;&lt;features-features-alphaToOne,alpha to one&gt;&gt; feature is not enabled, pname:alphaToOneEnable must: be ename:VK_FALSE</usage>
+                <usage>pname:minSampleShading must: be in the range latexmath:[$[0,1\]$]</usage>
             </validity>
         </type>
         <type category="struct" name="VkPipelineColorBlendAttachmentState">
@@ -2279,7 +2280,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <enum value="0"     name="VK_CULL_MODE_NONE"/>
         <enum bitpos="0"    name="VK_CULL_MODE_FRONT_BIT"/>
         <enum bitpos="1"    name="VK_CULL_MODE_BACK_BIT"/>
-        <enum value="0x3"   name="VK_CULL_MODE_FRONT_AND_BACK"/>
+        <enum value="0x00000003" name="VK_CULL_MODE_FRONT_AND_BACK"/>
     </enums>
     <enums name="VkFrontFace" type="enum" expand="VK_FRONT_FACE">
         <enum value="0"     name="VK_FRONT_FACE_COUNTER_CLOCKWISE"/>
@@ -2831,7 +2832,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
     <enums name="VkStencilFaceFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_STENCIL_FACE_FRONT_BIT"                         comment="Front face"/>
         <enum bitpos="1"    name="VK_STENCIL_FACE_BACK_BIT"                          comment="Back face"/>
-        <enum value="0x3"   name="VK_STENCIL_FRONT_AND_BACK"                         comment="Front and back faces"/>
+        <enum value="0x00000003" name="VK_STENCIL_FRONT_AND_BACK"                         comment="Front and back faces"/>
     </enums>
     <enums name="VkDescriptorPoolCreateFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT" comment="Descriptor sets may be freed individually"/>
@@ -3021,7 +3022,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
             <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
             <param optional="true" len="pPropertyCount"><type>VkExtensionProperties</type>* <name>pProperties</name></param>
             <validity>
-                <usage>If pname:pLayerName is not `NULL`, it must: be the name of a layer available on the system</usage>
+                <usage>If pname:pLayerName is not `NULL`, it must: be the name of an instance layer returned by flink:vkEnumerateInstanceLayerProperties</usage>
             </validity>
         </command>
         <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
@@ -3037,7 +3038,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
             <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
             <param optional="true" len="pPropertyCount"><type>VkExtensionProperties</type>* <name>pProperties</name></param>
             <validity>
-                <usage>If pname:pLayerName is not `NULL`, it must: be the name of a layer available on the system</usage>
+                <usage>If pname:pLayerName is not `NULL`, it must: be the name of a device layer returned by flink:vkEnumerateDeviceLayerProperties</usage>
             </validity>
         </command>
         <command>

--- a/src/vulkan/vulkan.h
+++ b/src/vulkan/vulkan.h
@@ -992,7 +992,7 @@ typedef enum VkCullModeFlagBits {
     VK_CULL_MODE_NONE = 0,
     VK_CULL_MODE_FRONT_BIT = 0x00000001,
     VK_CULL_MODE_BACK_BIT = 0x00000002,
-    VK_CULL_MODE_FRONT_AND_BACK = 0x3,
+    VK_CULL_MODE_FRONT_AND_BACK = 0x00000003,
 } VkCullModeFlagBits;
 typedef VkFlags VkCullModeFlags;
 typedef VkFlags VkPipelineMultisampleStateCreateFlags;
@@ -1083,7 +1083,7 @@ typedef VkFlags VkCommandBufferResetFlags;
 typedef enum VkStencilFaceFlagBits {
     VK_STENCIL_FACE_FRONT_BIT = 0x00000001,
     VK_STENCIL_FACE_BACK_BIT = 0x00000002,
-    VK_STENCIL_FRONT_AND_BACK = 0x3,
+    VK_STENCIL_FRONT_AND_BACK = 0x00000003,
 } VkStencilFaceFlagBits;
 typedef VkFlags VkStencilFaceFlags;
 


### PR DESCRIPTION
This is for people to review edits for @philiptaylor's points in #101, but I'll probably pull equivalent changes back into the private repo and merge there before bringing it back to github in one of the (hopefully) weekly updates.

[ChangeLog] This bundles up low-hanging editorial issues from public issue
101. Some items from that issue are more complex and remain to be done.
There's also some related cleanup of the extensions appendix to clarify the
distinction between a Vulkan API command, and the functions and function
pointers corresponding to that command which may be provided by the API
loader and runtime.                                 

Remaining todo:

- [ ] 24.5.1 "Ab, Yb, Zb" -> "Xb, Yb, Zb"
- [x] 29.2 "explicitly enabled layers" clarification
- [ ] 30.3.3 Confusingly similar tiny circle symbols in format tables
- [ ] 30.3.3 Missing information about some formats
- [ ] C.3 Clarify lower-case UTF-8 in FQDN layer names
