### PR TITLE
Make dynamic state array len VU implicit

### DIFF
--- a/doc/specs/vulkan/chapters/VK_NV_clip_space_w_scaling/vertexpostproc.txt
+++ b/doc/specs/vulkan/chapters/VK_NV_clip_space_w_scaling/vertexpostproc.txt
@@ -75,9 +75,6 @@ pname:viewportCount)#.
   * [[VUID-vkCmdSetViewportWScalingNV-firstViewport-01324]]
     The sum of pname:firstViewport and pname:viewportCount must: be between
     `1` and slink:VkPhysicalDeviceLimits::pname:maxViewports, inclusive
-  * [[VUID-vkCmdSetViewportWScalingNV-pViewportScalings-01325]]
-    pname:pViewportScalings must: be a pointer to an array of
-    pname:viewportCount valid sname:VkViewportWScalingNV structures
 ****
 
 include::../../validity/protos/vkCmdSetViewportWScalingNV.txt[]

--- a/doc/specs/vulkan/chapters/vertexpostproc.txt
+++ b/doc/specs/vulkan/chapters/vertexpostproc.txt
@@ -614,9 +614,6 @@ replace the current state for the viewport index [eq]#pname:firstViewport
   * [[VUID-vkCmdSetViewport-viewportCount-01225]]
     If the <<features-features-multiViewport,multiple viewports>> feature is
     not enabled, pname:viewportCount must: be `1`
-  * [[VUID-vkCmdSetViewport-pViewports-01226]]
-    pname:pViewports must: be a valid pointer to an array of
-    pname:viewportCount valid sname:VkViewport structures
 ****
 
 include::../validity/protos/vkCmdSetViewport.txt[]

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -4320,7 +4320,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>uint32_t</type> <name>firstViewport</name></param>
             <param><type>uint32_t</type> <name>viewportCount</name></param>
-            <param len="viewportCount" noautovalidity="true">const <type>VkViewport</type>* <name>pViewports</name></param>
+            <param len="viewportCount">const <type>VkViewport</type>* <name>pViewports</name></param>
         </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdSetScissor</name></proto>
@@ -5327,7 +5327,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>uint32_t</type> <name>firstViewport</name></param>
             <param><type>uint32_t</type> <name>viewportCount</name></param>
-            <param len="viewportCount" noautovalidity="true">const <type>VkViewportWScalingNV</type>* <name>pViewportWScalings</name></param>
+            <param len="viewportCount">const <type>VkViewportWScalingNV</type>* <name>pViewportWScalings</name></param>
         </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdSetDiscardRectangleEXT</name></proto>


### PR DESCRIPTION
- make implicit for `vkCmdSetViewport`
- make implicit for `vkCmdSetViewportWScalingNV`
- <s>removed redundant explicit duplicate for `vkCmdSetDiscardRectangleEXT`</s>

Not sure why they were `noautovalidity`. Possibly because the script forgets to add "valid" (some kind of bug)?