### PR TITLE
[ChangeLog] Build fix for latexmath: without escaped right brackets in the features section.

### DIFF
--- a/doc/specs/vulkan/chapters/features.txt
+++ b/doc/specs/vulkan/chapters/features.txt
@@ -952,7 +952,7 @@ different equations in the spec).
     the code:Bias operand of image sampling operations in shader modules (or
     0 if no code:Bias operand is provided to an image sampling operation)
     are clamped to the range
-    latexmath:[$[-\mathit{maxSamplerLodBias},+\mathit{maxSamplerLodBias}]$].
+    latexmath:[$[-\mathit{maxSamplerLodBias},+\mathit{maxSamplerLodBias}\]$].
     See <<samplers-mipLodBias>>.
   * [[features-limits-maxSamplerAnisotropy]] pname:maxSamplerAnisotropy is
     the maximum degree of sampler anisotropy. The maximum degree of
@@ -972,7 +972,7 @@ different equations in the spec).
     <<vertexpostproc-viewport,Controlling the Viewport>>.
   * [[features-limits-viewportboundsrange]] pname:viewportBoundsRange[2] is
     the viewport bounds range
-    latexmath:[$[\mathit{minimum},\mathit{maximum}]$]. See
+    latexmath:[$[\mathit{minimum},\mathit{maximum}\]$]. See
     <<vertexpostproc-viewport,Controlling the Viewport>>.
   * [[features-limits-viewportSubPixelBits]] pname:viewportSubPixelBits is
     the number of bits of subpixel precision for viewport bounds. The
@@ -1126,12 +1126,12 @@ different equations in the spec).
     least 2, and levels must: be spread evenly over the range, with at least
     one level at 1.0, and another at 0.0. See <<devsandqueues-priority>>.
   * [[features-limits-pointSizeRange]] pname:pointSizeRange[2] is the range
-    latexmath:[$[\mathit{minimum},\mathit{maximum}]$] of supported sizes for
-    points. Values written to variables decorated with the code:PointSize
-    built-in decoration are clamped to this range.
+    latexmath:[$[\mathit{minimum},\mathit{maximum}\]$] of supported sizes
+    for points. Values written to variables decorated with the
+    code:PointSize built-in decoration are clamped to this range.
   * [[features-limits-lineWidthRange]] pname:lineWidthRange[2] is the range
-    latexmath:[$[\mathit{minimum},\mathit{maximum}]$] of supported widths for
-    lines. Values specified by the pname:lineWidth member of the
+    latexmath:[$[\mathit{minimum},\mathit{maximum}\]$] of supported widths
+    for lines. Values specified by the pname:lineWidth member of the
     sname:VkPipelineRasterizationStateCreateInfo or the pname:lineWidth
     parameter to fname:vkCmdSetLineWidth are clamped to this range.
   * [[features-limits-pointSizeGranularity]] pname:pointSizeGranularity is


### PR DESCRIPTION
See #102 which fixed one latexmath: macro problem and in doing so exposed another one that had been lurking.