### PR TITLE
Correct refBegin for VkDebugReportFlagBitsEXT

### DIFF
--- a/doc/specs/vulkan/chapters/VK_EXT_debug_report.txt
+++ b/doc/specs/vulkan/chapters/VK_EXT_debug_report.txt
@@ -48,7 +48,7 @@ include::../api/structs/VkDebugReportCallbackCreateInfoEXT.txt[]
     Bits which can: be set include:
 +
 --
-// refBegin VkDebugReportCallbackCreateInfoEXT Bitmask specifying events which cause a debug report callback
+// refBegin VkDebugReportFlagBitsEXT Bitmask specifying events which cause a debug report callback
 include::../api/enums/VkDebugReportFlagBitsEXT.txt[]
 
   * ename:VK_DEBUG_REPORT_ERROR_BIT_EXT indicates an error that may cause


### PR DESCRIPTION
The refBegin entry for VkDebugReportFlagBitsEXT is incorrectly set to VkDebugReportCallbackCreateInfoEXT