### PR TITLE
Fix prototype guard in documentation

### DIFF
--- a/src/spec/readme.tex
+++ b/src/spec/readme.tex
@@ -925,7 +925,7 @@ When processed into a C header for Vulkan, this results in:
 #define VK_MAX_EXTENSION_NAME   256
 #define VK_LOD_CLAMP_NONE       MAX_FLOAT
 typedef VkResult (VKAPI_PTR *PFN_vkCreateInstance)(const VkInstanceCreateInfo* pCreateInfo, VkInstance* pInstance);
-#ifdef VK_PROTOTYPES
+#ifndef VK_NO_PROTOTYPES
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     VkInstance*                                 pInstance);
@@ -1040,7 +1040,7 @@ typedef VkResult (VKAPI_PTR *PFN_vkCreateSharedSwapchainsKHR)(
     const VkAllocationCallbacks* pAllocator,
     VkSwapchainKHR* pSwapchains);
 
-#ifdef VK_PROTOTYPES
+#ifndef VK_NO_PROTOTYPES
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateSharedSwapchainsKHR(
     VkDevice                                    device,
     uint32_t                                    swapchainCount,
@@ -1510,7 +1510,7 @@ VK_DEFINE_DISP_SUBCLASS_HANDLE(VkInstance, VkObject)
 #define VK_MAX_PHYSICAL_DEVICE_NAME       256
 #define VK_MAX_EXTENSION_NAME             256
 typedef VkResult (VKAPI_PTR *PFN_vkCreateInstance)(const VkInstanceCreateInfo* pCreateInfo, VkInstance* pInstance);
-#ifdef VK_PROTOTYPES
+#ifndef VK_NO_PROTOTYPES
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     VkInstance*                                 pInstance);


### PR DESCRIPTION
This was changed before the release, so as far as everyone knows, this has always been the other way around: define `VK_NO_PROTOTYPES` when you do *not* want the prototypes.