### PR TITLE
Fix use of FlagBits to Flags types.

### DIFF
--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -736,7 +736,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member><type>VkExtent3D</type>             <name>extent</name></member>
             <member><type>uint32_t</type>               <name>mipLevels</name></member>
             <member><type>uint32_t</type>               <name>arrayLayers</name></member>
-            <member><type>VkSampleCountFlagBits</type>  <name>samples</name></member>
+            <member><type>VkSampleCountFlags</type>  <name>samples</name></member>
             <member><type>VkImageTiling</type>          <name>tiling</name></member>
             <member><type>VkImageUsageFlags</type>      <name>usage</name><comment>Image usage flags</comment></member>
             <member><type>VkSharingMode</type>          <name>sharingMode</name><comment>Cross-queue-family sharing mode</comment></member>
@@ -893,7 +893,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member values="VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineShaderStageCreateFlags</type>    <name>flags</name></member>
-            <member><type>VkShaderStageFlagBits</type>  <name>stage</name><comment>Shader stage</comment></member>
+            <member><type>VkShaderStageFlags</type>  <name>stage</name><comment>Shader stage</comment></member>
             <member><type>VkShaderModule</type>         <name>module</name><comment>Module containing entry point</comment></member>
             <member len="null-terminated">const <type>char</type>*            <name>pName</name><comment>Null-terminated entry point name</comment></member>
             <member optional="true">const <type>VkSpecializationInfo</type>* <name>pSpecializationInfo</name></member>
@@ -968,7 +968,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member values="VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member validextensionstructs="VkPipelineCoverageToColorStateCreateInfoNV,VkPipelineCoverageModulationStateCreateInfoNV">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineMultisampleStateCreateFlags</type>    <name>flags</name></member>
-            <member><type>VkSampleCountFlagBits</type>  <name>rasterizationSamples</name><comment>Number of samples used for rasterization</comment></member>
+            <member><type>VkSampleCountFlags</type>  <name>rasterizationSamples</name><comment>Number of samples used for rasterization</comment></member>
             <member><type>VkBool32</type>               <name>sampleShadingEnable</name><comment>optional (GL45)</comment></member>
             <member><type>float</type>                  <name>minSampleShading</name><comment>optional (GL45)</comment></member>
             <member optional="true" len="latexmath:[\lceil{\mathit{rasterizationSamples} \over 32}\rceil]">const <type>VkSampleMask</type>*    <name>pSampleMask</name><comment>Array of sampleMask words</comment></member>
@@ -1146,7 +1146,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
         <type category="struct" name="VkAttachmentDescription">
             <member optional="true"><type>VkAttachmentDescriptionFlags</type> <name>flags</name></member>
             <member><type>VkFormat</type>               <name>format</name></member>
-            <member><type>VkSampleCountFlagBits</type>  <name>samples</name></member>
+            <member><type>VkSampleCountFlags</type>  <name>samples</name></member>
             <member><type>VkAttachmentLoadOp</type>     <name>loadOp</name><comment>Load operation for color or depth data</comment></member>
             <member><type>VkAttachmentStoreOp</type>    <name>storeOp</name><comment>Store operation for color or depth data</comment></member>
             <member><type>VkAttachmentLoadOp</type>     <name>stencilLoadOp</name><comment>Load operation for stencil data</comment></member>
@@ -1480,9 +1480,9 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member><type>VkDisplayModeKHR</type>                 <name>displayMode</name><comment>The mode to use when displaying this surface</comment></member>
             <member><type>uint32_t</type>                         <name>planeIndex</name><comment>The plane on which this surface appears.  Must be between 0 and the value returned by vkGetPhysicalDeviceDisplayPlanePropertiesKHR() in pPropertyCount.</comment></member>
             <member><type>uint32_t</type>                         <name>planeStackIndex</name><comment>The z-order of the plane.</comment></member>
-            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>transform</name><comment>Transform to apply to the images as part of the scanout operation</comment></member>
+            <member><type>VkSurfaceTransformFlagsKHR</type>    <name>transform</name><comment>Transform to apply to the images as part of the scanout operation</comment></member>
             <member><type>float</type>                            <name>globalAlpha</name><comment>Global alpha value.  Must be between 0 and 1, inclusive.  Ignored if alphaMode is not VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR</comment></member>
