### PR TITLE
Fix composite pname markup

### DIFF
--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -440,16 +440,16 @@ endif::VK_VERSION_1_1[]
 all other bits are unset
 endif::VK_VERSION_1_1,VK_KHR_device_group[]
 | pname:imageType               | ename:VK_IMAGE_TYPE_2D
-| pname:format                  | `pCreateInfo->imageFormat`
-| pname:extent                  | `{pCreateInfo->imageExtent.width, pCreateInfo->imageExtent.height, 1}`
+| pname:format                  | pname:pCreateInfo\->imageFormat
+| pname:extent                  | `{pname:pCreateInfo\->imageExtent.width, pname:pCreateInfo\->imageExtent.height, 1}`
 | pname:mipLevels               | 1
-| pname:arrayLayers             | `pCreateInfo->imageArrayLayers`
+| pname:arrayLayers             | pname:pCreateInfo\->imageArrayLayers
 | pname:samples                 | ename:VK_SAMPLE_COUNT_1_BIT
 | pname:tiling                  | ename:VK_IMAGE_TILING_OPTIMAL
-| pname:usage                   | `pCreateInfo->imageUsage`
-| pname:sharingMode             | `pCreateInfo->imageSharingMode`
-| pname:queueFamilyIndexCount   | `pCreateInfo->queueFamilyIndexCount`
-| pname:pQueueFamilyIndices     | `pCreateInfo->pQueueFamilyIndices`
+| pname:usage                   | pname:pCreateInfo\->imageUsage
+| pname:sharingMode             | pname:pCreateInfo\->imageSharingMode
+| pname:queueFamilyIndexCount   | pname:pCreateInfo\->queueFamilyIndexCount
+| pname:pQueueFamilyIndices     | pname:pCreateInfo\->pQueueFamilyIndices
 | pname:initialLayout           | ename:VK_IMAGE_LAYOUT_UNDEFINED
 |====
 

--- a/chapters/VK_NV_external_memory_capabilities/external_image_format.txt
+++ b/chapters/VK_NV_external_memory_capabilities/external_image_format.txt
@@ -25,7 +25,7 @@ include::../../api/protos/vkGetPhysicalDeviceExternalImageFormatPropertiesNV.txt
     are returned.
 
 If pname:externalHandleType is 0,
-pname:pExternalImageFormatProperties::imageFormatProperties will return the
+pname:pExternalImageFormatProperties\->imageFormatProperties will return the
 same values as a call to flink:vkGetPhysicalDeviceImageFormatProperties, and
 the other members of pname:pExternalImageFormatProperties will all be 0.
 Otherwise, they are filled in as described for

--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -169,7 +169,7 @@ include::../api/protos/vkCreateCommandPool.txt[]
 .Valid Usage
 ****
   * [[VUID-vkCreateCommandPool-queueFamilyIndex-01937]]
-    pname:pCreateInfo::pname:queueFamilyIndex must: be the index of a queue
+    pname:pCreateInfo\->queueFamilyIndex must: be the index of a queue
     family available in the logical device pname:device.
 ****
 
@@ -1023,7 +1023,7 @@ See <<devsandqueues-lost-device,Lost Device>>.
     pname:pSubmits must: have been allocated from a sname:VkCommandPool that
     was created for the same queue family pname:queue belongs to.
   * [[VUID-vkQueueSubmit-pSubmits-02207]]
-    If any element of pname:pSubmits->pname:pCommandBuffers includes a
+    If any element of pname:pSubmits\->pCommandBuffers includes a
     <<synchronization-queue-transfers-acquire, Queue Family Transfer Acquire
     Operation>>, there must: exist a previously submitted
     <<synchronization-queue-transfers-release, Queue Family Transfer Release
@@ -1429,10 +1429,10 @@ command buffer becomes <<commandbuffers-lifecycle, invalid>>.
   * [[VUID-vkCmdExecuteCommands-pInheritanceInfo-00098]]
     If fname:vkCmdExecuteCommands is being called within a render pass
     instance, the render passes specified in the
-    pname:pBeginInfo::pname:pInheritanceInfo::pname:renderPass members of
-    the flink:vkBeginCommandBuffer commands used to begin recording each
-    element of pname:pCommandBuffers must: be
-    <<renderpass-compatibility,compatible>> with the current render pass.
+    pname:pBeginInfo\->pInheritanceInfo\->renderPass members of the
+    flink:vkBeginCommandBuffer commands used to begin recording each element
+    of pname:pCommandBuffers must: be <<renderpass-compatibility,
+    compatible>> with the current render pass.
   * [[VUID-vkCmdExecuteCommands-pCommandBuffers-00099]]
     If fname:vkCmdExecuteCommands is being called within a render pass
     instance, and any element of pname:pCommandBuffers was recorded with

