### PR TITLE
Tweak some void* (auto)validity

### DIFF
--- a/doc/specs/vulkan/chapters/descriptorsets.txt
+++ b/doc/specs/vulkan/chapters/descriptorsets.txt
@@ -2373,6 +2373,15 @@ include::../api/protos/vkUpdateDescriptorSetWithTemplateKHR.txt[]
     of slink:VkDescriptorImageInfo, slink:VkDescriptorBufferInfo, or
     slink:VkBufferView used to write the descriptors.
 
+.Valid Usage
+****
+  * pname:pData must: be a pointer to a memory that contains one or more
+    valid instances of slink:VkDescriptorImageInfo,
+    slink:VkDescriptorBufferInfo, or slink:VkBufferView in a layout defined
+    by pname:descriptorUpdateTemplate when it was created with
+    flink:vkCreateDescriptorUpdateTemplateKHR
+****
+
 include::../validity/protos/vkUpdateDescriptorSetWithTemplateKHR.txt[]
 
 .API example
@@ -2699,6 +2708,11 @@ include::../api/protos/vkCmdPushDescriptorSetWithTemplateKHR.txt[]
     The pipelineBindPoint specified during the creation of the descriptor
     update template must: be supported by the pname:commandBuffer's parent
     sname:VkCommandPool's queue family
+  * pname:pData must: be a pointer to a memory that contains one or more
+    valid instances of slink:VkDescriptorImageInfo,
+    slink:VkDescriptorBufferInfo, or slink:VkBufferView in a layout defined
+    by pname:descriptorUpdateTemplate when it was created with
+    flink:vkCreateDescriptorUpdateTemplateKHR
 ****
 
 include::../validity/protos/vkCmdPushDescriptorSetWithTemplateKHR.txt[]

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -1527,7 +1527,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member values="VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkViSurfaceCreateFlagsNN</type>   <name>flags</name></member>
-            <member><type>void</type>*                            <name>window</name></member>
+            <member noautovalidity="true"><type>void</type>*                            <name>window</name></member>
         </type>
         <type category="struct" name="VkWaylandSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -2317,13 +2317,13 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member values="VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                                    <name>pNext</name></member>
             <member optional="true"><type>VkIOSSurfaceCreateFlagsMVK</type>     <name>flags</name></member>
-            <member>const <type>void</type>*                                    <name>pView</name></member>
+            <member noautovalidity="true">const <type>void</type>*                                    <name>pView</name></member>
         </type>
         <type category="struct" name="VkMacOSSurfaceCreateInfoMVK">
             <member values="VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                                    <name>pNext</name></member>
             <member optional="true"><type>VkMacOSSurfaceCreateFlagsMVK</type>   <name>flags</name></member>
-            <member>const <type>void</type>*                                    <name>pView</name></member>
+            <member noautovalidity="true">const <type>void</type>*                                    <name>pView</name></member>
         </type>
         <type category="struct" name="VkViewportWScalingNV">
             <member><type>float</type>          <name>xcoeff</name></member>
@@ -3796,7 +3796,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <param><type>VkDeviceSize</type> <name>offset</name></param>
             <param><type>VkDeviceSize</type> <name>size</name></param>
             <param optional="true"><type>VkMemoryMapFlags</type> <name>flags</name></param>
-            <param><type>void</type>** <name>ppData</name></param>
+            <param optional="false,true"><type>void</type>** <name>ppData</name></param>
         </command>
         <command>
             <proto><type>void</type> <name>vkUnmapMemory</name></proto>
@@ -5222,7 +5222,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <param><type>VkDevice</type> <name>device</name></param>
             <param externsync="true"><type>VkDescriptorSet</type> <name>descriptorSet</name></param>
             <param><type>VkDescriptorUpdateTemplateKHR</type> <name>descriptorUpdateTemplate</name></param>
-            <param>const <type>void</type>* <name>pData</name></param>
+            <param noautovalidity="true">const <type>void</type>* <name>pData</name></param>
         </command>
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdPushDescriptorSetWithTemplateKHR</name></proto>
@@ -5230,7 +5230,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <param><type>VkDescriptorUpdateTemplateKHR</type> <name>descriptorUpdateTemplate</name></param>
             <param><type>VkPipelineLayout</type> <name>layout</name></param>
             <param><type>uint32_t</type> <name>set</name></param>
-            <param>const <type>void</type>* <name>pData</name></param>
+            <param noautovalidity="true">const <type>void</type>* <name>pData</name></param>
         </command>
         <command>
             <proto><type>void</type> <name>vkSetHdrMetadataEXT</name></proto>


### PR DESCRIPTION
- Make implicit validity for optional `void*` mean "nothing" in the
script
- Make `optional` mean non-NULL for `void*` in the registry (unimplemented in script though; there is not much use for non-optional void*)
- Uses of `void*` that point to something should preferrably have `noautovalidity`
(adding it)
- Add missing explicit VUs of `void*` parameters
(`vkCmdPushDescriptorSetWithTemplateKHR` and
`vkUpdateDescriptorSetWithTemplateKHR`)
- Also indirectly fixes `vkMapMemory`, `VkAllocationCallbacks`,
`VkDebugReportCallbackCreateInfoEXT`, and Apple and NN surface creation
- Remove ugly text hack from script