-            <member><type>VkDisplayPlaneAlphaFlagBitsKHR</type>   <name>alphaMode</name><comment>What type of alpha blending to use.  Must be a bit from vkGetDisplayPlanePropertiesKHR::supportedAlpha.</comment></member>
+            <member><type>VkDisplayPlaneAlphaFlagsKHR</type>   <name>alphaMode</name><comment>What type of alpha blending to use.  Must be a bit from vkGetDisplayPlanePropertiesKHR::supportedAlpha.</comment></member>
             <member><type>VkExtent2D</type>                       <name>imageExtent</name><comment>size of the images to use with this surface</comment></member>
         </type>
         <type category="struct" name="VkDisplayPresentInfoKHR" structextends="VkPresentInfoKHR">
@@ -1500,7 +1500,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member><type>VkExtent2D</type>                       <name>maxImageExtent</name><comment>Supported maximum image width and height for the surface</comment></member>
             <member><type>uint32_t</type>                         <name>maxImageArrayLayers</name><comment>Supported maximum number of image layers for the surface</comment></member>
             <member optional="true"><type>VkSurfaceTransformFlagsKHR</type>       <name>supportedTransforms</name><comment>1 or more bits representing the transforms supported</comment></member>
-            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>currentTransform</name><comment>The surface's current transform relative to the device's natural orientation</comment></member>
+            <member><type>VkSurfaceTransformFlagsKHR</type>    <name>currentTransform</name><comment>The surface's current transform relative to the device's natural orientation</comment></member>
             <member optional="true"><type>VkCompositeAlphaFlagsKHR</type>         <name>supportedCompositeAlpha</name><comment>1 or more bits representing the alpha compositing modes supported</comment></member>
             <member optional="true"><type>VkImageUsageFlags</type>                <name>supportedUsageFlags</name><comment>Supported image usage flags for the surface</comment></member>
         </type>
@@ -1569,8 +1569,8 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member><type>VkSharingMode</type>                    <name>imageSharingMode</name><comment>Sharing mode used for the presentation images</comment></member>
             <member optional="true"><type>uint32_t</type>         <name>queueFamilyIndexCount</name><comment>Number of queue families having access to the images in case of concurrent sharing mode</comment></member>
             <member noautovalidity="true" len="queueFamilyIndexCount">const <type>uint32_t</type>*                  <name>pQueueFamilyIndices</name><comment>Array of queue family indices having access to the images in case of concurrent sharing mode</comment></member>
-            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>preTransform</name><comment>The transform, relative to the device's natural orientation, applied to the image content prior to presentation</comment></member>
-            <member><type>VkCompositeAlphaFlagBitsKHR</type>      <name>compositeAlpha</name><comment>The alpha blending mode used when compositing this surface with other surfaces in the window system</comment></member>
+            <member><type>VkSurfaceTransformFlagsKHR</type>    <name>preTransform</name><comment>The transform, relative to the device's natural orientation, applied to the image content prior to presentation</comment></member>
+            <member><type>VkCompositeAlphaFlagsKHR</type>      <name>compositeAlpha</name><comment>The alpha blending mode used when compositing this surface with other surfaces in the window system</comment></member>
             <member><type>VkPresentModeKHR</type>                 <name>presentMode</name><comment>Which presentation mode to use for presents on this swap chain</comment></member>
             <member><type>VkBool32</type>                         <name>clipped</name><comment>Specifies whether presentable images may be affected by window clip regions</comment></member>
             <member optional="true"><type>VkSwapchainKHR</type>   <name>oldSwapchain</name><comment>Existing swap chain to replace, if any</comment></member>
@@ -1829,7 +1829,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkFormat</type>                         <name>format</name></member>
             <member><type>VkImageType</type>                      <name>type</name></member>
-            <member><type>VkSampleCountFlagBits</type>            <name>samples</name></member>
+            <member><type>VkSampleCountFlags</type>            <name>samples</name></member>
             <member><type>VkImageUsageFlags</type>                <name>usage</name></member>
             <member><type>VkImageTiling</type>                    <name>tiling</name></member>
         </type>
@@ -1867,7 +1867,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
         <type category="struct" name="VkPhysicalDeviceExternalImageFormatInfoKHR"  structextends="VkPhysicalDeviceImageFormatInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member noautovalidity="true">const <type>void</type>*                      <name>pNext</name></member>
-            <member optional="true"><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member optional="true"><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkExternalImageFormatPropertiesKHR" returnedonly="true" structextends="VkImageFormatProperties2KHR">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -1879,7 +1879,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkBufferCreateFlags</type> <name>flags</name></member>
             <member><type>VkBufferUsageFlags</type>               <name>usage</name></member>
-            <member><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkExternalBufferPropertiesKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -1913,7 +1913,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
         <type category="struct" name="VkImportMemoryWin32HandleInfoKHR" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
