### PR TITLE
Clarification for Get*ProcAddr

### DIFF
--- a/doc/specs/vulkan/chapters/initialization.txt
+++ b/doc/specs/vulkan/chapters/initialization.txt
@@ -54,12 +54,12 @@ be cast to the type of the command being queried.
 
 1::
 The returned function pointer must: only be called with a dispatchable object
-(the first parameter) that is a child of pname:instance.
+(the first parameter) that is pname:instance or a child of pname:instance.
     e.g. sname:VkInstance, sname:VkPhysicalDevice, sname:VkDevice, sname:VkQueue, or
     sname:VkCommandBuffer.
 
 2::
-available extension is an extension function supported by any of the loader, ICD or layer.
+An ``available extension'' is an extension function supported by any of the loader, ICD or layer.
 
 ifdef::editing-notes[]
 [NOTE]
@@ -112,14 +112,14 @@ be cast to the type of the command being queried.
 | invalid device | * | undefined
 | device | NULL | undefined
 | device | core Vulkan command^1^ | fp
-| device | enabled device extension commands for pname:device | fp
+| device | enabled extension commands^1^ | fp
 | device | * (any pname:pName not covered above) | NULL
 |=====
 
 1::
-pname:pName is the name of any Vulkan command whose first parameter
-    is sname:VkDevice or any of its dispatchable children (e.g. sname:VkQueue,
-    sname:vkCommandBuffer).
+The returned function pointer must: only be called with a dispatchable object
+(the first parameter) that is pname:device or a child of pname:device.
+    e.g. sname:VkDevice, sname:VkQueue, or sname:VkCommandBuffer.
 
 include::../validity/protos/vkGetDeviceProcAddr.txt[]
 

--- a/doc/specs/vulkan/man/vkGetDeviceProcAddr.txt
+++ b/doc/specs/vulkan/man/vkGetDeviceProcAddr.txt
@@ -48,14 +48,14 @@ be cast to the type of the command being queried.
 | invalid device | * | undefined
 | device | NULL | undefined
 | device | core Vulkan command^1^ | fp
-| device | enabled device extension commands for pname:device | fp
+| device | enabled extension commands^1^ | fp
 | device | * (any pname:pName not covered above) | NULL
 |=====
 
 1::
-pname:pName is the name of any Vulkan command whose first parameter
-    is sname:VkDevice or any of its dispatchable children (e.g. sname:VkQueue,
-    sname:vkCommandBuffer).
+The returned function pointer must: only be called with a dispatchable object
+(the first parameter) that is pname:device or a child of pname:device.
+    e.g. sname:VkDevice, sname:VkQueue, or sname:VkCommandBuffer.
 
 include::../validity/protos/vkGetDeviceProcAddr.txt[]
 

--- a/doc/specs/vulkan/man/vkGetInstanceProcAddr.txt
+++ b/doc/specs/vulkan/man/vkGetInstanceProcAddr.txt
@@ -64,12 +64,12 @@ be cast to the type of the command being queried.
 
 1::
 The returned function pointer must: only be called with a dispatchable object
-(the first parameter) that is a child of pname:instance.
+(the first parameter) that is pname:instance or a child of pname:instance.
     e.g. sname:VkInstance, sname:VkPhysicalDevice, sname:VkDevice, sname:VkQueue, or
     sname:VkCommandBuffer.
 
 2::
-available extension is an extension function supported by any of the loader, ICD or layer.
+An ``available extension'' is an extension function supported by any of the loader, ICD or layer.
 
 ifdef::editing-notes[]
 [NOTE]


### PR DESCRIPTION
Follow-on to public issue 212.
https://github.com/KhronosGroup/Vulkan-Docs/issues/212
[ChangeLog] Clarify description of GetInstanceProcAddr and
GetDeviceProcAddr.
