### PR TITLE
Fixing stuff related to C -> operator

### DIFF
--- a/src/spec/validitygenerator.py
+++ b/src/spec/validitygenerator.py
@@ -346,7 +346,8 @@ class ValidityOutputGenerator(OutputGenerator):
                 if 'latexmath:' in lengths[0]:
                     asciidoc += lengths[0]
                 else:
-                    asciidoc += self.makeParameterName(lengths[0])
+                    asciidoc += 'pname:'
+                    asciidoc += lengths[0].replace('->', '\->pname:')
                 asciidoc += ' '
 
             for length in lengths[1:]:
@@ -360,7 +361,8 @@ class ValidityOutputGenerator(OutputGenerator):
                     if 'latex:' in length:
                         asciidoc += length
                     else:
-                        asciidoc += self.makeParameterName(length)
+                        asciidoc += 'pname:'
+                        asciidoc += length.replace('->', '\->pname:')
                     asciidoc += ' '
 
             # Void pointers don't actually point at anything - remove the word "to"
@@ -434,8 +436,7 @@ class ValidityOutputGenerator(OutputGenerator):
                     asciidoc += '* '
                     if self.paramIsArray(param):
                         asciidoc += 'Each element of '
-                    asciidoc += 'pname:'
-                    asciidoc += paramname.text
+                    asciidoc += self.makeParameterName(paramname.text)
                     asciidoc += ' mustnot: be `0`'
                     asciidoc += '\n'
 
@@ -615,6 +616,24 @@ class ValidityOutputGenerator(OutputGenerator):
         asciidoc += '\n'
 
         return asciidoc
+
+    #
+    # Turn the "name[].member[]" notation into plain English.
+    def makeThreadDereferenceHumanReadable(self, dereference):
+        matches = re.findall(r"[\w]+[^\w]*",dereference)
+        stringval = ''
+        for match in reversed(matches):
+            if '->' in match or '.' in match:
+                stringval += 'member of '
+            if '[]' in match:
+                stringval += 'each element of '
+
+            stringval += 'the '
+            stringval += self.makeParameterName(re.findall(r"[\w]+",match)[0])
+            stringval += ' '
+
+        return stringval + 'parameter'
+
 
     #
     # Generate all the valid usage information for a given struct or command
@@ -838,7 +857,7 @@ class ValidityOutputGenerator(OutputGenerator):
         # For any vkCmd* functions, the commandBuffer parameter must be being recorded
         if cmd.find('proto/name') is not None and 'vkCmd' in cmd.find('proto/name'):
             paramdecl += '* '
-            paramdecl += 'The sname:VkCommandPool that pname:commandBuffer was created from'
+            paramdecl += 'The sname:VkCommandPool that pname:commandBuffer was allocated from'
             paramdecl += '\n'
 
         # Find and add any parameters that are thread unsafe
@@ -852,15 +871,22 @@ class ValidityOutputGenerator(OutputGenerator):
                     paramdecl += 'Host access to '
                     if externsyncattrib == 'true':
                         if self.paramIsArray(param):
-                            paramdecl += 'each member of ' + self.makeParameterName(paramname.text)
+                            paramdecl += 'each element of the '
+                            paramdecl += self.makeParameterName(paramname.text)
+                            paramdecl += ' array '
                         elif self.paramIsPointer(param):
-                            paramdecl += 'the object referenced by ' + self.makeParameterName(paramname.text)
+                            paramdecl += 'the object referenced by the '
+                            paramdecl += self.makeParameterName(paramname.text)
+                            paramdecl += ' pointer '
                         else:
                             paramdecl += self.makeParameterName(paramname.text)
+                            paramdecl += ' '
+
                     else:
-                        paramdecl += 'pname:'
-                        paramdecl += externsyncattrib
-                    paramdecl += ' must: be externally synchronized\n'
+                        paramdecl += self.makeThreadDereferenceHumanReadable(externsyncattrib)
+                        paramdecl += ' '
+
+                    paramdecl += 'must: be externally synchronized\n'
 
         # Find and add any "implicit" parameters that are thread unsafe
         implicitexternsyncparams = cmd.find('implicitexternsyncparams')

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -1392,8 +1392,8 @@ maintained in the master branch of the Khronos Vulkan Github project.
                 <usage>If pname:subpass uses a depth/stencil attachment in pname:renderpass that has a layout of ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL in the sname:VkAttachmentReference defined by pname:subpass, and pname:pDepthStencilState is not `NULL`, the pname:failOp, pname:passOp and pname:depthFailOp members of each of the pname:front and pname:back members of pname:pDepthStencilState must: be ename:VK_STENCIL_OP_KEEP</usage>
                 <usage>If pname:pColorBlendState is not `NULL`, the pname:blendEnable member of each element of the pname:pAttachment member of pname:pColorBlendState must: be ename:VK_FALSE if the pname:format of the attachment referred to in pname:subpass of pname:renderPass does not support color blend operations, as specified by the ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT flag in sname:VkFormatProperties::pname:linearTilingFeatures or sname:VkFormatProperties::pname:optimalTilingFeatures returned by fname:vkGetPhysicalDeviceFormatProperties</usage>
                 <usage>If pname:pColorBlendState is not `NULL`, The pname:attachmentCount member of pname:pColorBlendState must: be equal to the pname:colorAttachmentCount used to create pname:subpass</usage>
-                <usage>If no element of the pname:pDynamicStates member of pname:pDynamicState is ename:VK_DYNAMIC_STATE_VIEWPORT, the pname:pViewports member of pname:pViewportState must: be a pointer to an array of pname:pViewportState->viewportCount sname:VkViewport structures</usage>
-                <usage>If no element of the pname:pDynamicStates member of pname:pDynamicState is ename:VK_DYNAMIC_STATE_SCISSOR, the pname:pScissors member of pname:pViewportState must: be a pointer to an array of pname:pViewportState->scissorCount sname:VkRect2D structures</usage>
+                <usage>If no element of the pname:pDynamicStates member of pname:pDynamicState is ename:VK_DYNAMIC_STATE_VIEWPORT, the pname:pViewports member of pname:pViewportState must: be a pointer to an array of pname:pViewportState\-&gt;pname:viewportCount sname:VkViewport structures</usage>
+                <usage>If no element of the pname:pDynamicStates member of pname:pDynamicState is ename:VK_DYNAMIC_STATE_SCISSOR, the pname:pScissors member of pname:pViewportState must: be a pointer to an array of pname:pViewportState\-&gt;pname:scissorCount sname:VkRect2D structures</usage>
                 <usage>If the wide lines feature is not enabled, and no element of the pname:pDynamicStates member of pname:pDynamicState is ename:VK_DYNAMIC_STATE_LINE_WIDTH, the pname:lineWidth member of pname:pRasterizationState must: be `1.0`</usage>
                 <usage>If the pname:rasterizerDiscardEnable member of pname:pRasterizationState is ename:VK_FALSE, pname:pViewportState must: be a pointer to a valid sname:VkPipelineViewportStateCreateInfo structure</usage>
                 <usage>If the pname:rasterizerDiscardEnable member of pname:pRasterizationState is ename:VK_FALSE, pname:pMultisampleState must: be a pointer to a valid sname:VkPipelineMultisampleStateCreateInfo structure</usage>