--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -2123,8 +2123,8 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
 If a call to fname:vkAllocateDescriptorSets would cause the total number of
 descriptor sets allocated from the pool to exceed the value of
 slink:VkDescriptorPoolCreateInfo::pname:maxSets used to create
-pname:pAllocateInfo->pname:descriptorPool, then the allocation may: fail due
-to lack of space in the descriptor pool.
+pname:pAllocateInfo\->descriptorPool, then the allocation may: fail due to
+lack of space in the descriptor pool.
 Similarly, the allocation may: fail due to lack of space if the call to
 fname:vkAllocateDescriptorSets would cause the number of any given
 descriptor type to exceed the sum of all the pname:descriptorCount members

--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -880,13 +880,12 @@ endif::VK_KHR_maintenance3[]
 .Valid Usage
 ****
   * [[VUID-vkAllocateMemory-pAllocateInfo-01713]]
-    pname:pAllocateInfo\->pname:allocationSize must: be less than or equal
-    to
-    slink:VkPhysicalDeviceMemoryProperties::pname:memoryHeaps[pname:pAllocateInfo\->pname:memoryTypeIndex].pname:size
+    pname:pAllocateInfo\->allocationSize must: be less than or equal
+    slink:VkPhysicalDeviceMemoryProperties::pname:memoryHeaps[pname:pAllocateInfo\->memoryTypeIndex].pname:size
     as returned by flink:vkGetPhysicalDeviceMemoryProperties for the
     slink:VkPhysicalDevice that pname:device was created from.
   * [[VUID-vkAllocateMemory-pAllocateInfo-01714]]
-    pname:pAllocateInfo\->pname:memoryTypeIndex must: be less than
+    pname:pAllocateInfo\->memoryTypeIndex must: be less than
     slink:VkPhysicalDeviceMemoryProperties::pname:memoryTypeCount as
     returned by flink:vkGetPhysicalDeviceMemoryProperties for the
     slink:VkPhysicalDevice that pname:device was created from.

--- a/chapters/pipelines.txt
+++ b/chapters/pipelines.txt
@@ -744,13 +744,12 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
     If no element of the pname:pDynamicStates member of pname:pDynamicState
     is ename:VK_DYNAMIC_STATE_VIEWPORT, the pname:pViewports member of
     pname:pViewportState must: be a valid pointer to an array of
-    pname:pViewportState::pname:viewportCount valid sname:VkViewport
-    structures
+    pname:pViewportState\->viewportCount valid sname:VkViewport structures
   * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00748]]
     If no element of the pname:pDynamicStates member of pname:pDynamicState
     is ename:VK_DYNAMIC_STATE_SCISSOR, the pname:pScissors member of
     pname:pViewportState must: be a valid pointer to an array of
-    pname:pViewportState::pname:scissorCount sname:VkRect2D structures
+    pname:pViewportState\->scissorCount sname:VkRect2D structures
   * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749]]
     If the wide lines feature is not enabled, and no element of the
     pname:pDynamicStates member of pname:pDynamicState is

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -562,7 +562,7 @@ pass.
 
 pname:subpass and pname:inputAttachmentIndex index into the render pass as:
 
-pname:pCreateInfo::pname:pSubpasses[pname:subpass].pname:pInputAttachments[pname:inputAttachmentIndex]
+pname:pCreateInfo\->pSubpasses[pname:subpass].pname:pInputAttachments[pname:inputAttachmentIndex]
 
 include::../api/structs/VkInputAttachmentAspectReference.txt[]
 

--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -140,8 +140,8 @@ ifdef::VK_VERSION_1_1,VK_KHR_external_memory[]
     must: only contain bits that are also in
     slink:VkExternalBufferProperties::pname:externalMemoryProperties.compatibleHandleTypes,
     as returned by flink:vkGetPhysicalDeviceExternalBufferProperties with
-    pname:pExternalBufferInfo\->pname:handleType equal to any one of the
-    handle types specified in
+    pname:pExternalBufferInfo\->handleType equal to any one of the handle
+    types specified in
     slink:VkExternalMemoryBufferCreateInfo::pname:handleTypes
 endif::VK_VERSION_1_1,VK_KHR_external_memory[]
 ifdef::VK_VERSION_1_1[]

--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -1367,7 +1367,7 @@ or transfer ownership back to Vulkan by using the file descriptor to import
 a fence payload.
 ====
 
