### PR TITLE
Update VkPipelineViewportWScalingStateCreateInfoNV

### DIFF
--- a/doc/specs/vulkan/chapters/VK_NV_clip_space_w_scaling/vertexpostproc.txt
+++ b/doc/specs/vulkan/chapters/VK_NV_clip_space_w_scaling/vertexpostproc.txt
@@ -1,8 +1,8 @@
 [[vertexpostproc-viewportwscaling]]
 == Controlling Viewport W Scaling
 
-If viewport W scaling is enabled, the W component of the clip coordinate is
-modified by the provided coefficients from the corresponding viewport as
+If viewport *W* scaling is enabled, the *W* component of the clip coordinate
+is modified by the provided coefficients from the corresponding viewport as
 follows.
 
   :: [eq]#w~c~' = x~coeff~ x~c~ {plus} y~coeff~ y~c~ {plus} w~c~#
@@ -15,40 +15,17 @@ as:
 
 include::../../api/structs/VkPipelineViewportWScalingStateCreateInfoNV.txt[]
 
-  * pname:sType is the type of this structure
-  * pname:pNext is `NULL` or a pointer to an extension-specific structure
-  * pname:viewportWScalingEnable is the enable for viewport W scaling
-  * pname:viewportCount is the number of viewports used by W scaling and
-    must: match the number of viewports in the pipeline if viewport W
+  * pname:sType is the type of this structure.
+  * pname:pNext is `NULL` or a pointer to an extension-specific structure.
+  * pname:viewportWScalingEnable controls whether viewport *W* scaling is
+    enabled.
+  * pname:viewportCount is the number of viewports used by *W* scaling, and
+    must: match the number of viewports in the pipeline if viewport *W*
     scaling is enabled.
   * pname:pViewportWScalings is a pointer to an array of
-    sname:VkViewportWScalingNV structures which define the W scaling
+    sname:VkViewportWScalingNV structures, which define the *W* scaling
     parameters for the corresponding viewport.
-    If the viewport W scaling state is dynamic, this member is ignored.
-  * If no element of the pname:pDynamicStates member of
-    sname::VkPipelineViewportStateCreateInfo::pname:pDynamicState is
-    ename:VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV, the
-    pname:pViewportScalings member of a
-    sname:VkPipelineViewportWScalingStateCreateInfoNV extension structure
-    must: be a pointer to an array of
-    sname:VkPipelineViewportWScalingStateCreateInfoNV::pname:viewportCount
-    sname:VkViewportWScalingNV structures
-
-.Valid Usage
-****
-  * [[VUID-VkPipelineViewportWScalingStateCreateInfoNV-viewportWScalingEnable-01319]]
-    If the <<features-features-multiViewport,multiple viewports>> feature is
-    not enabled and pname:viewportWScalingEnable is ename:VK_TRUE,
-    pname:viewportCount must: be `1`
-  * [[VUID-VkPipelineViewportWScalingStateCreateInfoNV-viewportCount-01320]]
-    pname:viewportCount must: be between `1` and
-    sname:VkPhysicalDeviceLimits::pname:maxViewports, inclusive if
-    pname:viewportWScalingEnable is ename:VK_TRUE
-  * [[VUID-VkPipelineViewportWScalingStateCreateInfoNV-viewportCount-01321]]
-    pname:viewportCount and
-    sname:VkPipelineViewportStateCreateInfo::pname:viewportCount must: be
-    identical if pname:viewportWScalingEnable is ename:VK_TRUE
-****
+    If the viewport *W* scaling state is dynamic, this member is ignored.
 
 include::../../validity/structs/VkPipelineViewportWScalingStateCreateInfoNV.txt[]
 --

--- a/doc/specs/vulkan/chapters/pipelines.txt
+++ b/doc/specs/vulkan/chapters/pipelines.txt
@@ -771,6 +771,18 @@ endif::VK_KHR_maintenance2[]
     The number of resources in pname:layout accessible to each shader stage
     that is used by the pipeline must: be less than or equal to
     sname:VkPhysicalDeviceLimits::pname:maxPerStageResources
+ifdef::VK_NV_clip_space_w_scaling[]
+  * If no element of the pname:pDynamicStates member of pname:pDynamicState
+    is ename:VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV, and the
+    pname:viewportWScalingEnable member of a
+    slink:VkPipelineViewportWScalingStateCreateInfoNV structure, chained to
+    the pname:pNext chain of pname:pViewportState, is ename:VK_TRUE,
+    the pname:pViewportWScalings member of the
+    slink:VkPipelineViewportWScalingStateCreateInfoNV must: be a pointer to
+    an array of
+    slink:VkPipelineViewportWScalingStateCreateInfoNV::pname:viewportCount
+    valid slink:VkViewportWScalingNV structures
+endif::VK_NV_clip_space_w_scaling[]
 ****
 
 include::../validity/structs/VkGraphicsPipelineCreateInfo.txt[]

--- a/doc/specs/vulkan/chapters/vertexpostproc.txt
+++ b/doc/specs/vulkan/chapters/vertexpostproc.txt
@@ -494,6 +494,13 @@ include::../api/structs/VkPipelineViewportStateCreateInfo.txt[]
     sname:VkPhysicalDeviceLimits::pname:maxViewports, inclusive
   * [[VUID-VkPipelineViewportStateCreateInfo-scissorCount-01220]]
     pname:scissorCount and pname:viewportCount must: be identical
+ifdef::VK_NV_clip_space_w_scaling[]
+  * If the pname:viewportWScalingEnable member of a
+    slink:VkPipelineViewportWScalingStateCreateInfoNV structure chained to
+    the pname:pNext chain is ename:VK_TRUE, the pname:viewportCount member
+    of the slink:VkPipelineViewportWScalingStateCreateInfoNV structure must:
+    be equal to pname:viewportCount
+endif::VK_NV_clip_space_w_scaling[]
 ****
 
 include::../validity/structs/VkPipelineViewportStateCreateInfo.txt[]


### PR DESCRIPTION
- fix bad description (VU like) block + some tweaks
- remove redundant VUs (redundant due to required equality to `VkPipelineViewportStateCreateInfo::viewportCount`)
- move `viewportCount` equality VU to `VkPipelineViewportStateCreateInfo` where it belongs
- make a dynamic state related VU in `VkGraphicsPipelineCreateInfo`