### PR TITLE
List of Tables fixes

### DIFF
--- a/doc/specs/vulkan/appendices/spirvenv.txt
+++ b/doc/specs/vulkan/appendices/spirvenv.txt
@@ -208,6 +208,7 @@ enable additional functionality beyond what code:OpUMod provides.
 Compatibility Between SPIR-V Image Formats And Vulkan Formats
 -------------------------------------------------------------
 
+.SPIR-V and Vulkan image formats compatibility
 [cols="2*", options="header"]
 |===
 |SPIR-V Image Format    |Vulkan Format

--- a/doc/specs/vulkan/chapters/features.txt
+++ b/doc/specs/vulkan/chapters/features.txt
@@ -2734,7 +2734,7 @@ endianness.
 |===============
 
 [[features-formats-packed-16-bit]]
-.Bit mappings for packed 16-bit VK_FORMAT_* formats
+.Bit mappings for packed 16-bit etext:VK_FORMAT_* formats
 [options="header",cols="18h,16*1",width="100%"]
 |===============
 ^| Bit latexmath:[$\rightarrow$] >| 15 >| 14 >| 13 >| 12 >| 11 >| 10 >| 9 >| 8 >| 7 >| 6 >| 5 >| 4 >| 3 >| 2 >| 1 >| 0

--- a/doc/specs/vulkan/chapters/pipelines.txt
+++ b/doc/specs/vulkan/chapters/pipelines.txt
@@ -666,7 +666,7 @@ of the device. To enable applications to detect when previously retrieved
 data is incompatible with the device, the initial bytes written to
 pname:pData must: be a header consisting of the following members:
 
-.Layout for pipeline cache header version VK_PIPELINE_CACHE_HEADER_VERSION_ONE
+.Layout for pipeline cache header version ename:VK_PIPELINE_CACHE_HEADER_VERSION_ONE
 [width="85%",cols="8%,21%,71%",options="header"]
 |=====
 | Offset | Size | Meaning

--- a/doc/specs/vulkan/chapters/synchronization.txt
+++ b/doc/specs/vulkan/chapters/synchronization.txt
@@ -423,16 +423,6 @@ include::../protos/vkGetEventStatus.txt[]
   * pname:device is the logical device that owns the event.
   * pname:event is the handle of the event to query.
 
-Upon success, fname:vkGetEventStatus returns the state of the event object
-with the following return codes:
-
-[width="80%",options="header"]
-|=====
-| Status | Meaning
-| ename:VK_EVENT_SET | The event specified by pname:event is signaled.
-| ename:VK_EVENT_RESET | The event specified by pname:event is unsignaled.
-|=====
-
 The state of an event can: be updated by the host. The state of the event is
 immediately changed, and subsequent calls to fname:vkGetEventStatus will
 return the new state. If an event is already in the requested state, then

--- a/doc/specs/vulkan/config/vkspec-xhtml.css
+++ b/doc/specs/vulkan/config/vkspec-xhtml.css
@@ -265,6 +265,12 @@ div.indexdiv dl, div.indexdiv dt
   margin-bottom: 0;
 }
 
+/* Force proper hyperlink style for MathJax elements */
+a .inlinemediaobject,
+a .inlinemediaobject *{
+  text-decoration: inherit !important;
+}
+
 /*
   Table styling does not work because of overriding attributes in
   generated HTML.


### PR DESCRIPTION
Fixed:
- ~~3~~ [since 1.0.21] 2 missing tables relating to issue #219
- misformated names with underline
- missing link styling for MathJax elements

Most of those are trivial fixes, except:

One of the tables re-explains VkResult values. I removed that altogether, because that seemed redundant to the Return Codes block and 2.6.2 chapter.

To make math in links underlined I added CSS rule for inlineMedia class and its descendants to inherit decoration style (hopefuly form \<a\>). I made some assumptions and the rule uses evil *, so if someone knows CSS well, I could use some advice on that...