### PR TITLE
Fix VkImageSubresource* VUs

### DIFF
--- a/doc/specs/vulkan/chapters/clears.txt
+++ b/doc/specs/vulkan/chapters/clears.txt
@@ -88,24 +88,21 @@ endif::VK_KHR_shared_presentable_image[]
     elements of the pname:pRanges array must: each be less than the
     pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
     was created
-  * If the slink:VkImageSubresourceRange::pname:levelCount member of any
-    element of the pname:pRanges array is not ename:VK_REMAINING_MIP_LEVELS,
-    [eq]#slink:VkImageSubresourceRange::pname:baseMipLevel {plus}
-    slink:VkImageSubresourceRange::pname:levelCount# for that element of the
-    pname:pRanges array must: be less than or equal to the pname:mipLevels
-    specified in slink:VkImageCreateInfo when pname:image was created
+  * For each slink:VkImageSubresourceRange element of pname:pRanges, if
+    the pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
   * [[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]
     The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the
     elements of the pname:pRanges array must: each be less than the
     pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
     was created
-  * If the slink:VkImageSubresourceRange::pname:layerCount member of any
-    element of the pname:pRanges array is not
-    ename:VK_REMAINING_ARRAY_LAYERS,
-    [eq]#slink:VkImageSubresourceRange::pname:baseArrayLayer {plus}
-    slink:VkImageSubresourceRange::pname:layerCount# for that element of the
-    pname:pRanges array must: be less than or equal to the pname:arrayLayers
-    specified in slink:VkImageCreateInfo when pname:image was created
+  * For each slink:VkImageSubresourceRange element of pname:pRanges, if
+    the pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
   * [[VUID-vkCmdClearColorImage-image-00007]]
     pname:image must: not have a compressed or depth/stencil format
 ****
@@ -173,24 +170,21 @@ endif::VK_KHR_maintenance1[]
     elements of the pname:pRanges array must: each be less than the
     pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
     was created
-  * If the slink:VkImageSubresourceRange::pname:levelCount member of any
-    element of the pname:pRanges array is not ename:VK_REMAINING_MIP_LEVELS,
-    [eq]#slink:VkImageSubresourceRange::pname:baseMipLevel {plus}
-    slink:VkImageSubresourceRange::pname:levelCount# for that element of the
-    pname:pRanges array must: be less than or equal to the pname:mipLevels
-    specified in slink:VkImageCreateInfo when pname:image was created
+  * For each slink:VkImageSubresourceRange element of pname:pRanges, if
+    the pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
   * [[VUID-vkCmdClearDepthStencilImage-baseArrayLayer-01476]]
     The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the
     elements of the pname:pRanges array must: each be less than the
     pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
     was created
-  * If the slink:VkImageSubresourceRange::pname:layerCount member of any
-    element of the pname:pRanges array is not
-    ename:VK_REMAINING_ARRAY_LAYERS,
-    [eq]#slink:VkImageSubresourceRange::pname:baseArrayLayer {plus}
-    slink:VkImageSubresourceRange::pname:layerCount# for that element of the
-    pname:pRanges array must: be less than or equal to the pname:arrayLayers
-    specified in slink:VkImageCreateInfo when pname:image was created
+  * For each slink:VkImageSubresourceRange element of pname:pRanges, if
+    the pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
   * [[VUID-vkCmdClearDepthStencilImage-image-00014]]
     pname:image must: have a depth/stencil format
 ****

--- a/doc/specs/vulkan/chapters/clears.txt
+++ b/doc/specs/vulkan/chapters/clears.txt
@@ -88,10 +88,8 @@ endif::VK_KHR_shared_presentable_image[]
     elements of the pname:pRanges array must: each be less than the
     pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
     was created
-  * [[VUID-vkCmdClearColorImage-levelCount-01471]]
-    If the slink:VkImageSubresourceRange::pname:levelCount member of any
+  * If the slink:VkImageSubresourceRange::pname:levelCount member of any
     element of the pname:pRanges array is not ename:VK_REMAINING_MIP_LEVELS,
-    it must: be non-zero and
     [eq]#slink:VkImageSubresourceRange::pname:baseMipLevel {plus}
     slink:VkImageSubresourceRange::pname:levelCount# for that element of the
     pname:pRanges array must: be less than or equal to the pname:mipLevels
@@ -101,10 +99,9 @@ endif::VK_KHR_shared_presentable_image[]
     elements of the pname:pRanges array must: each be less than the
     pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
     was created
-  * [[VUID-vkCmdClearColorImage-layerCount-01473]]
-    If the slink:VkImageSubresourceRange::pname:layerCount member of any
+  * If the slink:VkImageSubresourceRange::pname:layerCount member of any
     element of the pname:pRanges array is not
-    ename:VK_REMAINING_ARRAY_LAYERS, it must: be non-zero and
+    ename:VK_REMAINING_ARRAY_LAYERS,
     [eq]#slink:VkImageSubresourceRange::pname:baseArrayLayer {plus}
     slink:VkImageSubresourceRange::pname:layerCount# for that element of the
     pname:pRanges array must: be less than or equal to the pname:arrayLayers
@@ -176,10 +173,8 @@ endif::VK_KHR_maintenance1[]
     elements of the pname:pRanges array must: each be less than the
     pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
     was created
-  * [[VUID-vkCmdClearDepthStencilImage-levelCount-01475]]
-    If the slink:VkImageSubresourceRange::pname:levelCount member of any
+  * If the slink:VkImageSubresourceRange::pname:levelCount member of any
     element of the pname:pRanges array is not ename:VK_REMAINING_MIP_LEVELS,
-    it must: be non-zero and
     [eq]#slink:VkImageSubresourceRange::pname:baseMipLevel {plus}
     slink:VkImageSubresourceRange::pname:levelCount# for that element of the
     pname:pRanges array must: be less than or equal to the pname:mipLevels
@@ -189,10 +184,9 @@ endif::VK_KHR_maintenance1[]
     elements of the pname:pRanges array must: each be less than the
     pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
     was created
-  * [[VUID-vkCmdClearDepthStencilImage-layerCount-01477]]
-    If the slink:VkImageSubresourceRange::pname:layerCount member of any
+  * If the slink:VkImageSubresourceRange::pname:layerCount member of any
     element of the pname:pRanges array is not
-    ename:VK_REMAINING_ARRAY_LAYERS, it must: be non-zero and
+    ename:VK_REMAINING_ARRAY_LAYERS,
     [eq]#slink:VkImageSubresourceRange::pname:baseArrayLayer {plus}
     slink:VkImageSubresourceRange::pname:layerCount# for that element of the
     pname:pRanges array must: be less than or equal to the pname:arrayLayers

--- a/doc/specs/vulkan/chapters/copies.txt
+++ b/doc/specs/vulkan/chapters/copies.txt
@@ -436,24 +436,20 @@ ifdef::VK_KHR_sampler_ycbcr_conversion[]
 endif::VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-vkCmdCopyImage-srcImage-00136]]
     The sample count of pname:srcImage and pname:dstImage must: match
