### PR TITLE
WIP: issue 214: clarify validity for ppEnabled*

### DIFF
--- a/doc/specs/vulkan/validity/structs/VkDeviceCreateInfo.txt
+++ b/doc/specs/vulkan/validity/structs/VkDeviceCreateInfo.txt
@@ -16,8 +16,7 @@ endif::doctype-manpage[]
 * If pname:pEnabledFeatures is not `NULL`, pname:pEnabledFeatures must: be a pointer to a valid sname:VkPhysicalDeviceFeatures structure
 * pname:queueCreateInfoCount must: be greater than `0`
 * pname:ppEnabledLayerNames must: either be sname:NULL or contain the same sequence of layer names that was enabled when creating the parent instance
-* Any given element of pname:ppEnabledExtensionNames must: be the name of an extension present on the system, exactly matching a string returned in the sname:VkExtensionProperties structure by fname:vkEnumerateDeviceExtensionProperties
-* If an extension listed in pname:ppEnabledExtensionNames is provided as part of a layer, then both the layer and extension must: be enabled to enable that extension
+* Each extension name in the pname:ppEnabledExtensionNames array must: be one of those provided by the implementation or by an enabled layer and must: exactly match a string returned in the sname:VkExtensionProperties structure from flink:vkEnumerateDeviceExtensionProperties
 * The pname:queueFamilyIndex member of any given element of pname:pQueueCreateInfos must: be unique within pname:pQueueCreateInfos
 ifndef::doctype-manpage[]
 ********************************************************************************

--- a/doc/specs/vulkan/validity/structs/VkInstanceCreateInfo.txt
+++ b/doc/specs/vulkan/validity/structs/VkInstanceCreateInfo.txt
@@ -13,9 +13,8 @@ endif::doctype-manpage[]
 * If pname:pApplicationInfo is not `NULL`, pname:pApplicationInfo must: be a pointer to a valid sname:VkApplicationInfo structure
 * If pname:enabledLayerCount is not `0`, pname:ppEnabledLayerNames must: be a pointer to an array of pname:enabledLayerCount null-terminated strings
 * If pname:enabledExtensionCount is not `0`, pname:ppEnabledExtensionNames must: be a pointer to an array of pname:enabledExtensionCount null-terminated strings
-* Any given element of pname:ppEnabledLayerNames must: be the name of a layer present on the system, exactly matching a string returned in the sname:VkLayerProperties structure by fname:vkEnumerateInstanceLayerProperties
-* Any given element of pname:ppEnabledExtensionNames must: be the name of an extension present on the system, exactly matching a string returned in the sname:VkExtensionProperties structure by fname:vkEnumerateInstanceExtensionProperties
-* If an extension listed in pname:ppEnabledExtensionNames is provided as part of a layer, then both the layer and extension must: be enabled to enable that extension
+* Each layer name in the pname:ppEnabledLayerNames array must: exactly match a string returned in the sname:VkLayerProperties structure from flink:vkEnumerateInstanceLayerProperties
+* Each extension name in the pname:ppEnabledExtensionNames array must: be one of those provided by the implementation or by an enabled layer and must: exactly match a string returned in the sname:VkExtensionProperties structure from flink:vkEnumerateInstanceExtensionProperties
 ifndef::doctype-manpage[]
 ********************************************************************************
 endif::doctype-manpage[]

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -506,8 +506,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
             <member optional="true">const <type>VkPhysicalDeviceFeatures</type>* <name>pEnabledFeatures</name></member>
             <validity>
                 <usage>pname:ppEnabledLayerNames must: either be sname:NULL or contain the same sequence of layer names that was enabled when creating the parent instance</usage>
-                <usage>Any given element of pname:ppEnabledExtensionNames must: be the name of an extension present on the system, exactly matching a string returned in the sname:VkExtensionProperties structure by fname:vkEnumerateDeviceExtensionProperties</usage>
-                <usage>If an extension listed in pname:ppEnabledExtensionNames is provided as part of a layer, then both the layer and extension must: be enabled to enable that extension</usage>
+                <usage>Each extension name in the pname:ppEnabledExtensionNames array must: be one of those provided by the implementation or by an enabled layer and must: exactly match a string returned in the sname:VkExtensionProperties structure from flink:vkEnumerateDeviceExtensionProperties</usage>
                 <usage>The pname:queueFamilyIndex member of any given element of pname:pQueueCreateInfos must: be unique within pname:pQueueCreateInfos</usage>
             </validity>
         </type>
@@ -521,9 +520,8 @@ maintained in the master branch of the Khronos Vulkan Github project.
             <member optional="true"><type>uint32_t</type>               <name>enabledExtensionCount</name></member>
             <member len="enabledExtensionCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledExtensionNames</name></member>        <!-- Extension names to be enabled -->
             <validity>
-                <usage>Any given element of pname:ppEnabledLayerNames must: be the name of a layer present on the system, exactly matching a string returned in the sname:VkLayerProperties structure by fname:vkEnumerateInstanceLayerProperties</usage>
-                <usage>Any given element of pname:ppEnabledExtensionNames must: be the name of an extension present on the system, exactly matching a string returned in the sname:VkExtensionProperties structure by fname:vkEnumerateInstanceExtensionProperties</usage>
-                <usage>If an extension listed in pname:ppEnabledExtensionNames is provided as part of a layer, then both the layer and extension must: be enabled to enable that extension</usage>
+                <usage>Each layer name in the pname:ppEnabledLayerNames array must: exactly match a string returned in the sname:VkLayerProperties structure from flink:vkEnumerateInstanceLayerProperties</usage>
+                <usage>Each extension name in the pname:ppEnabledExtensionNames array must: be one of those provided by the implementation or by an enabled layer and must: exactly match a string returned in the sname:VkExtensionProperties structure from flink:vkEnumerateInstanceExtensionProperties</usage>
             </validity>
         </type>
         <type category="struct" name="VkQueueFamilyProperties" returnedonly="true">


### PR DESCRIPTION
issue 214
Simplify validity language around ppEnabledExtensionNames
and ppEnabledLayerNames.

Note: **Do not merge** this on the Github Khronos repository. Once the changes have passed review, will submit through Khronos specification change process.