### PR TITLE
Fix wrong param name in PipelineMultisampleStateCreateInfo validity

### DIFF
--- a/doc/specs/vulkan/chapters/primsrast.txt
+++ b/doc/specs/vulkan/chapters/primsrast.txt
@@ -147,7 +147,7 @@ include::../api/structs/VkPipelineMultisampleStateCreateInfo.txt[]
 ifdef::VK_NV_framebuffer_mixed_samples[]
   * [[VUID-VkPipelineMultisampleStateCreateInfo-rasterizationSamples-01415]]
     If the subpass has any color attachments and pname:rasterizationSamples
-    is greater than the number of color samples, then pname:minSampleShading
+    is greater than the number of color samples, then pname:sampleShadingEnable
     must: be ename:VK_FALSE
 endif::VK_NV_framebuffer_mixed_samples[]
 


### PR DESCRIPTION
This is probably a small mistake in the specs, since `minSampleShading` is not a bool but a float.