-  * The slink:VkImageCopy::pname:srcSubresource::pname:mipLevel members of
-    the elements of the pname:pRegions array must: each be less than the
-    pname:mipLevels specified in slink:VkImageCreateInfo when pname:srcImage
-    was created
-  * The slink:VkImageCopy::pname:dstSubresource::pname:mipLevel members of
-    the elements of the pname:pRegions array must: each be less than the
-    pname:mipLevels specified in slink:VkImageCreateInfo when pname:dstImage
-    was created
-  * The slink:VkImageCopy::pname:srcSubresource members of the elements of
-    the pname:pRegions array must: each have
-    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:srcImage was created
-  * The slink:VkImageCopy::pname:dstSubresource members of the elements of
-    the pname:pRegions array must: each have
-    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:dstImage was created
+  * The pname:srcSubresource.mipLevel member of each element of
+    pname:pRegions must: be less than the pname:mipLevels specified in
+    slink:VkImageCreateInfo when pname:srcImage was created
+  * The pname:dstSubresource.mipLevel member of each element of
+    pname:pRegions must: be less than the pname:mipLevels specified in
+    slink:VkImageCreateInfo when pname:dstImage was created
+  * The [eq]#pname:srcSubresource.baseArrayLayer {plus}
+    pname:srcSubresource.layerCount# of each element of pname:pRegions must:
+    be less than or equal to the pname:arrayLayers specified in
+    slink:VkImageCreateInfo when pname:srcImage was created
+  * The [eq]#pname:dstSubresource.baseArrayLayer {plus}
+    pname:dstSubresource.layerCount# of each element of pname:pRegions must:
+    be less than or equal to the pname:arrayLayers specified in
+    slink:VkImageCreateInfo when pname:dstImage was created
 ****
 
 include::../validity/protos/vkCmdCopyImage.txt[]
