### PR TITLE
Remove redundant vkCmdSetDiscardRectangleEXT VUs + tweaks

### DIFF
--- a/doc/specs/vulkan/chapters/fragops.txt
+++ b/doc/specs/vulkan/chapters/fragops.txt
@@ -125,26 +125,22 @@ pname:discardRectangleCount)#.
   * [[VUID-vkCmdSetDiscardRectangleEXT-None-00583]]
     The currently bound graphics pipeline must: have been created with the
     ename:VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT dynamic state enabled
-  * [[VUID-vkCmdSetDiscardRectangleEXT-firstDiscardRectangle-00584]]
-    pname:firstDiscardRectangle must: be less than
-    slink:VkPhysicalDeviceDiscardRectanglePropertiesEXT::pname:maxDiscardRectangles
   * [[VUID-vkCmdSetDiscardRectangleEXT-firstDiscardRectangle-00585]]
     The sum of pname:firstDiscardRectangle and pname:discardRectangleCount
-    must: be between `1` and
-    sname:VkPhysicalDeviceDiscardRectanglePropertiesEXT::pname:maxDiscardRectangles,
-    inclusive
-  * [[VUID-vkCmdSetDiscardRectangleEXT-pDiscardRectangles-00586]]
-    pname:pDiscardRectangles must: be a valid pointer to an array of
-    pname:discardRectangleCount valid sname:VkRect2D structures
+    must: be less than or equal to
+    slink:VkPhysicalDeviceDiscardRectanglePropertiesEXT::pname:maxDiscardRectangles
   * [[VUID-vkCmdSetDiscardRectangleEXT-x-00587]]
-    The pname:x and pname:y members of pname:offset in sname:VkRect2D must:
-    be greater than or equal to `0`
+    The pname:x and pname:y member of pname:offset in each slink:VkRect2D
+    element of pname:pDiscardRectangles must: be greater than or equal to
+    `0`
   * [[VUID-vkCmdSetDiscardRectangleEXT-offset-00588]]
     Evaluation of [eq]#(pname:offset.x {plus} pname:extent.width)# in
-    sname:VkRect2D must: not cause a signed integer addition overflow
+    each slink:VkRect2D element of pname:pDiscardRectangles must: not cause
+    a signed integer addition overflow
   * [[VUID-vkCmdSetDiscardRectangleEXT-offset-00589]]
     Evaluation of [eq]#(pname:offset.y {plus} pname:extent.height)# in
-    sname:VkRect2D must: not cause a signed integer addition overflow
+    each slink:VkRect2D element of pname:pDiscardRectangles must: not cause
+    a signed integer addition overflow
 ****
 
 include::../validity/protos/vkCmdSetDiscardRectangleEXT.txt[]


### PR DESCRIPTION
- remove redundant VU about the `pDiscardRectanges` vector; it is implicit
- remove redundant VU about `firstDiscardRectangle` it is fully covered by `00585` and implicit VU that says `discardRectangleCount` >0
- remove redundant VU part saying &ge;1; it is implicit because of `discardRectangleCount` > 0
- tweak `VkRect2D` VUs to mention the array they are part of