### PR TITLE
Fix invalid parameter reference in vkEnumeratePhysicalDevice description

### DIFF
--- a/doc/specs/vulkan/man/vkEnumeratePhysicalDevices.txt
+++ b/doc/specs/vulkan/man/vkEnumeratePhysicalDevices.txt
@@ -41,7 +41,7 @@ If pname:pPhysicalDevices is not code:NULL, then pname:pPhysicalDeviceCount shou
 to a variable that has been initialized with the size of the array pointed to by pname:pPhysicalDevices.
 No more than this number of physical device handles will be written into the output array.
 The actual number of device handles written into pname:pPhysicalDevices is then written into
-the variable pointed to pname:pPhysicalDevices.
+the variable pointed to pname:pPhysicalDeviceCount.
 
 include::../validity/protos/vkEnumeratePhysicalDevices.txt[]
 


### PR DESCRIPTION
The number of devices written by `vkEnumeratePhysicalDevices` is returned using the integer pointed to by `pPhysicalDeviceCount`, but the description states that the number is written to `pPhysicalDevices`.