@@ -830,15 +826,13 @@ ifdef::VK_KHR_shared_presentable_image[]
     ename:VK_IMAGE_LAYOUT_GENERAL, or
     ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
 endif::VK_KHR_shared_presentable_image[]
-  * The slink:VkBufferImageCopy::pname:imageSubresource::pname:mipLevel
-    members of the elements of the pname:pRegions array must: each be less
-    than the pname:mipLevels specified in slink:VkImageCreateInfo when
-    pname:dstImage was created
-  * The slink:VkBufferImageCopy::pname:imageSubresource members of the elements of
-    the pname:pRegions array must: each have
-    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:dstImage was created
+  * The pname:imageSubresource.mipLevel member of each element of
+    pname:pRegions must: be less than the pname:mipLevels specified in
+    slink:VkImageCreateInfo when pname:dstImage was created
+  * The [eq]#pname:imageSubresource.baseArrayLayer {plus}
+    pname:imageSubresource.layerCount# of each element of pname:pRegions
+    must: be less than or equal to the pname:arrayLayers specified in
+    slink:VkImageCreateInfo when pname:dstImage was created
 ****
 
 include::../validity/protos/vkCmdCopyBufferToImage.txt[]
@@ -940,15 +934,13 @@ endif::VK_KHR_shared_presentable_image[]
   * [[VUID-vkCmdCopyImageToBuffer-dstBuffer-00192]]
     If pname:dstBuffer is non-sparse then it must: be bound completely and
     contiguously to a single sname:VkDeviceMemory object
-  * The slink:VkBufferImageCopy::pname:imageSubresource::pname:mipLevel
-    members of the elements of the pname:pRegions array must: each be less
-    than the pname:mipLevels specified in slink:VkImageCreateInfo when
-    pname:srcImage was created
-  * The slink:VkBufferImageCopy::pname:imageSubresource members of the elements of
-    the pname:pRegions array must: each have
-    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:srcImage was created
+  * The pname:imageSubresource.mipLevel member of each element of
+    pname:pRegions must: be less than the pname:mipLevels specified in
+    slink:VkImageCreateInfo when pname:srcImage was created
+  * The [eq]#pname:imageSubresource.baseArrayLayer {plus}
+    pname:imageSubresource.layerCount# of each element of pname:pRegions
+    must: be less than or equal to the pname:arrayLayers specified in
+    slink:VkImageCreateInfo when pname:srcImage was created
 ****
 
 include::../validity/protos/vkCmdCopyImageToBuffer.txt[]
@@ -1480,24 +1472,20 @@ ifdef::VK_IMG_filter_cubic[]
     If pname:filter is ename:VK_FILTER_CUBIC_IMG, pname:srcImage must: have
     a elink:VkImageType of ename:VK_IMAGE_TYPE_3D
 endif::VK_IMG_filter_cubic[]
-  * The slink:VkImageBlit::pname:srcSubresource::pname:mipLevel members of
-    the elements of the pname:pRegions array must: each be less than the
-    pname:mipLevels specified in slink:VkImageCreateInfo when pname:srcImage
-    was created
-  * The slink:VkImageBlit::pname:dstSubresource::pname:mipLevel members of
-    the elements of the pname:pRegions array must: each be less than the
-    pname:mipLevels specified in slink:VkImageCreateInfo when pname:dstImage
-    was created
-  * The slink:VkImageBlit::pname:srcSubresource members of the elements of
-    the pname:pRegions array must: each have
-    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:srcImage was created
-  * The slink:VkImageBlit::pname:dstSubresource members of the elements of
-    the pname:pRegions array must: each have
-    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:dstImage was created
+  * The pname:srcSubresource.mipLevel member of each element of
+    pname:pRegions must: be less than the pname:mipLevels specified in
+    slink:VkImageCreateInfo when pname:srcImage was created
+  * The pname:dstSubresource.mipLevel member of each element of
+    pname:pRegions must: be less than the pname:mipLevels specified in
+    slink:VkImageCreateInfo when pname:dstImage was created
+  * The [eq]#pname:srcSubresource.baseArrayLayer {plus}
+    pname:srcSubresource.layerCount# of each element of pname:pRegions must:
+    be less than or equal to the pname:arrayLayers specified in
+    slink:VkImageCreateInfo when pname:srcImage was created
+  * The [eq]#pname:dstSubresource.baseArrayLayer {plus}
+    pname:dstSubresource.layerCount# of each element of pname:pRegions must:
+    be less than or equal to the pname:arrayLayers specified in
+    slink:VkImageCreateInfo when pname:dstImage was created
 ****
 
 include::../validity/protos/vkCmdBlitImage.txt[]
