### PR TITLE
Faster MathJax configuration

### DIFF
--- a/doc/specs/vulkan/config/docbook-xsl/xhtml.xsl
+++ b/doc/specs/vulkan/config/docbook-xsl/xhtml.xsl
@@ -17,14 +17,16 @@
 
 <!-- Add MathJax <script> tags  to document <head> -->
 <xsl:template name="user.head.content">
-    <script type="text/x-mathjax-config">
-        MathJax.Hub.Config({
-            MathML: { extensions: ["content-mathml.js"] },
-            tex2jax: { inlineMath: [['$','$'], ['\\(','\\)']] }
-        });
-    </script>
-    <script type="text/javascript"
-        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-    </script>
+  <script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [ ['$','$'], ['\\(','\\)'] ]
+    },
+    "fast-preview": { disabled: true },
+    "AssistiveMML": { disabled: true }
+    });
+  </script>
+  <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML">
+  </script>
 </xsl:template>
 </xsl:stylesheet>

--- a/doc/specs/vulkan/config/mathjax.js
+++ b/doc/specs/vulkan/config/mathjax.js
@@ -1,8 +1,11 @@
-    <script type="text/x-mathjax-config">
-	MathJax.Hub.Config({
-	    MathML: { extensions: ["content-mathml.js"] },
-	    tex2jax: { inlineMath: [['$','$'], ['\\(','\\)']] }
-	});
-    </script>
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-    </script>
+  <script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [ ['$','$'], ['\\(','\\)'] ]
+    },
+    "fast-preview": { disabled: true },
+    "AssistiveMML": { disabled: true }
+    });
+  </script>
+  <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML">
+  </script>


### PR DESCRIPTION
Experimented with Mathjax configuration and this renders faster. Kept the chunked version unmodified for now though(as it is in short, quick to render pages)
My baseline time for the original (for page reload) is 75 s.

Changes:
- Removed MathML input(`MML` config and `content-mathml.js`), since only TeX math is used by the spec

- Removed `orMML` output. MML is almost never chosen and the script doing this automaticaly seems to be deprecated

- Swiched to `CHTML` which sheds about 10 s. Tradeoff is support for some old browsers.
Alternative could be `SVG` with another ~3 s improvement. Fastest would be the `MathML` setting (20 s off baseline), but they claim browser support is unreliable. `Preview` version is similarly fast.

- Disabled fast preview (renders preview, then the final version). It takes almost as much time as the final version and so not worth it. It also jerks the page by being replaced by the (slightly larger) final version and hides further MathJax % progress and uses CPU (so e.g. scrolling is slow/jerky), so not very usable. Sheds ~20 s

- Disabled AssistiveMML (supposedly adds better alternative code for readers). Sheds ~7 s. It can be re-enabled (as the other configurations) in a RMB context menu (the browser seems to remember these user settings).

Ended up with 35 s time.