-If pname:pGetFdInfo\->pname:handleType is
+If pname:pGetFdInfo\->handleType is
 ename:VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT and the fence is signaled at
 the time fname:vkGetFenceFdKHR is called, pname:pFd may: return the value
 `-1` instead of a valid file descriptor.

--- a/config/vulkan-macros/extension.rb
+++ b/config/vulkan-macros/extension.rb
@@ -169,12 +169,12 @@ end
 
 class PnameInlineMacro < ParamInlineMacroBase
     named :pname
-    match /pname:(\w+(\.\w+)*)/
+    match /pname:(\w+((\.|\-&gt;)\w+)*)/
 end
 
 class PtextInlineMacro < ParamInlineMacroBase
     named :ptext
-    match /ptext:([\w\*]+(\.[\w\*]+)*)/
+    match /ptext:([\w\*]+(\[\])?((\.|\-&gt;)[\w\*]+(\[\])?)*)/
 end
 
 class DnameInlineMacro < CodeInlineMacroBase

--- a/style/markup.txt
+++ b/style/markup.txt
@@ -449,9 +449,26 @@ table:
 | pname{cl}     | Formats the macro argument as a Vulkan parameter or
                   structure member name. Example: pname{cl}device ->
                   pname:device.
+
+                  It consumes whole composite names linked with `.` or
+                  `+->+`.
+                  `+->+` must  be written as `+\->+` to avoid asciidoctor
+                  text replacement with unicode arrow.
+                  Example: flink{cl}vkCreateDevice::pname{cl}pCreateInfo\\->flags
+                  -> flink:vkCreateDevice::pname:pCreateInfo\->flags
+
+                  It does not currently support arrays, so the pname{cl}
+                  environment needs to be restarted inside, and after `[]`.
+                  Example:
+                  pname{cl}pCreateInfo\\->pSubpasses[pname{cl}subpass].pname{cl}pInputAttachments[pname{cl}inputAttachmentIndex]
+                  ->
+                  pname:pCreateInfo\->pSubpasses[pname:subpass].pname:pInputAttachments[pname:inputAttachmentIndex] 
 | ptext{cl}     | Formats the macro argument like pname{cl}. May contain
                   asterisks for wildcards. Not validated. Example:
                   ptext{cl}sparseResidency* -> ptext:sparseResidency*.
+
+                  Same rules as for pname{cl} applies, exept ptext{cl} can
+                  tolerate empty `[]` to signify a pointer that is an array.
 
                   Only use this macro <<markup-macros-api-text, when
                   necessary>>.

--- a/xml/validitygenerator.py
+++ b/xml/validitygenerator.py
@@ -49,8 +49,14 @@ class ValidityOutputGenerator(OutputGenerator):
         # Finish processing in superclass
         OutputGenerator.endFeature(self)
 
+    def sanitizeName(self, name):
+        return name.replace('->', '\->')
+
     def makeParameterName(self, name):
-        return 'pname:' + name
+        if '*' in name or '[]' in name:
+            return 'ptext:' + self.sanitizeName(name)
+        else:
+            return 'pname:' + self.sanitizeName(name)
 
     def makeStructName(self, name):
         return 'sname:' + name
@@ -452,8 +458,7 @@ class ValidityOutputGenerator(OutputGenerator):
                 asciidoc += self.makeAnchor(blockname, paramname.text, 'requiredbitmask')
                 if self.paramIsArray(param):
                     asciidoc += 'Each element of '
-                asciidoc += 'pname:'
-                asciidoc += paramname.text
+                asciidoc += self.makeParameterName(paramname.text)
                 asciidoc += ' must: not be `0`'
                 asciidoc += '\n'
 
@@ -985,8 +990,7 @@ class ValidityOutputGenerator(OutputGenerator):
                         else:
                             paramdecl += self.makeParameterName(paramname.text)
                     else:
-                        paramdecl += 'pname:'
-                        paramdecl += externsyncattrib
+                            paramdecl += self.makeParameterName(externsyncattrib)
                     paramdecl += ' must: be externally synchronized\n'
 
         # For any vkCmd* functions, the command pool is externally synchronized

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -5194,8 +5194,8 @@ server.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FRAGMENTED_POOL,VK_ERROR_OUT_OF_POOL_MEMORY">
             <proto><type>VkResult</type> <name>vkAllocateDescriptorSets</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pAllocateInfo::descriptorPool">const <type>VkDescriptorSetAllocateInfo</type>* <name>pAllocateInfo</name></param>