@@ -1698,24 +1686,20 @@ endif::VK_KHR_shared_presentable_image[]
   * [[VUID-vkCmdResolveImage-srcImage-01386]]
     pname:srcImage and pname:dstImage must: have been created with the same
     image format
-  * The slink:VkImageResolve::pname:srcSubresource::pname:mipLevel members of
-    the elements of the pname:pRegions array must: each be less than the
-    pname:mipLevels specified in slink:VkImageCreateInfo when pname:srcImage
-    was created
-  * The slink:VkImageResolve::pname:dstSubresource::pname:mipLevel members of
-    the elements of the pname:pRegions array must: each be less than the
-    pname:mipLevels specified in slink:VkImageCreateInfo when pname:dstImage
-    was created
-  * The slink:VkImageResolve::pname:srcSubresource members of the elements of
-    the pname:pRegions array must: each have
-    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:srcImage was created
-  * The slink:VkImageResolve::pname:dstSubresource members of the elements of
-    the pname:pRegions array must: each have
-    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:dstImage was created
+  * The pname:srcSubresource.mipLevel member of each element of
+    pname:pRegions must: be less than the pname:mipLevels specified in
+    slink:VkImageCreateInfo when pname:srcImage was created
+  * The pname:dstSubresource.mipLevel member of each element of
+    pname:pRegions must: be less than the pname:mipLevels specified in
+    slink:VkImageCreateInfo when pname:dstImage was created
+  * The [eq]#pname:srcSubresource.baseArrayLayer {plus}
+    pname:srcSubresource.layerCount# of each element of pname:pRegions must:
+    be less than or equal to the pname:arrayLayers specified in
+    slink:VkImageCreateInfo when pname:srcImage was created
+  * The [eq]#pname:dstSubresource.baseArrayLayer {plus}
+    pname:dstSubresource.layerCount# of each element of pname:pRegions must:
+    be less than or equal to the pname:arrayLayers specified in
+    slink:VkImageCreateInfo when pname:dstImage was created
 ****
 
 include::../validity/protos/vkCmdResolveImage.txt[]

--- a/doc/specs/vulkan/chapters/copies.txt
+++ b/doc/specs/vulkan/chapters/copies.txt
@@ -436,6 +436,24 @@ ifdef::VK_KHR_sampler_ycbcr_conversion[]
 endif::VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-vkCmdCopyImage-srcImage-00136]]
     The sample count of pname:srcImage and pname:dstImage must: match
+  * The slink:VkImageCopy::pname:srcSubresource::pname:mipLevel members of
+    the elements of the pname:pRegions array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:srcImage
+    was created
+  * The slink:VkImageCopy::pname:dstSubresource::pname:mipLevel members of
+    the elements of the pname:pRegions array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:dstImage
+    was created
+  * The slink:VkImageCopy::pname:srcSubresource members of the elements of
+    the pname:pRegions array must: each have
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:srcImage was created
+  * The slink:VkImageCopy::pname:dstSubresource members of the elements of
+    the pname:pRegions array must: each have
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:dstImage was created
 ****
 
 include::../validity/protos/vkCmdCopyImage.txt[]
@@ -590,11 +608,6 @@ endif::VK_KHR_maintenance1[]
     If the calling command's pname:srcImage is of type
     ename:VK_IMAGE_TYPE_1D or ename:VK_IMAGE_TYPE_2D, then pname:srcOffset.z
     must: be `0` and pname:extent.depth must: be `1`.
-  * [[VUID-VkImageCopy-srcSubresource-00149]]
-    pname:srcSubresource.baseArrayLayer must: be less than and
-    [eq]#(pname:srcSubresource.layerCount {plus}
-    pname:srcSubresource.baseArrayLayer)# must: be less than or equal to the
-    number of layers in the source image
   * [[VUID-VkImageCopy-dstOffset-00150]]
     pname:dstOffset.x and [eq]#(pname:extent.width {plus}
     pname:dstOffset.x)# must: both be greater than or equal to `0` and less
