### PR TITLE
Remove space after comma in vkEnumerateInstanceExtensionProperties errorcodes

### DIFF
--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -3098,7 +3098,7 @@ maintained in the master branch of the Khronos Vulkan Github project.
             <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
             <param optional="true" len="pPropertyCount"><type>VkLayerProperties</type>* <name>pProperties</name></param>
         </command>
-        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_LAYER_NOT_PRESENT">
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_LAYER_NOT_PRESENT">
             <proto><type>VkResult</type> <name>vkEnumerateInstanceExtensionProperties</name></proto>
             <param optional="true" len="null-terminated">const <type>char</type>* <name>pLayerName</name></param>
             <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>


### PR DESCRIPTION
This fixes the broken formatting in the spec for [`vkEnumerateInstanceExtensionProperties`][vkenumerateinstanceextensionproperties].

[vkenumerateinstanceextensionproperties]: https://www.khronos.org/registry/vulkan/specs/1.0/xhtml/vkspec.html#vkEnumerateInstanceExtensionProperties