### PR TITLE
Fix styleguide build

### DIFF
--- a/doc/specs/vulkan/Makefile
+++ b/doc/specs/vulkan/Makefile
@@ -224,6 +224,7 @@ STYLEFILES = $(wildcard style/[A-Za-z]*.txt)
 styleguide: $(OUTDIR)/styleguide.html
 
 $(OUTDIR)/styleguide.html: $(CONFIG) $(SPECVERSION) $(STYLESRC) $(STYLEFILES) $(GENINCLUDE) $(GENDEPENDS)
+	$(QUIET)$(MKDIR) $(OUTDIR)
 	$(QUIET)$(ASCIIDOC) -b html5 $(ADOCOPTS) \
 	    -o $@ -a svgpdf=$(SVGTYPEHTML) \
 	    $(STYLESRC)


### PR DESCRIPTION
Styleguide build was missing output directory existence test (and so make fails if build first).