### PR TITLE
Add bitmask type specification for NV vendor tag enums

### DIFF
--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -3057,13 +3057,13 @@ maintained in the master branch of the Khronos Vulkan Github project.
         <enum value="0" name="VK_RASTERIZATION_ORDER_STRICT_AMD"/>      <!-- Rasterization order strictly follows API order -->
         <enum value="1" name="VK_RASTERIZATION_ORDER_RELAXED_AMD"/>     <!-- Rasterization order may not follow API order -->
     </enums>
-    <enums name="VkExternalMemoryHandleTypeFlagBitsNV">
+    <enums name="VkExternalMemoryHandleTypeFlagBitsNV" type="bitmask">
         <enum value="0x00000001" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_NV"/>
         <enum value="0x00000002" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_NV"/>
         <enum value="0x00000004" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_IMAGE_BIT_NV"/>
         <enum value="0x00000008" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_IMAGE_KMT_BIT_NV"/>
     </enums>
-    <enums name="VkExternalMemoryFeatureFlagBitsNV">
+    <enums name="VkExternalMemoryFeatureFlagBitsNV" type="bitmask">
         <enum value="0x00000001" name="VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT_NV"/>
         <enum value="0x00000002" name="VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_NV"/>
         <enum value="0x00000004" name="VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT_NV"/>


### PR DESCRIPTION
Not sure if intentional or not, but the following enums were missing type specification attribute:

- VkExternalMemoryHandleTypeFlagBitsNV
- VkExternalMemoryFeatureFlagBitsNV
