### PR TITLE
Covering Get*ProcAddr() NULL return cases

### DIFF
--- a/doc/specs/vulkan/chapters/initialization.txt
+++ b/doc/specs/vulkan/chapters/initialization.txt
@@ -17,7 +17,7 @@ command:
 include::../protos/vkGetInstanceProcAddr.txt[]
 
   * pname:instance is the instance that the function pointer will be
-    compatible with.
+    compatible with, or `NULL` for commands not dependent on any instance.
   * pname:pName is the name of the command to obtain.
 
 include::../validity/protos/vkGetInstanceProcAddr.txt[]
@@ -31,21 +31,28 @@ Vulkan commands as well; if this is done, then applications that use only
 the core Vulkan commands have no need to use fname:vkGetInstanceProcAddr.
 
 Function pointers to commands that don't operate on a specific instance can:
-be obtained by using this command with pname:instance equal to `NULL`. The
-following commands can: be accessed this way:
+be obtained by using this command with pname:instance equal to `NULL`. Only
+pointers to the following commands can: be obtained this way:
 
   * flink:vkEnumerateInstanceExtensionProperties
   * flink:vkEnumerateInstanceLayerProperties
   * flink:vkCreateInstance
 
-If pname:instance is a valid sname:VkInstance, function pointers to any
-commands that operate on pname:instance or a child of pname:instance can: be
-obtained. The returned function pointer must: only be called with a
-dispatchable object (the first parameter) that is a child of pname:instance.
+If pname:instance is a valid sname:VkInstance, then function pointer to any
+command from any of the following groups can: be obtained:
 
-If pname:pName is not the name of a core Vulkan command, or is an
-extension command for any extension not supported by any available layer or
-implementation, then fname:vkGetInstanceProcAddr will return `NULL`.
+  * core Vulkan commands
+  * commands of instance extensions enabled for pname:instance
+  * commands of device extensions enabled for a valid sname:VkDevice child
+    object of pname:instance
+
+Any other valid usage of fname:vkGetInstanceProcAddr command must:
+return `NULL`.
+
+If pname:instance is a valid sname:VkInstance and the command does return a
+valid (non-`NULL`) function pointer, then the returned function pointer
+must: only be called with a dispatchable object (the first parameter) being
+pname:instance or its child.
 
 ifdef::editing-notes[]
 [NOTE]
@@ -79,17 +86,27 @@ command:
 include::../protos/vkGetDeviceProcAddr.txt[]
 
   * pname:device is the logical device that provides the function pointer.
-  * pname:pName is the name of any Vulkan command whose first parameter
-    is one of
-  ** sname:VkDevice
-  ** sname:VkQueue
-  ** sname:VkCommandBuffer
-
-If pname:pName is not the name of one of these Vulkan commands, and is
-not the name of an extension command belonging to an extension enabled for
-pname:device, then fname:vkGetDeviceProcAddr will return `NULL`.
+  * pname:pName is the name of Vulkan device dependent command.
 
 include::../validity/protos/vkGetDeviceProcAddr.txt[]
+
+For any command which takes a first parameter of any of the following types:
+
+  * sname:VkDevice
+  * sname:VkQueue
+  * sname:VkCommandBuffer
+
+and at the same time being from any of the following groups function pointer
+can: be obtained:
+
+  * core Vulkan commands
+  * commands of instance extensions enabled for the sname:VkInstance parent
+    object of pname:device
+  * commands of device extensions enabled for pname:device
+
+Any other valid usage of fname:vkGetDeviceProcAddr command must:
+return `NULL`.
+
 
 [[initialization-instances]]
 == Instances

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -2994,17 +2994,11 @@ maintained in the master branch of the Khronos Vulkan Github project.
             <proto><type>PFN_vkVoidFunction</type> <name>vkGetDeviceProcAddr</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param len="null-terminated">const <type>char</type>* <name>pName</name></param>
-            <validity>
-            </validity>
         </command>
         <command>
             <proto><type>PFN_vkVoidFunction</type> <name>vkGetInstanceProcAddr</name></proto>
             <param optional="true"><type>VkInstance</type> <name>instance</name></param>
             <param len="null-terminated">const <type>char</type>* <name>pName</name></param>
-            <validity>
-                <usage>If pname:instance is `NULL`, pname:pName must: be one of: fname:vkEnumerateInstanceExtensionProperties, fname:vkEnumerateInstanceLayerProperties or fname:vkCreateInstance</usage>
-                <usage>If pname:instance is not `NULL`, pname:pName mustnot: be fname:vkEnumerateInstanceExtensionProperties, fname:vkEnumerateInstanceLayerProperties or fname:vkCreateInstance</usage>
-            </validity>
         </command>
         <command>
             <proto><type>void</type> <name>vkGetPhysicalDeviceProperties</name></proto>


### PR DESCRIPTION
Fixes emergent issue in #212 

Rewording in such a way `Get*ProcAddr()` returns NULL in all reasonable
error cases. Additions to previous version:

1) General cleanup and more clear and enforcing language

2) vkGetInstanceProcAddr returns NULL even for supported non-enabled
extension functions

3) really returns NULL for all recoverable errors (except for `pName == NULL` which is still inValid Usage)

Requesting advice:
- Not sure if it should include `pName == NULL` case. It does imply it even in the old version.
- Not sure if it should include `instance == valid instance` case and requesting freestanding command and `instance == NULL` and requesting instance commands
- ~~Not sure if `vkGetDeviceProcAddr()` can apply to some instance extensions' commands.~~ R: it can
- Not sure if `vkGetInstanceProcAddr()` can apply to some device extensions' commands.
- Not sure if requesting its own pointer should conceptually return NULL or a valid pointer.