### PR TITLE
Fix comments of VkResult constants.

### DIFF
--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -2630,8 +2630,8 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <!-- Error codes (negative values) -->
         <enum value="-1"    name="VK_ERROR_OUT_OF_HOST_MEMORY" comment="A host memory allocation has failed"/>
         <enum value="-2"    name="VK_ERROR_OUT_OF_DEVICE_MEMORY" comment="A device memory allocation has failed"/>
-        <enum value="-3"    name="VK_ERROR_INITIALIZATION_FAILED" comment="The logical device has been lost. See &lt;&lt;devsandqueues-lost-device&gt;&gt;"/>
-        <enum value="-4"    name="VK_ERROR_DEVICE_LOST" comment="Initialization of a object has failed"/>
+        <enum value="-3"    name="VK_ERROR_INITIALIZATION_FAILED" comment="Initialization of a object has failed"/>
+        <enum value="-4"    name="VK_ERROR_DEVICE_LOST" comment="The logical device has been lost. See &lt;&lt;devsandqueues-lost-device&gt;&gt;"/>
         <enum value="-5"    name="VK_ERROR_MEMORY_MAP_FAILED" comment="Mapping of a memory object has failed"/>
         <enum value="-6"    name="VK_ERROR_LAYER_NOT_PRESENT" comment="Layer specified does not exist"/>
         <enum value="-7"    name="VK_ERROR_EXTENSION_NOT_PRESENT" comment="Extension specified does not exist"/>


### PR DESCRIPTION
`VK_ERROR_INITIALIZATION_FAILED` and `VK_ERROR_DEVICE_LOST` comments are inverted.