@@ -615,11 +628,6 @@ endif::VK_KHR_maintenance1[]
     If the calling command's pname:dstImage is of type
     ename:VK_IMAGE_TYPE_1D or ename:VK_IMAGE_TYPE_2D, then pname:dstOffset.z
     must: be `0` and pname:extent.depth must: be `1`.
-  * [[VUID-VkImageCopy-dstSubresource-00155]]
-    pname:dstSubresource.baseArrayLayer must: be less than and
-    [eq]#(pname:dstSubresource.layerCount {plus}
-    pname:dstSubresource.baseArrayLayer)# must: be less than or equal to the
-    number of layers in the destination image
   * [[VUID-VkImageCopy-srcOffset-00157]]
     If the calling command's pname:srcImage is a compressed image,
 ifdef::VK_KHR_sampler_ycbcr_conversion[]
@@ -714,13 +722,7 @@ include::../api/structs/VkImageSubresourceLayers.txt[]
     ename:VK_IMAGE_ASPECT_STENCIL_BIT
   * [[VUID-VkImageSubresourceLayers-aspectMask-00168]]
     pname:aspectMask must: not contain ename:VK_IMAGE_ASPECT_METADATA_BIT
-  * [[VUID-VkImageSubresourceLayers-mipLevel-00169]]
-    pname:mipLevel must: be less than the pname:mipLevels specified in
-    slink:VkImageCreateInfo when the image was created
-  * [[VUID-VkImageSubresourceLayers-baseArrayLayer-00170]]
-    [eq]#(pname:baseArrayLayer {plus} pname:layerCount)# must: be less than
-    or equal to the pname:arrayLayers specified in slink:VkImageCreateInfo
-    when the image was created
+  * pname:layerCount must: be greater than 0
 ****
 
 include::../validity/structs/VkImageSubresourceLayers.txt[]
@@ -828,6 +830,15 @@ ifdef::VK_KHR_shared_presentable_image[]
     ename:VK_IMAGE_LAYOUT_GENERAL, or
     ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
 endif::VK_KHR_shared_presentable_image[]
+  * The slink:VkBufferImageCopy::pname:imageSubresource::pname:mipLevel
+    members of the elements of the pname:pRegions array must: each be less
+    than the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:dstImage was created
+  * The slink:VkBufferImageCopy::pname:imageSubresource members of the elements of
+    the pname:pRegions array must: each have
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:dstImage was created
 ****
 
 include::../validity/protos/vkCmdCopyBufferToImage.txt[]
@@ -929,6 +940,15 @@ endif::VK_KHR_shared_presentable_image[]
   * [[VUID-vkCmdCopyImageToBuffer-dstBuffer-00192]]
     If pname:dstBuffer is non-sparse then it must: be bound completely and
     contiguously to a single sname:VkDeviceMemory object
+  * The slink:VkBufferImageCopy::pname:imageSubresource::pname:mipLevel
+    members of the elements of the pname:pRegions array must: each be less
+    than the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:srcImage was created
+  * The slink:VkBufferImageCopy::pname:imageSubresource members of the elements of
+    the pname:pRegions array must: each have
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:srcImage was created
 ****
 
 include::../validity/protos/vkCmdCopyImageToBuffer.txt[]
@@ -1460,6 +1480,24 @@ ifdef::VK_IMG_filter_cubic[]
     If pname:filter is ename:VK_FILTER_CUBIC_IMG, pname:srcImage must: have
     a elink:VkImageType of ename:VK_IMAGE_TYPE_3D
 endif::VK_IMG_filter_cubic[]
+  * The slink:VkImageBlit::pname:srcSubresource::pname:mipLevel members of
+    the elements of the pname:pRegions array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:srcImage
+    was created
+  * The slink:VkImageBlit::pname:dstSubresource::pname:mipLevel members of
+    the elements of the pname:pRegions array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:dstImage
+    was created
+  * The slink:VkImageBlit::pname:srcSubresource members of the elements of
+    the pname:pRegions array must: each have
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:srcImage was created
+  * The slink:VkImageBlit::pname:dstSubresource members of the elements of
+    the pname:pRegions array must: each have
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:dstImage was created
 ****
 
 include::../validity/protos/vkCmdBlitImage.txt[]
@@ -1660,6 +1698,24 @@ endif::VK_KHR_shared_presentable_image[]
   * [[VUID-vkCmdResolveImage-srcImage-01386]]
     pname:srcImage and pname:dstImage must: have been created with the same
     image format
