### PR TITLE
Fix autovalidity for output Flags pointers

### DIFF
--- a/src/spec/validitygenerator.py
+++ b/src/spec/validitygenerator.py
@@ -438,16 +438,17 @@ class ValidityOutputGenerator(OutputGenerator):
         if asciidoc != '':
             asciidoc += '\n'
 
-            # Add additional line for non-optional bitmasks
-            if self.getTypeCategory(paramtype.text) == 'bitmask':
-                if param.attrib.get('optional') is None:
-                    asciidoc += self.makeAnchor(blockname, paramname.text, 'requiredbitmask')
-                    if self.paramIsArray(param):
-                        asciidoc += 'Each element of '
-                    asciidoc += 'pname:'
-                    asciidoc += paramname.text
-                    asciidoc += ' must: not be `0`'
-                    asciidoc += '\n'
+        # Add additional line for non-optional bitmasks
+        if self.getTypeCategory(paramtype.text) == 'bitmask':
+            isMandatory = param.attrib.get('optional') is None #TODO does not really handle if someone tries something like optional="true,false"
+            if isMandatory:
+                asciidoc += self.makeAnchor(blockname, paramname.text, 'requiredbitmask')
+                if self.paramIsArray(param):
+                    asciidoc += 'Each element of '
+                asciidoc += 'pname:'
+                asciidoc += paramname.text
+                asciidoc += ' must: not be `0`'
+                asciidoc += '\n'
 
         return asciidoc
 
@@ -508,7 +509,16 @@ class ValidityOutputGenerator(OutputGenerator):
                 asciidoc += '\n'
             else:
                 if self.paramIsArray(param):
-                    asciidoc += self.makeAsciiDocLineForParameter(blockname, param, params, 'combinations of ' + self.makeEnumerationName(bitsname) + ' value')
+                    #
+                    if param.text is not None and 'const' in param.text:
+                        asciidoc += self.makeAsciiDocLineForParameter(blockname, param, params, 'combinations of ' + self.makeEnumerationName(bitsname) + ' value')
+                    else:
+                        asciidoc += self.makeAsciiDocLineForParameter(blockname, param, params, self.makeEnumerationName(paramtype.text) + ' value')
+                elif self.paramIsPointer(param):
+                    if param.text is not None and 'const' in param.text:
+                        asciidoc += self.makeAsciiDocLineForParameter(blockname, param, params, 'combination of ' + self.makeEnumerationName(bitsname) + ' values')
+                    else:
+                        asciidoc += self.makeAsciiDocLineForParameter(blockname, param, params, self.makeEnumerationName(paramtype.text) + ' value')
                 else:
                     asciidoc += self.makeAsciiDocLineForParameter(blockname, param, params, 'combination of ' + self.makeEnumerationName(bitsname) + ' values')
         elif typecategory == 'handle':

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -5151,7 +5151,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <param><type>uint32_t</type> <name>heapIndex</name></param>
             <param><type>uint32_t</type> <name>localDeviceIndex</name></param>
             <param><type>uint32_t</type> <name>remoteDeviceIndex</name></param>
-            <param><type>VkPeerMemoryFeatureFlagsKHX</type>* <name>pPeerMemoryFeatures</name></param>
+            <param optional="false,true"><type>VkPeerMemoryFeatureFlagsKHX</type>* <name>pPeerMemoryFeatures</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkBindBufferMemory2KHR</name></proto>
@@ -5179,7 +5179,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <proto><type>VkResult</type> <name>vkGetDeviceGroupSurfacePresentModesKHX</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param externsync="true"><type>VkSurfaceKHR</type> <name>surface</name></param>
-            <param><type>VkDeviceGroupPresentModeFlagsKHX</type>* <name>pModes</name></param>
+            <param optional="false,true"><type>VkDeviceGroupPresentModeFlagsKHX</type>* <name>pModes</name></param>
         </command>
         <command successcodes="VK_SUCCESS,VK_TIMEOUT,VK_NOT_READY,VK_SUBOPTIMAL_KHR" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR">
             <proto><type>VkResult</type> <name>vkAcquireNextImage2KHX</name></proto>


### PR DESCRIPTION
Previously it required to be valid combination + non-0
(for `vkGetDeviceGroupSurfacePresentModesKHX::pModes` and`vkGetDeviceGroupPeerMemoryFeaturesKHX::pPeerMemoryFeatures`)

exported from #547 (was bit offtopic there and now allows better piecemeal reviewing)
