### PR TITLE
Fix remaining len latexmath confusion

### DIFF
--- a/src/spec/registry.rnc
+++ b/src/spec/registry.rnc
@@ -109,7 +109,7 @@ Types = element types {
 #           things, separated by commas (one for each array indirection): another
 #           member of that struct, 'null-terminated' for a string, '1' to indicate it's
 #           just a pointer (used for nested pointers), or a latex equation (prefixed with
-#           'latex:')
+#           'latexmath:')
 #       externsync - denotes that the member should be externally synchronized
 #           when accessed by Vulkan
 #       optional - whether this value can be omitted by providing NULL (for
@@ -262,7 +262,7 @@ Commands = element commands {
 #           things, separated by commas (one for each array indirection): another
 #           member of that struct, 'null-terminated' for a string, '1' to indicate it's
 #           just a pointer (used for nested pointers), or a latex equation (prefixed with
-#           'latex:')
+#           'latexmath:')
 #     externsync - denotes that the member should be externally synchronized
 #         when accessed by Vulkan
 #     optional - whether this value can be omitted by providing NULL (for

--- a/src/spec/validitygenerator.py
+++ b/src/spec/validitygenerator.py
@@ -367,7 +367,7 @@ class ValidityOutputGenerator(OutputGenerator):
                 else:
                     asciidoc += 'pointers to arrays of '
                     # Handle equations, which are currently denoted with latex
-                    if 'latex:' in length:
+                    if 'latexmath:' in length:
                         asciidoc += length
                     else:
                         asciidoc += self.makeParameterName(length)


### PR DESCRIPTION
- fix `latex:` used in validity for remaining comma separated lengths in `len`
- correct comments in `registry.rnc` also refering to `latex:`

fixes rest of the emergent issue in #555