### PR TITLE
Correct typo in comment on VK_INCOMPLETE

### DIFF
--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -2626,7 +2626,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <enum value="2"     name="VK_TIMEOUT" comment="A wait operation has not completed in the specified time"/>
         <enum value="3"     name="VK_EVENT_SET" comment="An event is signaled"/>
         <enum value="4"     name="VK_EVENT_RESET" comment="An event is unsignalled"/>
-        <enum value="5"     name="VK_INCOMPLETE" comment="A return array was too small for the resul"/>
+        <enum value="5"     name="VK_INCOMPLETE" comment="A return array was too small for the result"/>
         <!-- Error codes (negative values) -->
         <enum value="-1"    name="VK_ERROR_OUT_OF_HOST_MEMORY" comment="A host memory allocation has failed"/>
         <enum value="-2"    name="VK_ERROR_OUT_OF_DEVICE_MEMORY" comment="A device memory allocation has failed"/>


### PR DESCRIPTION
`s/resul/result/`