### PR TITLE
Avoid double negation in phrase.

### DIFF
--- a/doc/specs/vulkan/chapters/renderpass.txt
+++ b/doc/specs/vulkan/chapters/renderpass.txt
@@ -759,8 +759,8 @@ include::../structs/VkRenderPassBeginInfo.txt[]
   * pname:pClearValues is an array of sname:VkClearValue structures that
     contains clear values for each attachment, if the attachment uses a
     pname:loadOp value of ename:VK_ATTACHMENT_LOAD_OP_CLEAR. The array is
-    indexed by attachment number, with elements corresponding to uncleared
-    attachments being unused.
+    indexed by attachment number, only elements corresponding to cleared
+    attachments are used, the rest are ignored.
 
 include::../validity/structs/VkRenderPassBeginInfo.txt[]
 


### PR DESCRIPTION
To me it seems like double negation here is harder to understand. And reader is mostly interested in things being used and not the things being unused. But also mentioning that they are both used and ignored implies that you need to put elements corresponding to each attachment and not just used ones.