-            <param len="pAllocateInfo::descriptorSetCount"><type>VkDescriptorSet</type>* <name>pDescriptorSets</name></param>
+            <param externsync="pAllocateInfo-&gt;descriptorPool">const <type>VkDescriptorSetAllocateInfo</type>* <name>pAllocateInfo</name></param>
+            <param len="pAllocateInfo-&gt;descriptorSetCount"><type>VkDescriptorSet</type>* <name>pDescriptorSets</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkFreeDescriptorSets</name></proto>
@@ -5266,8 +5266,8 @@ server.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkAllocateCommandBuffers</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pAllocateInfo::commandPool">const <type>VkCommandBufferAllocateInfo</type>* <name>pAllocateInfo</name></param>
-            <param len="pAllocateInfo::commandBufferCount"><type>VkCommandBuffer</type>* <name>pCommandBuffers</name></param>
+            <param externsync="pAllocateInfo-&gt;commandPool">const <type>VkCommandBufferAllocateInfo</type>* <name>pAllocateInfo</name></param>
+            <param len="pAllocateInfo-&gt;commandBufferCount"><type>VkCommandBuffer</type>* <name>pCommandBuffers</name></param>
         </command>
         <command>
             <proto><type>void</type> <name>vkFreeCommandBuffers</name></proto>
@@ -5756,7 +5756,7 @@ server.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR">
             <proto><type>VkResult</type> <name>vkCreateSwapchainKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pCreateInfo.surface,pCreateInfo.oldSwapchain">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfo</name></param>
+            <param externsync="pCreateInfo-&gt;surface,pCreateInfo-&gt;oldSwapchain">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfo</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param><type>VkSwapchainKHR</type>* <name>pSwapchain</name></param>
         </command>
@@ -5785,7 +5785,7 @@ server.
         <command successcodes="VK_SUCCESS,VK_SUBOPTIMAL_KHR" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR">
             <proto><type>VkResult</type> <name>vkQueuePresentKHR</name></proto>
             <param externsync="true"><type>VkQueue</type> <name>queue</name></param>
-            <param externsync="pPresentInfo.pWaitSemaphores[],pPresentInfo.pSwapchains[]">const <type>VkPresentInfoKHR</type>* <name>pPresentInfo</name></param>
+            <param externsync="pPresentInfo-&gt;pWaitSemaphores[],pPresentInfo-&gt;pSwapchains[]">const <type>VkPresentInfoKHR</type>* <name>pPresentInfo</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR">
             <proto><type>VkResult</type> <name>vkCreateViSurfaceNN</name></proto>
@@ -5881,12 +5881,12 @@ server.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkDebugMarkerSetObjectNameEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pNameInfo.object">const <type>VkDebugMarkerObjectNameInfoEXT</type>* <name>pNameInfo</name></param>
+            <param externsync="pNameInfo-&gt;object">const <type>VkDebugMarkerObjectNameInfoEXT</type>* <name>pNameInfo</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkDebugMarkerSetObjectTagEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pTagInfo.object">const <type>VkDebugMarkerObjectTagInfoEXT</type>* <name>pTagInfo</name></param>
+            <param externsync="pTagInfo-&gt;object">const <type>VkDebugMarkerObjectTagInfoEXT</type>* <name>pTagInfo</name></param>
         </command>
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdDebugMarkerBeginEXT</name></proto>
@@ -6520,12 +6520,12 @@ server.
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkSetDebugUtilsObjectNameEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pNameInfo.objectHandle">const <type>VkDebugUtilsObjectNameInfoEXT</type>* <name>pNameInfo</name></param>
+            <param externsync="pNameInfo-&gt;objectHandle">const <type>VkDebugUtilsObjectNameInfoEXT</type>* <name>pNameInfo</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkSetDebugUtilsObjectTagEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pTagInfo.objectHandle">const <type>VkDebugUtilsObjectTagInfoEXT</type>* <name>pTagInfo</name></param>
+            <param externsync="pTagInfo-&gt;objectHandle">const <type>VkDebugUtilsObjectTagInfoEXT</type>* <name>pTagInfo</name></param>
         </command>
         <command>
             <proto><type>void</type> <name>vkQueueBeginDebugUtilsLabelEXT</name></proto>


### PR DESCRIPTION
- make pointers use proper `->`
- make `pname:` consume `->`
- make `ptext:` consume `[]` as it appears in externsync
- fix some obvious `->` and `[]` related errors in the spec text

Does **not** cover `::` names. It is still rendered bit awkwardly and requires cleaning current attempts at markuping.
I was thinking perhaps it should.
And perhaps `plink:Blah::blah` should be introduced to cover cases where now something like `slink:Blah::pname:blah` is used.
Thoughts?