### PR TITLE
Specify more restrictions on sample count variables

### DIFF
--- a/doc/specs/vulkan/chapters/features.txt
+++ b/doc/specs/vulkan/chapters/features.txt
@@ -1105,7 +1105,7 @@ range.
   * [[features-limits-sampledImageColorSampleCounts]]
     pname:sampledImageColorSampleCounts is a bitmask^1^ of
     elink:VkSampleCountFlagBits bits indicating the sample counts supported
-    for all images with a non-integer color format.
+    for all non-cube, 2D, optimal images with a non-integer color format.
   * [[features-limits-sampledImageIntegerSampleCounts]]
     pname:sampledImageIntegerSampleCounts is a bitmask^1^ of
     elink:VkSampleCountFlagBits bits indicating the sample counts supported
@@ -1113,15 +1113,15 @@ range.
   * [[features-limits-sampledImageDepthSampleCounts]]
     pname:sampledImageDepthSampleCounts is a bitmask^1^ of
     elink:VkSampleCountFlagBits bits indicating the sample counts supported
-    for all images with a depth format.
+    for all non-cube, 2D, optimal images with a depth format.
   * [[features-limits-sampledImageStencilSampleCounts]]
     pname:sampledImageStencilSampleCounts is a bitmask^1^ of
     elink:VkSampleCountFlagBits bits indicating the sample supported for all
-    images with a stencil format.
+    non-cube, 2D, optimal images with a stencil format.
   * [[features-limits-storageImageSampleCounts]]
     pname:storageImageSampleCounts is a bitmask^1^ of
     elink:VkSampleCountFlagBits bits indicating the sample counts supported
-    for all images used for storage operations.
+    for all non-cube, 2D, optimal images used for storage operations.
   * [[features-limits-maxSampleMaskWords]] pname:maxSampleMaskWords is the
     maximum number of array elements of a variable decorated with the
     code:SampleMask built-in decoration.
@@ -3672,9 +3672,11 @@ include::../structs/VkImageFormatProperties.txt[]
     ename:VK_IMAGE_TYPE_3D.
   * pname:sampleCounts is a bitmask of elink:VkSampleCountFlagBits
     specifying all the supported sample counts for this image. When
-    pname:tiling is ename:VK_IMAGE_TILING_LINEAR the pname:sampleCounts will
-    be set to ename:VK_SAMPLE_COUNT_1_BIT. Otherwise the bits set here are a
-    superset of the corresponding limits for the image type in the
+    pname:tiling is ename:VK_IMAGE_TILING_LINEAR or pname:type is not
+    ename:VK_IMAGE_TYPE_2D, or pname:flags contains
+    ename:VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, the pname:sampleCounts
+    will be set to ename:VK_SAMPLE_COUNT_1_BIT. Otherwise the bits set here
+    are a superset of the corresponding limits for the image type in the
     sname:VkPhysicalDeviceLimits struct. For non-integer color images this
     is pname:sampledImageColorSampleCounts, for integer format color images
     this is pname:sampledImageIntegerSampleCounts, for depth/stencil images


### PR DESCRIPTION
To be in agreement with Table 11.1.'s implication that multisampled
images must be non-cube compatible and 2D, specify more restrictions on
VkImageFormatProperties::sampleCounts and the fields in
VkPhysicalDeviceLimits related to sample counts.

Fixes #185 