### PR TITLE
Update vkCmdSetViewportWScalingNV

### DIFF
--- a/doc/specs/vulkan/chapters/VK_NV_clip_space_w_scaling/vertexpostproc.txt
+++ b/doc/specs/vulkan/chapters/VK_NV_clip_space_w_scaling/vertexpostproc.txt
@@ -40,12 +40,12 @@ pipeline state with flink:vkCreateGraphicsPipelines.
 
 If the bound pipeline state object was not created with the
 ename:VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV dynamic state enabled, viewport
-W scaling parameters are specified using the pname:pViewportWScalings member
-of sname:VkPipelineViewportWScalingStateCreateInfoNV in the pipeline state
-object.
+*W* scaling parameters are specified using the pname:pViewportWScalings
+member of slink:VkPipelineViewportWScalingStateCreateInfoNV in the pipeline
+state object.
 If the pipeline state object was created with the
-ename:VK_DYNAMIC_STATE_VIEWPORT dynamic state enabled, the viewport
-transformation parameters are dynamically set and changed with the command:
+ename:VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV dynamic state enabled, the
+viewport transformation parameters are dynamically set and changed with the command:
 
 include::../../api/protos/vkCmdSetViewportWScalingNV.txt[]
 
@@ -55,11 +55,11 @@ include::../../api/protos/vkCmdSetViewportWScalingNV.txt[]
     are updated by the command.
   * pname:viewportCount is the number of viewports whose parameters are
     updated by the command.
-  * pname:pViewportScalings is a pointer to an array of
+  * pname:pViewportWScalings is a pointer to an array of
     slink:VkViewportWScalingNV structures specifying viewport parameters.
 
 The viewport parameters taken from element [eq]#i# of
-pname:pViewportScalings replace the current state for the viewport index
+pname:pViewportWScalings replace the current state for the viewport index
 [eq]#pname:firstViewport {plus} i#, for [eq]#i# in [eq]#[0,
 pname:viewportCount)#.
 
@@ -70,10 +70,10 @@ pname:viewportCount)#.
     ename:VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV dynamic state enabled
   * [[VUID-vkCmdSetViewportWScalingNV-firstViewport-01323]]
     pname:firstViewport must: be less than
-    sname:VkPhysicalDeviceLimits::pname:maxViewports
+    slink:VkPhysicalDeviceLimits::pname:maxViewports
   * [[VUID-vkCmdSetViewportWScalingNV-firstViewport-01324]]
     The sum of pname:firstViewport and pname:viewportCount must: be between
-    `1` and sname:VkPhysicalDeviceLimits::pname:maxViewports, inclusive
+    `1` and slink:VkPhysicalDeviceLimits::pname:maxViewports, inclusive
   * [[VUID-vkCmdSetViewportWScalingNV-pViewportScalings-01325]]
     pname:pViewportScalings must: be a pointer to an array of
     pname:viewportCount valid sname:VkViewportWScalingNV structures


### PR DESCRIPTION
- says `VK_DYNAMIC_STATE_VIEWPORT`, prolly means `VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV`
- fixed missing "W" in parameter references