### PR TITLE
VkDebugMarkerObjectNameInfoEXT instead of VkDeviceCreateInfo

### DIFF
--- a/doc/specs/vulkan/appendices/VK_EXT_debug_marker.txt
+++ b/doc/specs/vulkan/appendices/VK_EXT_debug_marker.txt
@@ -69,7 +69,7 @@ error messages.
     PFN_vkDebugMarkerSetObjectNameEXT pfnDebugMarkerSetObjectNameEXT = (PFN_vkDebugMarkerSetObjectNameEXT)vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT");
 
     // Set a name on the image
-    const VkDeviceCreateInfo imageNameInfo =
+    const VkDebugMarkerObjectNameInfoEXT imageNameInfo =
     {
         VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT, // sType
         NULL,                                           // pNext


### PR DESCRIPTION
Example 1 of the VK_EXT_debug_marker specification was erroneously using a VkDeviceCreateInfo structure instead of VkDebugMarkerObjectNameInfoEXT  to set the debug object name for the image.
