### PR TITLE
vk.xml: add structure to type[category='funcpointer'] elements

### DIFF
--- a/doc/specs/vulkan/funcpointers/PFN_vkAllocationFunction.txt
+++ b/doc/specs/vulkan/funcpointers/PFN_vkAllocationFunction.txt
@@ -7,7 +7,7 @@ ifdef::doctype-manpage[]
 ["source","{basebackend@docbook:c++:cpp}"]
 endif::doctype-manpage[]
 ------------------------------------------------------------------------------
-typedef void* (VKAPI_PTR *PFN_vkAllocationFunction)(
+typedef void* (*PFN_vkAllocationFunction)(
     void*                                       pUserData,
     size_t                                      size,
     size_t                                      alignment,

--- a/doc/specs/vulkan/funcpointers/PFN_vkFreeFunction.txt
+++ b/doc/specs/vulkan/funcpointers/PFN_vkFreeFunction.txt
@@ -7,7 +7,7 @@ ifdef::doctype-manpage[]
 ["source","{basebackend@docbook:c++:cpp}"]
 endif::doctype-manpage[]
 ------------------------------------------------------------------------------
-typedef void (VKAPI_PTR *PFN_vkFreeFunction)(
+typedef void (*PFN_vkFreeFunction)(
     void*                                       pUserData,
     void*                                       pMemory);
 

--- a/doc/specs/vulkan/funcpointers/PFN_vkInternalAllocationNotification.txt
+++ b/doc/specs/vulkan/funcpointers/PFN_vkInternalAllocationNotification.txt
@@ -7,7 +7,7 @@ ifdef::doctype-manpage[]
 ["source","{basebackend@docbook:c++:cpp}"]
 endif::doctype-manpage[]
 ------------------------------------------------------------------------------
-typedef void (VKAPI_PTR *PFN_vkInternalAllocationNotification)(
+typedef void (*PFN_vkInternalAllocationNotification)(
     void*                                       pUserData,
     size_t                                      size,
     VkInternalAllocationType                    allocationType,

--- a/doc/specs/vulkan/funcpointers/PFN_vkInternalFreeNotification.txt
+++ b/doc/specs/vulkan/funcpointers/PFN_vkInternalFreeNotification.txt
@@ -7,7 +7,7 @@ ifdef::doctype-manpage[]
 ["source","{basebackend@docbook:c++:cpp}"]
 endif::doctype-manpage[]
 ------------------------------------------------------------------------------
-typedef void (VKAPI_PTR *PFN_vkInternalFreeNotification)(
+typedef void (*PFN_vkInternalFreeNotification)(
     void*                                       pUserData,
     size_t                                      size,
     VkInternalAllocationType                    allocationType,

--- a/doc/specs/vulkan/funcpointers/PFN_vkReallocationFunction.txt
+++ b/doc/specs/vulkan/funcpointers/PFN_vkReallocationFunction.txt
@@ -7,7 +7,7 @@ ifdef::doctype-manpage[]
 ["source","{basebackend@docbook:c++:cpp}"]
 endif::doctype-manpage[]
 ------------------------------------------------------------------------------
-typedef void* (VKAPI_PTR *PFN_vkReallocationFunction)(
+typedef void* (*PFN_vkReallocationFunction)(
     void*                                       pUserData,
     void*                                       pOriginal,
     size_t                                      size,

--- a/doc/specs/vulkan/funcpointers/PFN_vkVoidFunction.txt
+++ b/doc/specs/vulkan/funcpointers/PFN_vkVoidFunction.txt
@@ -7,6 +7,6 @@ ifdef::doctype-manpage[]
 ["source","{basebackend@docbook:c++:cpp}"]
 endif::doctype-manpage[]
 ------------------------------------------------------------------------------
-typedef void (VKAPI_PTR *PFN_vkVoidFunction)(void);
+typedef void (*PFN_vkVoidFunction)(void);
 
 ------------------------------------------------------------------------------

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -476,7 +476,11 @@ class OutputGenerator:
     def makeProtoName(self, name, tail):
         return self.genOpts.apientry + name + tail
     def makeTypedefName(self, name, tail):
-       return '(' + self.genOpts.apientryp + 'PFN_' + name + tail + ')'
+        PFN_ = ''
+        if not name.startswith('PFN_'):
+            PFN_ = 'PFN_'
+        return '(' + self.genOpts.apientryp + PFN_ + name + tail + ')'
+
     #
     # makeCParamDecl - return a string which is an indented, formatted
     # declaration for a <param> or <member> block (e.g. function parameter
@@ -516,11 +520,14 @@ class OutputGenerator:
             paramdecl += text + tail
         return newLen
     #
-    # makeCDecls - return C prototype and function pointer typedef for a
-    #   command, as a two-element list of strings.
-    # cmd - Element containing a <command> tag
+    # makeCDecls - return C prototype, a one-line function pointer typedef and
+    #   a multi-line function pointer typedef for a function, as a three-element
+    #   tuple of strings.
+    # cmd - Element containing a <command> tag or a <type> tag and
+    #   "funcpointer" attribute
     def makeCDecls(self, cmd):
-        """Generate C function pointer typedef for <command> Element"""
+        """Generate C function pointer typedef for <command> Element or for
+        <type category="funcpointer"> Element"""
         proto = cmd.find('proto')
         params = cmd.findall('param')
         # Begin accumulating prototype and typedef strings
@@ -580,7 +587,7 @@ class OutputGenerator:
         else:
             paramdecl += 'void'
         paramdecl += ");";
-        return [ pdecl + indentdecl, tdecl + paramdecl ]
+        return (pdecl + indentdecl, tdecl + paramdecl, tdecl + indentdecl)
     #
     def newline(self):
         write('', file=self.outFile)
@@ -724,6 +731,9 @@ class COutputGenerator(OutputGenerator):
         category = typeElem.get('category')
         if (category == 'struct' or category == 'union'):
             self.genStruct(typeinfo, name)
+        elif (category == 'funcpointer'):
+            decls = self.makeCDecls(typeElem)
+            self.appendSection('funcpointer', decls[2] + '\n')
         else:
             # Replace <apientry /> tags with an APIENTRY-style string
             # (from self.genOpts). Copy other text through unchanged.
@@ -916,6 +926,9 @@ class DocOutputGenerator(OutputGenerator):
         category = typeElem.get('category')
         if (category == 'struct' or category == 'union'):
             self.genStruct(typeinfo, name)
+        elif (category == 'funcpointer'):
+            decls = self.makeCDecls(typeElem)
+            self.writeInclude('funcpointers', name, decls[2] + '\n')
         else:
             # Replace <apientry /> tags with an APIENTRY-style string
             # (from self.genOpts). Copy other text through unchanged.

--- a/src/spec/reg.py
+++ b/src/spec/reg.py
@@ -276,7 +276,10 @@ class Registry:
             # If the <type> doesn't already have a 'name' attribute, set
             # it from contents of its <name> tag.
             if (type.get('name') == None):
-                type.attrib['name'] = type.find('name').text
+                if (type.find('name') == None):
+                    type.attrib['name'] = type.find('proto/name').text
+                else:
+                    type.attrib['name'] = type.find('name').text
             self.addElementInfo(type, TypeInfo(type), 'type', self.typedict)
         #
         # Create dictionary of registry enum groups from <enums> tags.

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -338,44 +338,58 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <type name="VkDebugReportErrorEXT" category="enum"/>
 
         <!-- The PFN_vk*Function types are used by VkAllocationCallbacks below -->
-        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkInternalAllocationNotification</name>)(
-    <type>void</type>*                                       pUserData,
-    <type>size_t</type>                                      size,
-    <type>VkInternalAllocationType</type>                    allocationType,
-    <type>VkSystemAllocationScope</type>                     allocationScope);</type>
-        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkInternalFreeNotification</name>)(
-    <type>void</type>*                                       pUserData,
-    <type>size_t</type>                                      size,
-    <type>VkInternalAllocationType</type>                    allocationType,
-    <type>VkSystemAllocationScope</type>                     allocationScope);</type>
-        <type category="funcpointer">typedef void* (VKAPI_PTR *<name>PFN_vkReallocationFunction</name>)(
-    <type>void</type>*                                       pUserData,
-    <type>void</type>*                                       pOriginal,
-    <type>size_t</type>                                      size,
-    <type>size_t</type>                                      alignment,
-    <type>VkSystemAllocationScope</type>                     allocationScope);</type>
-        <type category="funcpointer">typedef void* (VKAPI_PTR *<name>PFN_vkAllocationFunction</name>)(
-    <type>void</type>*                                       pUserData,
-    <type>size_t</type>                                      size,
-    <type>size_t</type>                                      alignment,
-    <type>VkSystemAllocationScope</type>                     allocationScope);</type>
-        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkFreeFunction</name>)(
-    <type>void</type>*                                       pUserData,
-    <type>void</type>*                                       pMemory);</type>
+        <type category="funcpointer">
+            <proto><type>void</type> <name>PFN_vkInternalAllocationNotification</name></proto>
+            <param><type>void</type>* <name>pUserData</name></param>
+            <param><type>size_t</type> <name>size</name></param>
+            <param><type>VkInternalAllocationType</type> <name>allocationType</name></param>
+            <param><type>VkSystemAllocationScope</type> <name>allocationScope</name></param>
+        </type>
+        <type category="funcpointer">
+            <proto><type>void</type> <name>PFN_vkInternalFreeNotification</name></proto>
+            <param><type>void</type>* <name>pUserData</name></param>
+            <param><type>size_t</type> <name>size</name></param>
+            <param><type>VkInternalAllocationType</type> <name>allocationType</name></param>
+            <param><type>VkSystemAllocationScope</type> <name>allocationScope</name></param>
+        </type>
+        <type category="funcpointer">
+            <proto><type>void</type>* <name>PFN_vkReallocationFunction</name></proto>
+            <param><type>void</type>* <name>pUserData</name></param>
+            <param><type>void</type>* <name>pOriginal</name></param>
+            <param><type>size_t</type> <name>size</name></param>
+            <param><type>size_t</type> <name>alignment</name></param>
+            <param><type>VkSystemAllocationScope</type> <name>allocationScope</name></param>
+        </type>
+        <type category="funcpointer">
+            <proto><type>void</type>* <name>PFN_vkAllocationFunction</name></proto>
+            <param><type>void</type>* <name>pUserData</name></param>
+            <param><type>size_t</type> <name>size</name></param>
+            <param><type>size_t</type> <name>alignment</name></param>
+            <param><type>VkSystemAllocationScope</type> <name>allocationScope</name></param>
+        </type>
+        <type category="funcpointer">
+            <proto><type>void</type> <name>PFN_vkFreeFunction</name></proto>
+            <param><type>void</type>* <name>pUserData</name></param>
+            <param><type>void</type>* <name>pMemory</name></param>
+        </type>
 
-    <!-- The PFN_vkVoidFunction type are used by VkGet*ProcAddr below -->
-        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkVoidFunction</name>)(void);</type>
+        <!-- The PFN_vkVoidFunction type are used by VkGet*ProcAddr below -->
+        <type category="funcpointer">
+            <proto><type>void</type> <name>PFN_vkVoidFunction</name></proto>
+        </type>
 
-    <!-- The PFN_vkDebugReportCallbackEXT type are used by the DEBUG_REPORT extension-->
-        <type category="funcpointer">typedef VkBool32 (VKAPI_PTR *<name>PFN_vkDebugReportCallbackEXT</name>)(
-    <type>VkDebugReportFlagsEXT</type>                       flags,
-    <type>VkDebugReportObjectTypeEXT</type>                  objectType,
-    <type>uint64_t</type>                                    object,
-    <type>size_t</type>                                      location,
-    <type>int32_t</type>                                     messageCode,
-    const <type>char</type>*                                 pLayerPrefix,
-    const <type>char</type>*                                 pMessage,
-    <type>void</type>*                                       pUserData);</type>
+        <!-- The PFN_vkDebugReportCallbackEXT type are used by the DEBUG_REPORT extension-->
+        <type category="funcpointer">
+            <proto><type>VkBool32</type> <name>PFN_vkDebugReportCallbackEXT</name></proto>
+            <param><type>VkDebugReportFlagsEXT</type> <name>flags</name></param>
+            <param><type>VkDebugReportObjectTypeEXT</type> <name>objectType</name></param>
+            <param><type>uint64_t</type> <name>object</name></param>
+            <param><type>size_t</type> <name>location</name></param>
+            <param><type>int32_t</type> <name>messageCode</name></param>
+            <param>const <type>char</type>* <name>pLayerPrefix</name></param>
+            <param>const <type>char</type>* <name>pMessage</name></param>
+            <param><type>void</type>* <name>pUserData</name></param>
+        </type>
 
         <!-- Struct types -->
         <type category="struct" name="VkOffset2D">

--- a/src/vulkan/vulkan.h
+++ b/src/vulkan/vulkan.h
@@ -1157,6 +1157,7 @@ typedef void (VKAPI_PTR *PFN_vkInternalFreeNotification)(
 
 typedef void (VKAPI_PTR *PFN_vkVoidFunction)(void);
 
+
 typedef struct VkApplicationInfo {
     VkStructureType    sType;
     const void*        pNext;


### PR DESCRIPTION
(reopening the #108 PR as I messed up my Github-fu)

These elements' structure now matches the structure of the <command>
elements with a <proto> child and <param> children. This will make it
easier for third-party parser to understand function pointer types.

generator.py has been modified to understand the updated definitions.

There are no changes (apart from a newline) to vulkan.h. However typedef for function pointers in the docs has its VKAPI_PTR removed, which I think is an improvement as it matches the fact that Vulkan commands don't have the VKAPI_FOO in the docs.

@oddhack PTAL, this was rebased on top of 1.0.10 and AFAIK my employer (Google) has a CLA in place.
