### PR TITLE
Add missing DEBUG_REPORT_ENUMS for DisplayKHR and DisplayModeKHR objects

### DIFF
--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -2410,6 +2410,8 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <enum value="26" name="VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT"/>
         <enum value="27" name="VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT"/>
         <enum value="28" name="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT"/>
+        <enum value="29" name="VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT"/>
+        <enum value="30" name="VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT"/>
     </enums>
     <enums name="VkDebugReportErrorEXT" type="enum">
         <enum value="0" name="VK_DEBUG_REPORT_ERROR_NONE_EXT"/>         <!-- Used for INFO & other non-error messages -->


### PR DESCRIPTION
Addresses Github issue #408 .  Validation needs this to track these object types.