+  * The slink:VkImageResolve::pname:srcSubresource::pname:mipLevel members of
+    the elements of the pname:pRegions array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:srcImage
+    was created
+  * The slink:VkImageResolve::pname:dstSubresource::pname:mipLevel members of
+    the elements of the pname:pRegions array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:dstImage
+    was created
+  * The slink:VkImageResolve::pname:srcSubresource members of the elements of
+    the pname:pRegions array must: each have
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:srcImage was created
+  * The slink:VkImageResolve::pname:dstSubresource members of the elements of
+    the pname:pRegions array must: each have
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# less than or equal to
+    the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:dstImage was created
 ****
 
 include::../validity/protos/vkCmdResolveImage.txt[]

--- a/doc/specs/vulkan/chapters/resources.txt
+++ b/doc/specs/vulkan/chapters/resources.txt
@@ -2139,26 +2139,26 @@ endif::VK_KHR_maintenance1[]
     by fname:vkGetPhysicalDeviceFormatProperties with the same value of
     pname:format
   * [[VUID-VkImageViewCreateInfo-subresourceRange-01478]]
-    pname:subresourceRange::pname:baseMipLevel must: be less than the
+    pname:subresourceRange.baseMipLevel must: be less than the
     pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
     was created
-  * If pname:subresourceRange::pname:levelCount is not
+  * If pname:subresourceRange.levelCount is not
     ename:VK_REMAINING_MIP_LEVELS,
-    [eq]#pname:subresourceRange::pname:baseMipLevel
-    {plus} pname:subresourceRange::pname:levelCount# must: be less than or
-    equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
-    pname:image was created
+    [eq]#pname:subresourceRange.baseMipLevel {plus}
+    pname:subresourceRange.levelCount# must: be less than or equal to the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
 ifndef::VK_KHR_maintenance1[]
   * [[VUID-VkImageViewCreateInfo-subresourceRange-01480]]
-    pname:subresourceRange::pname:baseArrayLayer must: be less than the
+    pname:subresourceRange.baseArrayLayer must: be less than the
     pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
     was created
-  * If pname:subresourceRange::pname:layerCount is not
+  * If pname:subresourceRange.layerCount is not
     ename:VK_REMAINING_ARRAY_LAYERS,
-    [eq]#pname:subresourceRange::pname:baseArrayLayer {plus}
-    pname:subresourceRange::pname:layerCount# must: be less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:image was created
+    [eq]#pname:subresourceRange.baseArrayLayer {plus}
+    pname:subresourceRange.layerCount# must: be less than or equal to the
+    pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
+    was created
 endif::VK_KHR_maintenance1[]
 ifdef::VK_KHR_maintenance1[]
   * [[VUID-VkImageViewCreateInfo-image-01482]]
@@ -2418,9 +2418,9 @@ endif::VK_KHR_sampler_ycbcr_conversion[]
 .Valid Usage
 ****
   * If pname:levelCount is not ename:VK_REMAINING_MIP_LEVELS, it must:
-    be greater than 0
+    be greater than `0`
   * If pname:layerCount is not ename:VK_REMAINING_ARRAY_LAYERS, it must:
-    be greater than 0
+    be greater than `0`
   * [[VUID-VkImageSubresourceRange-aspectMask-01670]]
     If pname:aspectMask includes ename:VK_IMAGE_ASPECT_COLOR_BIT, then it
     must: not include any of ename:VK_IMAGE_ASPECT_PLANE_0_BIT_KHR,

--- a/doc/specs/vulkan/chapters/resources.txt
+++ b/doc/specs/vulkan/chapters/resources.txt
@@ -1343,6 +1343,12 @@ image.
   * [[VUID-vkGetImageSubresourceLayout-aspectMask-00997]]
     The pname:aspectMask member of pname:pSubresource must: only have a
     single bit set
+  * The pname:mipLevel member of pname:pSubresource must: be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * The pname:arrayLayer member of pname:pSubresource must: be less than the
+    pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
+    was created
 ifdef::VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-vkGetImageSubresourceLayout-format-01581]]
     If the pname:format of pname:image is a
@@ -1374,16 +1380,6 @@ include::../api/structs/VkImageSubresource.txt[]
     _aspect_.
   * pname:mipLevel selects the mipmap level.
   * pname:arrayLayer selects the array layer.
