### PR TITLE
man-pages: fix copy-paste error

### DIFF
--- a/doc/specs/vulkan/man/vkGetPhysicalDeviceSurfacePresentModesKHR.txt
+++ b/doc/specs/vulkan/man/vkGetPhysicalDeviceSurfacePresentModesKHR.txt
@@ -28,7 +28,7 @@ pname:pPresentModes::
 Description
 -----------
 
-fname:vkCreateWaylandSurfaceKHR queries the supported presentation modes for a surface.
+fname:vkGetPhysicalDeviceSurfacePresentModesKHR queries the supported presentation modes for a surface.
 
 pname:pPresentModes is an instance of the slink:VkPresentModeKHR
 structure, the definition of which is:

--- a/doc/specs/vulkan/man/vkGetPhysicalDeviceWin32PresentationSupportKHR.txt
+++ b/doc/specs/vulkan/man/vkGetPhysicalDeviceWin32PresentationSupportKHR.txt
@@ -22,7 +22,7 @@ pname:queueFamilyIndex::
 Description
 -----------
 
-fname:vkCreateWaylandSurfaceKHR determines whether a queue family of a physical device supports presentation to the Microsoft Windows desktop.
+fname:vkGetPhysicalDeviceWin32PresentationSupportKHR determines whether a queue family of a physical device supports presentation to the Microsoft Windows desktop.
 
 include::../validity/protos/vkGetPhysicalDeviceWin32PresentationSupportKHR.txt[]
 


### PR DESCRIPTION
It looks like `vkCreateWaylandSurfaceKHR.txt` was copy/pasted and not correctly modified.