### PR TITLE
fix typo in vkGetPhysicalDeviceQueueFamilyProperties manpage

### DIFF
--- a/doc/specs/vulkan/man/vkGetPhysicalDeviceQueueFamilyProperties.txt
+++ b/doc/specs/vulkan/man/vkGetPhysicalDeviceQueueFamilyProperties.txt
@@ -73,8 +73,8 @@ operations such as binding graphics state and graphics pipelines and executing d
 * If a queue's ptext:queueFlags member contains ename:VK_QUEUE_COMPUTE_BIT, then it supports compute
 operations such as binding compute pipelines and executing compute dispatches.
 
-* If a queue's ptext:queueFlags member contains ename:VK_QUEUE_TRANSFER_BIT, then it supports transsfer
-operations, which include copying data an images.
+* If a queue's ptext:queueFlags member contains ename:VK_QUEUE_TRANSFER_BIT, then it supports transfer
+operations, which include copying data and images.
 
 * If a queue's ptext:queueFlags member contains ename:VK_QUEUE_SPARSE_BINDING_BIT, then it supports
 binding memory to sparse buffer and image resources.


### PR DESCRIPTION
fix two typos in vkGetPhysicalDeviceQueueFamilyProperties manpage:
transsfer -> transfer
an -> and