@@ -3688,8 +3688,8 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkAllocateDescriptorSets</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pAllocateInfo->descriptorPool">const <type>VkDescriptorSetAllocateInfo</type>* <name>pAllocateInfo</name></param>
-            <param len="pAllocateInfo->descriptorSetCount"><type>VkDescriptorSet</type>* <name>pDescriptorSets</name></param>
+            <param externsync="pAllocateInfo-&gt;descriptorPool">const <type>VkDescriptorSetAllocateInfo</type>* <name>pAllocateInfo</name></param>
+            <param len="pAllocateInfo-&gt;descriptorSetCount"><type>VkDescriptorSet</type>* <name>pDescriptorSets</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkFreeDescriptorSets</name></proto>
@@ -3784,8 +3784,8 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkAllocateCommandBuffers</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pAllocateInfo->commandPool">const <type>VkCommandBufferAllocateInfo</type>* <name>pAllocateInfo</name></param>
-            <param len="pAllocateInfo->commandBufferCount"><type>VkCommandBuffer</type>* <name>pCommandBuffers</name></param>
+            <param externsync="pAllocateInfo-&gt;commandPool">const <type>VkCommandBufferAllocateInfo</type>* <name>pAllocateInfo</name></param>
+            <param len="pAllocateInfo-&gt;commandBufferCount"><type>VkCommandBuffer</type>* <name>pCommandBuffers</name></param>
         </command>
         <command>
             <proto><type>void</type> <name>vkFreeCommandBuffers</name></proto>
@@ -4668,7 +4668,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR">
             <proto><type>VkResult</type> <name>vkCreateSwapchainKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pCreateInfo.surface,pCreateInfo.oldSwapchain">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfo</name></param>
+            <param externsync="pCreateInfo-&gt;surface,pCreateInfo-&gt;oldSwapchain">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfo</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param><type>VkSwapchainKHR</type>* <name>pSwapchain</name></param>
         </command>
@@ -4706,7 +4706,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <command successcodes="VK_SUCCESS,VK_SUBOPTIMAL_KHR" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR">
             <proto><type>VkResult</type> <name>vkQueuePresentKHR</name></proto>
             <param externsync="true"><type>VkQueue</type> <name>queue</name></param>
-            <param externsync="pPresentInfo.pWaitSemaphores[],pPresentInfo.pSwapchains[]">const <type>VkPresentInfoKHR</type>* <name>pPresentInfo</name></param>
+            <param externsync="pPresentInfo-&gt;pWaitSemaphores[],pPresentInfo-&gt;pSwapchains[]">const <type>VkPresentInfoKHR</type>* <name>pPresentInfo</name></param>
             <validity>
                 <usage>Any given element of pname:pSwapchains member of pname:pPresentInfo must: be a swapchain that is created for a surface for which presentation is supported from pname:queue as determined using a call to fname:vkGetPhysicalDeviceSurfaceSupportKHR</usage>
             </validity>
@@ -4815,7 +4815,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkDebugMarkerSetObjectNameEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pNameInfo.object"><type>VkDebugMarkerObjectNameInfoEXT</type>* <name>pNameInfo</name></param>
+            <param externsync="pNameInfo-&gt;object"><type>VkDebugMarkerObjectNameInfoEXT</type>* <name>pNameInfo</name></param>
             <validity>
                <usage>pname:pNameInfo.object must: be a Vulkan object</usage>
             </validity>
@@ -4823,7 +4823,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkDebugMarkerSetObjectTagEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pTagInfo.object"><type>VkDebugMarkerObjectTagInfoEXT</type>* <name>pTagInfo</name></param>
+            <param externsync="pTagInfo-&gt;object"><type>VkDebugMarkerObjectTagInfoEXT</type>* <name>pTagInfo</name></param>
             <validity>
                <usage>pname:pTagInfo.object must: be a Vulkan object</usage>
                <usage>pname:pTagInfo.tagName mustnot: be `0`</usage>


### PR DESCRIPTION
1) Reused existing function (from `HostSynchronizationOutputGenerator`) for "human readable" output of externsync attribute values

2) Escaped `->` so it is not replaced with unicode arrow

3) Added `pname:` to members after C dereferences ( only after `->` -- there are no relevant `.` cases I think) 

4) Replaced `>` with `&gt;` (not necessary but a XML recommendation)

5) Fixed `.` where `->` should be instead

6) Opportunisticaly fixed "created" (on Pool resource) to "allocated"

Fixes part of #245 
Perhaps 1) gives hint how externsync in #265 should be specified in the schema documentation

Known problem: The arrows are ugly in XHTML output (nice in PDF) due to chosen font. If I make it ++literal++, then it is nice, but the PDF output decides to break line in the exact middle of the arrow in one case. Haven't found the appropriate hack for this to work correctly...