### PR TITLE
Fix references to VK_ERROR_DEVICE_LOST

### DIFF
--- a/doc/specs/vulkan/chapters/synchronization.txt
+++ b/doc/specs/vulkan/chapters/synchronization.txt
@@ -973,7 +973,7 @@ with the following return codes:
 | Status | Meaning
 | ename:VK_SUCCESS | The fence specified by pname:fence is signaled.
 | ename:VK_NOT_READY | The fence specified by pname:fence is unsignaled.
-| ename:VK_DEVICE_LOST | The device has been lost.  See <<devsandqueues-lost-device,Lost Device>>.
+| ename:VK_ERROR_DEVICE_LOST | The device has been lost.  See <<devsandqueues-lost-device,Lost Device>>.
 |====
 
 If a <<devsandqueues-submission, queue submission>> command is pending
@@ -983,7 +983,7 @@ of date.
 If the device has been lost (see <<devsandqueues-lost-device,Lost Device>>),
 fname:vkGetFenceStatus may: return any of the above status codes.
 If the device has been lost and fname:vkGetFenceStatus is called repeatedly,
-it will eventually return either ename:VK_SUCCESS or ename:VK_DEVICE_LOST.
+it will eventually return either ename:VK_SUCCESS or ename:VK_ERROR_DEVICE_LOST.
 
 include::../validity/protos/vkGetFenceStatus.txt[]
 
@@ -1079,7 +1079,7 @@ fname:vkWaitForFences returns ename:VK_SUCCESS.
 
 If device loss occurs (see <<devsandqueues-lost-device,Lost Device>>) before
 the timeout has expired, fname:vkWaitForFences must: return in finite time
-with either ename:VK_SUCCESS or ename:VK_DEVICE_LOST.
+with either ename:VK_SUCCESS or ename:VK_ERROR_DEVICE_LOST.
 
 .Note
 [NOTE]


### PR DESCRIPTION
The specification calls it VK_DEVICE_LOST in several places.