### PR TITLE
Fix and clarify altlen

### DIFF
--- a/doc/specs/vulkan/registry.txt
+++ b/doc/specs/vulkan/registry.txt
@@ -436,6 +436,10 @@ member.
     contains a `latexmath:` equation, this attribute should
     be specified with an equivalent equation using only C builtin operators,
     C math library function names, and variables as allowed for attr:len.
+    It must be a valid C99 expression whose result is equal to attr:len for
+    all possible inputs.
+    It is a comma separated list that has size equal to only the `latexmath`
+    item count in attr:len list.
     This attribute is intended to support consumers of the XML who need to
     generate validation code from the allowed length.
   * attr:externsync - denotes that the member should be externally
@@ -814,6 +818,10 @@ members.
     contains a `latexmath:` equation, this attribute should
     be specified with an equivalent equation using only C builtin operators,
     C math library function names, and variables as allowed for attr:len.
+    It must be a valid C99 expression whose result is equal to attr:len for
+    all possible inputs.
+    It is a comma separated list that has size equal to only the `latexmath`
+    item count in attr:len list.
     This attribute is intended to support consumers of the XML who need to
     generate validation code from the allowed length.
   * attr:optional - a value of `"true"` or `"false"` determines whether this

--- a/src/spec/registry.rnc
+++ b/src/spec/registry.rnc
@@ -110,6 +110,8 @@ Types = element types {
 #           member of that struct, 'null-terminated' for a string, '1' to indicate it's
 #           just a pointer (used for nested pointers), or a latex equation (prefixed with
 #           'latexmath:')
+#       altlen - if len has latexmath equations, this contains equivalent C99
+#                expressions separated by commas.
 #       externsync - denotes that the member should be externally synchronized
 #           when accessed by Vulkan
 #       optional - whether this value can be omitted by providing NULL (for
@@ -264,6 +266,8 @@ Commands = element commands {
 #           member of that struct, 'null-terminated' for a string, '1' to indicate it's
 #           just a pointer (used for nested pointers), or a latex equation (prefixed with
 #           'latexmath:')
+#     altlen - if len has latexmath equations, this contains equivalent C99
+#              expressions separated by commas.
 #     externsync - denotes that the member should be externally synchronized
 #         when accessed by Vulkan
 #     optional - whether this value can be omitted by providing NULL (for
@@ -295,6 +299,7 @@ Command = element command {
     } ,
     element param {
         attribute len { text } ? ,
+        attribute altlen { text } ? ,
         attribute externsync { text } ? ,
         attribute optional { text } ? ,
         attribute noautovalidity { text } ? ,

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -977,7 +977,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member><type>VkSampleCountFlagBits</type>  <name>rasterizationSamples</name><comment>Number of samples used for rasterization</comment></member>
             <member><type>VkBool32</type>               <name>sampleShadingEnable</name><comment>optional (GL45)</comment></member>
             <member><type>float</type>                  <name>minSampleShading</name><comment>optional (GL45)</comment></member>
-            <member optional="true" len="latexmath:[\lceil{\mathit{rasterizationSamples} \over 32}\rceil]" altlen="ceil(rasterizationSamples / 32)">const <type>VkSampleMask</type>*    <name>pSampleMask</name><comment>Array of sampleMask words</comment></member>
+            <member optional="true" len="latexmath:[\lceil{\mathit{rasterizationSamples} \over 32}\rceil]" altlen="(rasterizationSamples + 31) / 32">const <type>VkSampleMask</type>*    <name>pSampleMask</name><comment>Array of sampleMask words</comment></member>
             <member><type>VkBool32</type>               <name>alphaToCoverageEnable</name></member>
             <member><type>VkBool32</type>               <name>alphaToOneEnable</name></member>
         </type>


### PR DESCRIPTION
1) Fix `pSampleMask `s `altlen` to have C99 semantics equivalent to len
2) Fix `registry.rnc` to also have altlen for `param`s
3) Document `altlen` in `registry.rnc` comments
4) Clarify `altlen` in schema doc that beside C syntax it also follows C semantics
5) Clarify `altlen` in schema doc in case there ever is `latexmath` in
comma separated `len`

I am impartial to nr. 4, it could as well follow "infinite precission math" semantics. 
(TBH there are only two `len` latexmath attributes. Might as well hard-code it into a parser and update it once in a decade when new latexmath appears. And these cases could even be `noautovalidity` instead of polluting xml with latex.)

But either way (or especially if it does not have C semantics) it has to be documented.