### PR TITLE
Change scalar multiplication to cross sign

### DIFF
--- a/doc/specs/vulkan/chapters/fundamentals.txt
+++ b/doc/specs/vulkan/chapters/fundamentals.txt
@@ -861,8 +861,8 @@ We require simply that numbers' floating-point parts contain enough bits and
 that their exponent fields are large enough so that individual results of
 floating-point operations are accurate to about 1 part in 10^5^. The
 maximum representable magnitude for all floating-point values must: be at
-least 2^32^. latexmath:[$x \cdot 0 = 0 \cdot x = 0$] for any non-infinite
-and non-NaN latexmath:[$x$]. latexmath:[$1 \cdot x = x \cdot 1 = x$].
+least 2^32^. latexmath:[$x \times 0 = 0 \times x = 0$] for any non-infinite
+and non-NaN latexmath:[$x$]. latexmath:[$1 \times x = x \times 1 = x$].
 latexmath:[$x + 0 = 0 + x = x$]. latexmath:[$0^0 = 1$].
 
 Occasionally, further requirements will be specified. Most

--- a/doc/specs/vulkan/style/writing.txt
+++ b/doc/specs/vulkan/style/writing.txt
@@ -94,13 +94,13 @@ general LaTeX constructs are not.
 _Inline math_ is encoded using the latexmath{cl} macro. For example:
 
   * latexmath:[$[0,1\]$]
-  * latexmath:[$x \cdot 0 = 0 \cdot x = 0$]
+  * latexmath:[$x \times 0 = 0 \times x = 0$]
   * latexmath:[${\textbf c} = t {\textbf c}_1 + (1-t){\textbf c}_2. $]
 
 .Example Markup
 ----
     latexmath:[$[0,1\]$]
-    latexmath:[$x \cdot 0 = 0 \cdot x = 0$]
+    latexmath:[$x \times 0 = 0 \times x = 0$]
     latexmath:[${\textbf c} = t {\textbf c}_1 + (1-t){\textbf c}_2. $]
 ----
 


### PR DESCRIPTION
Use cross sign (Latex \times) for multiplication as ~~I was told is
prefered style of this spec~~ in styleguide ch 2.2.
Related to issue #220 

I was warned, there is some trouble with Unicode, but encountered none. Tried both styleguide and spec with:
- XHTML, Firefox, Windows 10
- XHTML, PDF Chrome, Windows 10
- XHTML, IE, Windows 10
- XHTML, PDF Edge, Windows 10
- XHTML, PDF Firefox, Linux Mint
- XHTML, PDF Chromium, Linux Mint
- PDF Evince(aka Document Viewer), Linux Mint
- PDF Foxit Reader, Windows 10