-            <member optional="true"><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member optional="true"><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleType</name></member>
             <member optional="true"><type>HANDLE</type>           <name>handle</name></member>
             <member optional="true"><type>LPCWSTR</type>          <name>name</name></member>
         </type>
@@ -1933,12 +1933,12 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member values="VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
-            <member><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkImportMemoryFdInfoKHR" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
-            <member optional="true"><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member optional="true"><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleType</name></member>
             <member><type>int</type>                              <name>fd</name></member>
         </type>
         <type category="struct" name="VkMemoryFdPropertiesKHR" returnedonly="true">
@@ -1950,7 +1950,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member values="VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
-            <member><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkWin32KeyedMutexAcquireReleaseInfoKHR" structextends="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -1966,7 +1966,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
         <type category="struct" name="VkPhysicalDeviceExternalSemaphoreInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
-            <member><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagsKHR</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkExternalSemaphorePropertiesKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -1985,7 +1985,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member externsync="true"><type>VkSemaphore</type>    <name>semaphore</name></member>
             <member optional="true"><type>VkSemaphoreImportFlagsKHR</type> <name>flags</name></member>
-            <member optional="true"><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member optional="true"><type>VkExternalSemaphoreHandleTypeFlagsKHR</type> <name>handleType</name></member>
             <member optional="true"><type>HANDLE</type>           <name>handle</name></member>
             <member optional="true"><type>LPCWSTR</type>          <name>name</name></member>
         </type>
@@ -2008,26 +2008,26 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkSemaphore</type>                      <name>semaphore</name></member>
-            <member><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagsKHR</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkImportSemaphoreFdInfoKHR">
             <member values="VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member externsync="true"><type>VkSemaphore</type>    <name>semaphore</name></member>
             <member optional="true"><type>VkSemaphoreImportFlagsKHR</type> <name>flags</name></member>
-            <member><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagsKHR</type> <name>handleType</name></member>
             <member><type>int</type>                              <name>fd</name></member>
         </type>
         <type category="struct" name="VkSemaphoreGetFdInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkSemaphore</type>                      <name>semaphore</name></member>
-            <member><type>VkExternalSemaphoreHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagsKHR</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExternalFenceInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
-            <member><type>VkExternalFenceHandleTypeFlagBitsKHR</type> <name>handleType</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagsKHR</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkExternalFencePropertiesKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -2046,7 +2046,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member>const <type>void</type>*                                        <name>pNext</name></member>
             <member externsync="true"><type>VkFence</type>                          <name>fence</name></member>
             <member optional="true"><type>VkFenceImportFlagsKHR</type>              <name>flags</name></member>
-            <member optional="true"><type>VkExternalFenceHandleTypeFlagBitsKHR</type>  <name>handleType</name></member>
+            <member optional="true"><type>VkExternalFenceHandleTypeFlagsKHR</type>  <name>handleType</name></member>
             <member optional="true"><type>HANDLE</type>                             <name>handle</name></member>
             <member optional="true"><type>LPCWSTR</type>                            <name>name</name></member>
         </type>
@@ -2061,21 +2061,21 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member values="VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                            <name>pNext</name></member>
             <member><type>VkFence</type>                                <name>fence</name></member>
-            <member><type>VkExternalFenceHandleTypeFlagBitsKHR</type>   <name>handleType</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagsKHR</type>   <name>handleType</name></member>
         </type>
         <type category="struct" name="VkImportFenceFdInfoKHR">
             <member values="VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                            <name>pNext</name></member>
             <member externsync="true"><type>VkFence</type>              <name>fence</name></member>
             <member optional="true"><type>VkFenceImportFlagsKHR</type>  <name>flags</name></member>
-            <member><type>VkExternalFenceHandleTypeFlagBitsKHR</type>   <name>handleType</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagsKHR</type>   <name>handleType</name></member>
             <member><type>int</type>                                    <name>fd</name></member>
         </type>
         <type category="struct" name="VkFenceGetFdInfoKHR">
             <member values="VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                            <name>pNext</name></member>
             <member><type>VkFence</type>                                <name>fence</name></member>
-            <member><type>VkExternalFenceHandleTypeFlagBitsKHR</type>   <name>handleType</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagsKHR</type>   <name>handleType</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewFeaturesKHX" structextends="VkPhysicalDeviceFeatures2KHR,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHX"><type>VkStructureType</type> <name>sType</name></member>
@@ -2110,7 +2110,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member><type>VkExtent2D</type>                       <name>maxImageExtent</name><comment>Supported maximum image width and height for the surface</comment></member>
             <member><type>uint32_t</type>                         <name>maxImageArrayLayers</name><comment>Supported maximum number of image layers for the surface</comment></member>
             <member optional="true"><type>VkSurfaceTransformFlagsKHR</type>       <name>supportedTransforms</name><comment>1 or more bits representing the transforms supported</comment></member>
