### PR TITLE
Correct description of vkCmdDrawIndexedIndirect

### DIFF
--- a/doc/specs/vulkan/chapters/drawing.txt
+++ b/doc/specs/vulkan/chapters/drawing.txt
@@ -527,7 +527,7 @@ include::../api/protos/vkCmdDrawIndexedIndirect.txt[]
   * pname:stride is the byte stride between successive sets of draw
     parameters.
 
-fname:vkCmdDrawIndexedIndirect behaves similarly to flink:vkCmdDrawIndirect
+fname:vkCmdDrawIndexedIndirect behaves similarly to flink:vkCmdDrawIndexed
 except that the parameters are read by the device from a buffer during
 execution. pname:drawCount draws are executed by the command, with
 parameters taken from pname:buffer starting at pname:offset and increasing


### PR DESCRIPTION
vkCmdDrawIndexedIndirect incorrectly claims it is an indirect version of vkCmdDrawIndirect instead of vkCmdDrawIndexed.