### PR TITLE
Fixing formating of SPIRV-Image-ImageView table

### DIFF
--- a/doc/specs/vulkan/chapters/resources.txt
+++ b/doc/specs/vulkan/chapters/resources.txt
@@ -755,103 +755,175 @@ Classes>> section.
 
 [[resources-image-views-compatibility]]
 .Image and image view parameter compatibility requirements
-[cols="20%h,35%,45%",options="header"]
+[cols="19%h,36%,45%",options="header"]
 |========================================
 | Dim, Arrayed, MS | Image parameters | View parameters
 | 1D, 0, 0 |
-imageType = ename:VK_IMAGE_TYPE_1D +
-width >= 1 +
-height = 1 +
-depth = 1 +
-arrayLayers >= 1 +
-samples = 1 |
-viewType = ename:VK_VIEW_TYPE_1D +
-baseArrayLayer >= 0 +
-layerCount = 1
+pname:imageType latexmath:[$=$] ename:VK_IMAGE_TYPE_1D 
+
+pname:width latexmath:[$\geq 1$]
+
+pname:height latexmath:[$= 1$]
+
+pname:depth latexmath:[$= 1$]
+
+pname:arrayLayers latexmath:[$\geq 1$]
+
+pname:samples latexmath:[$= 1$]
+|
+pname:viewType latexmath:[$=$] ename:VK_VIEW_TYPE_1D
+
+pname:baseArrayLayer latexmath:[$\geq 0$]
+
+pname:layerCount latexmath:[$= 1$]
 | 1D, 1, 0 |
-imageType = ename:VK_IMAGE_TYPE_1D +
-width >= 1 +
-height = 1 +
-depth = 1 +
-arrayLayers >= 1 +
-samples = 1 |
-viewType = ename:VK_VIEW_TYPE_1D_ARRAY +
-baseArrayLayer >= 0 +
-layerCount >= 1
+pname:imageType latexmath:[$=$] ename:VK_IMAGE_TYPE_1D
+
+pname:width latexmath:[$\geq 1$]
+
+pname:height latexmath:[$= 1$]
+
+pname:depth latexmath:[$= 1$]
+
+pname:arrayLayers latexmath:[$\geq 1$]
+
+pname:samples latexmath:[$= 1$]
+|
+pname:viewType latexmath:[$=$] ename:VK_VIEW_TYPE_1D_ARRAY
+
+pname:baseArrayLayer latexmath:[$\geq 0$]
+
+pname:layerCount latexmath:[$\geq 1$]
 | 2D, 0, 0 |
-imageType = ename:VK_IMAGE_TYPE_2D +
-width >= 1 +
-height >= 1 +
-depth = 1 +
-arrayLayers >= 1 +
-samples = 1 |
-viewType = ename:VK_VIEW_TYPE_2D +
-baseArrayLayer >= 0 +
-layerCount = 1
+pname:imageType latexmath:[$=$] ename:VK_IMAGE_TYPE_2D
+
+pname:width latexmath:[$\geq 1$]
+
+pname:height latexmath:[$\geq 1$]
+
+pname:depth latexmath:[$= 1$]
+
+pname:arrayLayers latexmath:[$\geq 1$]
+
+pname:samples latexmath:[$= 1$]
+|
+pname:viewType latexmath:[$=$] ename:VK_VIEW_TYPE_2D
+
+pname:baseArrayLayer latexmath:[$\geq 0$]
+
+pname:layerCount latexmath:[$= 1$]
 | 2D, 1, 0 |
-imageType = ename:VK_IMAGE_TYPE_2D +
-width >= 1 +
-height >= 1 +
-depth = 1 +
-arrayLayers >= 1 +
-samples = 1 |
-viewType = ename:VK_VIEW_TYPE_2D_ARRAY +
-baseArrayLayer >= 0 +
-layerCount >= 1
+pname:imageType latexmath:[$=$] ename:VK_IMAGE_TYPE_2D
+
+pname:width latexmath:[$\geq 1$]
+
+pname:height latexmath:[$\geq 1$]
+
+pname:depth latexmath:[$= 1$]
+
+pname:arrayLayers latexmath:[$\geq 1$]
+
+pname:samples latexmath:[$= 1$]
+|
+pname:viewType latexmath:[$=$] ename:VK_VIEW_TYPE_2D_ARRAY
+
+pname:baseArrayLayer latexmath:[$\geq 0$]
+
+pname:layerCount latexmath:[$\geq 1$]
 | 2D, 0, 1 |
-imageType = ename:VK_IMAGE_TYPE_2D +
-width >= 1 +
-height >= 1 +
-depth = 1 +
-arrayLayers >= 1 +
-samples > 1 |
-viewType = ename:VK_VIEW_TYPE_2D +
-baseArrayLayer >= 0 +
-layerCount = 1
+pname:imageType latexmath:[$=$] ename:VK_IMAGE_TYPE_2D
+
+pname:width latexmath:[$\geq 1$]
+
+pname:height latexmath:[$\geq 1$]
+
+pname:depth latexmath:[$= 1$]
+
+pname:arrayLayers latexmath:[$\geq 1$]
+
+pname:samples latexmath:[$> 1$]
+|
+pname:viewType latexmath:[$=$] ename:VK_VIEW_TYPE_2D
+
+pname:baseArrayLayer latexmath:[$\geq 0$]
+
+pname:layerCount latexmath:[$= 1$]
 | 2D, 1, 1 |