-
-.Valid Usage
-****
-  * [[VUID-VkImageSubresource-mipLevel-00998]]
-    pname:mipLevel must: be less than the pname:mipLevels specified in
-    slink:VkImageCreateInfo when the image was created
-  * [[VUID-VkImageSubresource-arrayLayer-00999]]
-    pname:arrayLayer must: be less than the pname:arrayLayers specified in
-    slink:VkImageCreateInfo when the image was created
-****
 
 include::../validity/structs/VkImageSubresource.txt[]
 --
@@ -2146,10 +2142,9 @@ endif::VK_KHR_maintenance1[]
     pname:subresourceRange::pname:baseMipLevel must: be less than the
     pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
     was created
-  * [[VUID-VkImageViewCreateInfo-subresourceRange-01479]]
-    If pname:subresourceRange::pname:levelCount is not
-    ename:VK_REMAINING_MIP_LEVELS, pname:subresourceRange::pname:levelCount
-    must: be non-zero and [eq]#pname:subresourceRange::pname:baseMipLevel
+  * If pname:subresourceRange::pname:levelCount is not
+    ename:VK_REMAINING_MIP_LEVELS,
+    [eq]#pname:subresourceRange::pname:baseMipLevel
     {plus} pname:subresourceRange::pname:levelCount# must: be less than or
     equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
     pname:image was created
@@ -2158,10 +2153,8 @@ ifndef::VK_KHR_maintenance1[]
     pname:subresourceRange::pname:baseArrayLayer must: be less than the
     pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
     was created
-  * [[VUID-VkImageViewCreateInfo-subresourceRange-01481]]
-    If pname:subresourceRange::pname:layerCount is not
+  * If pname:subresourceRange::pname:layerCount is not
     ename:VK_REMAINING_ARRAY_LAYERS,
-    pname:subresourceRange::pname:layerCount must: be non-zero and
     [eq]#pname:subresourceRange::pname:baseArrayLayer {plus}
     pname:subresourceRange::pname:layerCount# must: be less than or equal to
     the pname:arrayLayers specified in slink:VkImageCreateInfo when
@@ -2424,6 +2417,10 @@ endif::VK_KHR_sampler_ycbcr_conversion[]
 
 .Valid Usage
 ****
+  * If pname:levelCount is not ename:VK_REMAINING_MIP_LEVELS, it must:
+    be greater than 0
+  * If pname:layerCount is not ename:VK_REMAINING_ARRAY_LAYERS, it must:
+    be greater than 0
   * [[VUID-VkImageSubresourceRange-aspectMask-01670]]
     If pname:aspectMask includes ename:VK_IMAGE_ASPECT_COLOR_BIT, then it
     must: not include any of ename:VK_IMAGE_ASPECT_PLANE_0_BIT_KHR,

--- a/doc/specs/vulkan/chapters/sparsemem.txt
+++ b/doc/specs/vulkan/chapters/sparsemem.txt
@@ -1390,6 +1390,18 @@ include::../api/structs/VkSparseImageMemoryBindInfo.txt[]
   * pname:pBinds is a pointer to array of sname:VkSparseImageMemoryBind
     structures
 
+.Valid Usage
+****
+  * The slink:VkSparseImageMemoryBind::pname:subresource::pname:mipLevel
+    members of the elements of the pname:pBinds array must: each be less
+    than the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * The slink:VkSparseImageMemoryBind::pname:subresource::pname:arrayLayer
+    members of the elements of the pname:pBinds array must: each be less
+    than the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
+****
+
 include::../validity/structs/VkSparseImageMemoryBindInfo.txt[]
 --
 

--- a/doc/specs/vulkan/chapters/sparsemem.txt
+++ b/doc/specs/vulkan/chapters/sparsemem.txt
@@ -1392,14 +1392,12 @@ include::../api/structs/VkSparseImageMemoryBindInfo.txt[]
 
 .Valid Usage
 ****
-  * The slink:VkSparseImageMemoryBind::pname:subresource::pname:mipLevel
-    members of the elements of the pname:pBinds array must: each be less
-    than the pname:mipLevels specified in slink:VkImageCreateInfo when
-    pname:image was created
-  * The slink:VkSparseImageMemoryBind::pname:subresource::pname:arrayLayer
-    members of the elements of the pname:pBinds array must: each be less
-    than the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:image was created
+  * The pname:subresource.mipLevel member of each element of pname:pBinds
+    must: be less than the pname:mipLevels specified in
+    slink:VkImageCreateInfo when pname:image was created
+  * The pname:subresource.arrayLayer member of each element of pname:pBinds
+    must: be less than the pname:arrayLayers specified in
+    slink:VkImageCreateInfo when pname:image was created
 ****
 
 include::../validity/structs/VkSparseImageMemoryBindInfo.txt[]

