### PR TITLE
Fix fname:: -> fname: (Remove extra colon)

### DIFF
--- a/doc/specs/vulkan/man/vkAllocateCommandBuffers.txt
+++ b/doc/specs/vulkan/man/vkAllocateCommandBuffers.txt
@@ -25,7 +25,7 @@ pname:pCommandBuffers::
 Description
 -----------
 
-fname::vkAllocateCommandBuffers allocates command buffers from an existing command pool. pname:pAllocateInfo
+fname:vkAllocateCommandBuffers allocates command buffers from an existing command pool. pname:pAllocateInfo
 is a pointer to an instance of the slink:VkCommandBufferAllocateInfo structure which
 describes the command buffer allocation. The definition of slink:VkCommandBufferAllocateInfo is:
 

--- a/doc/specs/vulkan/man/vkGetInstanceProcAddr.txt
+++ b/doc/specs/vulkan/man/vkGetInstanceProcAddr.txt
@@ -30,7 +30,7 @@ different values of pname:instance.
 
 If pname:instance is code:NULL, fname:vkGetInstanceProcAddr will return
 non-code:NULL function pointers for the global commands
-fname::vkEnumerateInstanceExtensionProperties,
+fname:vkEnumerateInstanceExtensionProperties,
 fname:vkEnumerateInstanceLayerProperties, and fname:vkCreateInstance. It will
 return code:NULL for all other commands, since they may have different
 implementations in different instances.


### PR DESCRIPTION
I assume that colon snuck in there by accident.