-imageType = ename:VK_IMAGE_TYPE_2D +
-width >= 1 +
-height >= 1 +
-depth = 1 +
-arrayLayers >= 1 +
-samples > 1 |
-viewType = ename:VK_VIEW_TYPE_2D_ARRAY +
-baseArrayLayer >= 0 +
-layerCount >= 1
+pname:imageType latexmath:[$=$] ename:VK_IMAGE_TYPE_2D
+
+pname:width latexmath:[$\geq 1$]
+
+pname:height latexmath:[$\geq 1$]
+
+pname:depth latexmath:[$= 1$]
+
+pname:arrayLayers latexmath:[$\geq 1$]
+
+pname:samples latexmath:[$> 1$]
+|
+pname:viewType latexmath:[$=$] ename:VK_VIEW_TYPE_2D_ARRAY
+
+pname:baseArrayLayer latexmath:[$\geq 0$]
+
+pname:layerCount latexmath:[$\geq 1$]
 | CUBE, 0, 0 |
-imageType = ename:VK_IMAGE_TYPE_2D +
-width >= 1 +
-height = width +
-depth = 1 +
-arrayLayers >= 6 +
-samples = 1 +
-flags include ename:VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT |
-viewType = ename:VK_VIEW_TYPE_CUBE +
-baseArrayLayer >= 0 +
-layerCount = 6
+pname:imageType latexmath:[$=$] ename:VK_IMAGE_TYPE_2D
+
+pname:width latexmath:[$\geq 1$]
+
+pname:height latexmath:[$=$] pname:width
+
+pname:depth latexmath:[$= 1$]
+
+pname:arrayLayers latexmath:[$\geq 6$]
+
+pname:samples latexmath:[$= 1$]
+
+pname:flags include ename:VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT
+|
+pname:viewType latexmath:[$=$] ename:VK_VIEW_TYPE_CUBE
+
+pname:baseArrayLayer latexmath:[$\geq 0$]
+
+pname:layerCount latexmath:[$= 6$]
 | CUBE, 1, 0 |
-imageType = ename:VK_IMAGE_TYPE_2D +
-width >= 1 +
-height = width +
-depth = 1 +
-N >= 1 +
-arrayLayers >= latexmath:[$6 \times N$] +
-samples = 1 +
-flags include ename:VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT |
-viewType = ename:VK_VIEW_TYPE_CUBE_ARRAY +
-baseArrayLayer >= 0 +
-N >= 1 +
-layerCount = latexmath:[$6 \times N$]
+pname:imageType latexmath:[$=$] ename:VK_IMAGE_TYPE_2D
+
+pname:width latexmath:[$\geq 1$]
+
+pname:height latexmath:[$=$] pname:width
+
+pname:depth latexmath:[$= 1$]
+
+pname:arrayLayers latexmath:[$\geq 6 \times N; N \geq 1$]
+
+pname:samples latexmath:[$= 1$]
+
+pname:flags include ename:VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT
+|
+pname:viewType latexmath:[$=$] ename:VK_VIEW_TYPE_CUBE_ARRAY
+
+pname:baseArrayLayer latexmath:[$\geq 0$]
+
+pname:layerCount latexmath:[$=6 \times N; N \geq 1$]
 | 3D, 0, 0 |
-imageType = ename:VK_IMAGE_TYPE_3D +
-width >= 1 +
-height >= 1 +
-depth >= 1 +
-arrayLayers = 1 +
-samples = 1 |
-viewType = ename:VK_VIEW_TYPE_3D +
-baseArrayLayer = 0 +
-layerCount = 1
+pname:imageType latexmath:[$=$] ename:VK_IMAGE_TYPE_3D
+
+pname:width latexmath:[$\geq 1$]
+
+pname:height latexmath:[$\geq 1$]
+
+pname:depth latexmath:[$\geq 1$]
+
+pname:arrayLayers latexmath:[$= 1$]
+
+pname:samples latexmath:[$= 1$]
+|
+pname:viewType latexmath:[$=$] ename:VK_VIEW_TYPE_3D
+
+pname:baseArrayLayer latexmath:[$= 0$]
+
+pname:layerCount latexmath:[$= 1$]
 |========================================
 
 include::../validity/structs/VkImageViewCreateInfo.txt[]


### PR DESCRIPTION
from issue #304

 - Fixing formating so elements are on seprate lines across all build targets.
 - Adjusting witdth so contents fit well in man target.
 - Encapsulating stuff in math environment for format consistency
 - Moving `N` definition to same line where used

(I noticed there may be some trouble with tables generally in html man #323)