-            <member><type>VkSurfaceTransformFlagBitsKHR</type>    <name>currentTransform</name><comment>The surface's current transform relative to the device's natural orientation</comment></member>
+            <member><type>VkSurfaceTransformFlagsKHR</type>    <name>currentTransform</name><comment>The surface's current transform relative to the device's natural orientation</comment></member>
             <member optional="true"><type>VkCompositeAlphaFlagsKHR</type>         <name>supportedCompositeAlpha</name><comment>1 or more bits representing the alpha compositing modes supported</comment></member>
             <member optional="true"><type>VkImageUsageFlags</type>                <name>supportedUsageFlags</name><comment>Supported image usage flags for the surface</comment></member>
             <member optional="true"><type>VkSurfaceCounterFlagsEXT</type> <name>supportedSurfaceCounters</name></member>
@@ -2227,7 +2227,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member noautovalidity="true">const <type>void</type>*  <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>swapchainCount</name></member>
             <member len="swapchainCount">const <type>uint32_t</type>* <name>pDeviceMasks</name></member>
-            <member><type>VkDeviceGroupPresentModeFlagBitsKHX</type> <name>mode</name></member>
+            <member><type>VkDeviceGroupPresentModeFlagsKHX</type> <name>mode</name></member>
         </type>
         <type category="struct" name="VkDeviceGroupDeviceCreateInfoKHX" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO_KHX"><type>VkStructureType</type> <name>sType</name></member>
@@ -3681,7 +3681,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
             <param><type>VkFormat</type> <name>format</name></param>
             <param><type>VkImageType</type> <name>type</name></param>
-            <param><type>VkSampleCountFlagBits</type> <name>samples</name></param>
+            <param><type>VkSampleCountFlags</type> <name>samples</name></param>
             <param><type>VkImageUsageFlags</type> <name>usage</name></param>
             <param><type>VkImageTiling</type> <name>tiling</name></param>
             <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
@@ -4374,7 +4374,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" pipeline="transfer">
             <proto><type>void</type> <name>vkCmdWriteTimestamp</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
-            <param><type>VkPipelineStageFlagBits</type> <name>pipelineStage</name></param>
+            <param><type>VkPipelineStageFlags</type> <name>pipelineStage</name></param>
             <param><type>VkQueryPool</type> <name>queryPool</name></param>
             <param><type>uint32_t</type> <name>query</name></param>
         </command>
@@ -4836,7 +4836,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
             <proto><type>VkResult</type> <name>vkGetMemoryWin32HandlePropertiesKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></param>
+            <param><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleType</name></param>
             <param><type>HANDLE</type> <name>handle</name></param>
             <param><type>VkMemoryWin32HandlePropertiesKHR</type>* <name>pMemoryWin32HandleProperties</name></param>
         </command>
@@ -4849,7 +4849,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
             <proto><type>VkResult</type> <name>vkGetMemoryFdPropertiesKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param><type>VkExternalMemoryHandleTypeFlagBitsKHR</type> <name>handleType</name></param>
+            <param><type>VkExternalMemoryHandleTypeFlagsKHR</type> <name>handleType</name></param>
             <param><type>int</type> <name>fd</name></param>
             <param><type>VkMemoryFdPropertiesKHR</type>* <name>pMemoryFdProperties</name></param>
         </command>
@@ -4952,7 +4952,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <proto><type>VkResult</type> <name>vkGetSwapchainCounterEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkSwapchainKHR</type> <name>swapchain</name></param>
-            <param><type>VkSurfaceCounterFlagBitsEXT</type> <name>counter</name></param>
+            <param><type>VkSurfaceCounterFlagsEXT</type> <name>counter</name></param>
             <param><type>uint64_t</type>* <name>pCounterValue</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR">


### PR DESCRIPTION
Building an API binding for Rust through generation rather than manually typing made me aware of some irregularities in the use of the FlagBits rather than the corresponding Flags types for structure members and command arguments.

Assuming I understand the differentiation between FlagBits and Flags types correctly, as in the FlagBits types are only the enumerations of the available bits and the Flags types are the types containing the actually selected bits.
That's at least how i understand and have map it while generating the Rust types. The FlagBits are mapped to enumerations (with a u32 representation) and the Flags are mapped to the u32 type.