--- a/doc/specs/vulkan/chapters/synchronization.txt
+++ b/doc/specs/vulkan/chapters/synchronization.txt
@@ -3785,25 +3785,25 @@ endif::VK_KHR_external_memory[]
     least one of them must: be the same as the family of the queue that will
     execute this barrier
   * [[VUID-VkImageMemoryBarrier-subresourceRange-01486]]
-    pname:subresourceRange::pname:baseMipLevel must: be less than the
+    pname:subresourceRange.baseMipLevel must: be less than the
     pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
     was created
-  * If pname:subresourceRange::pname:levelCount is not
+  * If pname:subresourceRange.levelCount is not
     ename:VK_REMAINING_MIP_LEVELS,
-    [eq]#pname:subresourceRange::pname:baseMipLevel
-    {plus} pname:subresourceRange::pname:levelCount# must: be less than or
-    equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
-    pname:image was created
+    [eq]#pname:subresourceRange.baseMipLevel {plus}
+    pname:subresourceRange.levelCount# must: be less than or equal to the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
   * [[VUID-VkImageMemoryBarrier-subresourceRange-01488]]
-    pname:subresourceRange::pname:baseArrayLayer must: be less than the
+    pname:subresourceRange.baseArrayLayer must: be less than the
     pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
     was created
-  * If pname:subresourceRange::pname:layerCount is not
+  * If pname:subresourceRange.layerCount is not
     ename:VK_REMAINING_ARRAY_LAYERS,
-    [eq]#pname:subresourceRange::pname:baseArrayLayer {plus}
-    pname:subresourceRange::pname:layerCount# must: be less than or equal to
-    the pname:arrayLayers specified in slink:VkImageCreateInfo when
-    pname:image was created
+    [eq]#pname:subresourceRange.baseArrayLayer {plus}
+    pname:subresourceRange.layerCount# must: be less than or equal to the
+    pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
+    was created
   * [[VUID-VkImageMemoryBarrier-image-01207]]
     If pname:image has a depth/stencil format with both depth and stencil
     components, then the pname:aspectMask member of pname:subresourceRange

--- a/doc/specs/vulkan/chapters/synchronization.txt
+++ b/doc/specs/vulkan/chapters/synchronization.txt
@@ -3788,10 +3788,9 @@ endif::VK_KHR_external_memory[]
     pname:subresourceRange::pname:baseMipLevel must: be less than the
     pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
     was created
-  * [[VUID-VkImageMemoryBarrier-subresourceRange-01487]]
-    If pname:subresourceRange::pname:levelCount is not
-    ename:VK_REMAINING_MIP_LEVELS, pname:subresourceRange::pname:levelCount
-    must: be non-zero and [eq]#pname:subresourceRange::pname:baseMipLevel
+  * If pname:subresourceRange::pname:levelCount is not
+    ename:VK_REMAINING_MIP_LEVELS,
+    [eq]#pname:subresourceRange::pname:baseMipLevel
     {plus} pname:subresourceRange::pname:levelCount# must: be less than or
     equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
     pname:image was created
@@ -3799,10 +3798,8 @@ endif::VK_KHR_external_memory[]
     pname:subresourceRange::pname:baseArrayLayer must: be less than the
     pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
     was created
-  * [[VUID-VkImageMemoryBarrier-subresourceRange-01489]]
-    If pname:subresourceRange::pname:layerCount is not
+  * If pname:subresourceRange::pname:layerCount is not
     ename:VK_REMAINING_ARRAY_LAYERS,
-    pname:subresourceRange::pname:layerCount must: be non-zero and
     [eq]#pname:subresourceRange::pname:baseArrayLayer {plus}
     pname:subresourceRange::pname:layerCount# must: be less than or equal to
     the pname:arrayLayers specified in slink:VkImageCreateInfo when


### PR DESCRIPTION
- fixes rest of #416 (`VkImageSubresourceLayers`)
- migrate `VkImageSubresource` VUs where the state is known
- Simplify `VkImageSubresource`  (`*count` should always > 0)