### PR TITLE
Fix missing "valid" in some obscure cases

### DIFF
--- a/chapters/VK_KHR_display/display.txt
+++ b/chapters/VK_KHR_display/display.txt
@@ -411,6 +411,13 @@ include::../../api/structs/VkDisplayModeParametersKHR.txt[]
 For example, a 60Hz display mode would report a pname:refreshRate of 60,000.
 ====
 
+.Valid Usage
+****
+  * The pname:width member of pname:visibleRegion must: be greater than `0`
+  * The pname:height member of pname:visibleRegion must: be greater than `0`
+  * pname:refreshRate must: be greater than `0`
+****
+
 include::../../validity/structs/VkDisplayModeParametersKHR.txt[]
 --
 
@@ -448,16 +455,6 @@ include::../../api/structs/VkDisplayModeCreateInfoKHR.txt[]
     describing the display parameters to use in creating the new mode.
     If the parameters are not compatible with the specified display, the
     implementation must: return ename:VK_ERROR_INITIALIZATION_FAILED.
-
-.Valid Usage
-****
-  * [[VUID-VkDisplayModeCreateInfoKHR-width-01250]]
-    The pname:width and pname:height members of the pname:visibleRegion
-    member of pname:parameters must: be greater than `0`
-  * [[VUID-VkDisplayModeCreateInfoKHR-refreshRate-01251]]
-    The pname:refreshRate member of pname:parameters must: be greater than
-    `0`
-****
 
 include::../../validity/structs/VkDisplayModeCreateInfoKHR.txt[]
 --

--- a/chapters/clears.txt
+++ b/chapters/clears.txt
@@ -465,13 +465,6 @@ This union is used where part of the API requires either color or
 depth/stencil clear values, depending on the attachment, and defines the
 initial clear values in the slink:VkRenderPassBeginInfo structure.
 
-.Valid Usage
-****
-  * [[VUID-VkClearValue-depthStencil-00023]]
-    pname:depthStencil must: be a valid sname:VkClearDepthStencilValue
-    structure
-****
-
 include::../validity/structs/VkClearValue.txt[]
 --
 

--- a/chapters/copies.txt
+++ b/chapters/copies.txt
@@ -107,9 +107,6 @@ memory.
 
 .Valid Usage
 ****
-  * [[VUID-vkCmdCopyBuffer-size-00112]]
-    The pname:size member of each element of pname:pRegions must: be greater
-    than `0`
   * [[VUID-vkCmdCopyBuffer-srcOffset-00113]]
     The pname:srcOffset member of each element of pname:pRegions must: be
     less than the size of pname:srcBuffer
@@ -166,6 +163,11 @@ include::../api/structs/VkBufferCopy.txt[]
   * pname:dstOffset is the starting offset in bytes from the start of
     pname:dstBuffer.
   * pname:size is the number of bytes to copy.
+
+.Valid Usage
+****
+  * The pname:size must: be greater than `0`
+****
 
 include::../validity/structs/VkBufferCopy.txt[]
 --

--- a/chapters/pipelines.txt
+++ b/chapters/pipelines.txt
@@ -648,7 +648,8 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
     If no element of the pname:pDynamicStates member of pname:pDynamicState
     is ename:VK_DYNAMIC_STATE_VIEWPORT, the pname:pViewports member of
     pname:pViewportState must: be a valid pointer to an array of
-    pname:pViewportState::pname:viewportCount sname:VkViewport structures
+    pname:pViewportState::pname:viewportCount valid sname:VkViewport
+    structures
   * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00748]]
     If no element of the pname:pDynamicStates member of pname:pDynamicState
     is ename:VK_DYNAMIC_STATE_SCISSOR, the pname:pScissors member of
@@ -1466,10 +1467,6 @@ slink:VkSpecializationMapEntry.
   * [[VUID-VkSpecializationInfo-pMapEntries-00774]]
     The pname:size member of each element of pname:pMapEntries must: be less
     than or equal to pname:dataSize minus pname:offset
-  * [[VUID-VkSpecializationInfo-mapEntryCount-00775]]
-    If pname:mapEntryCount is not `0`, pname:pMapEntries must: be a valid
-    pointer to an array of pname:mapEntryCount valid
-    sname:VkSpecializationMapEntry structures
 ****
 
 include::../validity/structs/VkSpecializationInfo.txt[]

--- a/registry.txt
+++ b/registry.txt
@@ -501,6 +501,8 @@ member.
   * attr:noautovalidity - prevents automatic validity language being
     generated for the tagged item. Only suppresses item-specific
     validity - parenting issues etc. are still captured.
+    It must also be used for structures that have no implicit validity when
+    such structure has explicit validity.
 
 ==== Contents of tag:member tags
 

--- a/xml/validitygenerator.py
+++ b/xml/validitygenerator.py
@@ -466,10 +466,13 @@ class ValidityOutputGenerator(OutputGenerator):
 
         return asciidoc
 
-    # Try to do check if a structure is always considered valid (i.e. there's no rules to its acceptance)
+    # Check if a structure is always considered valid (i.e. there are no rules to its acceptance)
     def isStructAlwaysValid(self, blockname, structname):
 
         struct = self.registry.tree.find("types/type[@name='" + structname + "']")
+
+        if struct.attrib.get('returnedonly') is not None:
+            return True
 
         params = struct.findall('member')
 
@@ -482,6 +485,9 @@ class ValidityOutputGenerator(OutputGenerator):
                 return False
 
             if paramname.text == 'sType':
+                return False
+
+            if param.attrib.get('noautovalidity') is not None:
                 return False
 
             if paramtype.text == 'void' or paramtype.text == 'char' or self.paramIsArray(param) or self.paramIsPointer(param):

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -588,12 +588,12 @@ server.
             <member><type>uint32_t</type>        <name>depth</name></member>
         </type>
         <type category="struct" name="VkViewport">
-            <member><type>float</type>          <name>x</name></member>
-            <member><type>float</type>          <name>y</name></member>
-            <member><type>float</type>          <name>width</name></member>
-            <member><type>float</type>          <name>height</name></member>
-            <member><type>float</type>          <name>minDepth</name></member>
-            <member><type>float</type>          <name>maxDepth</name></member>
+            <member noautovalidity="true"><type>float</type> <name>x</name></member>
+            <member noautovalidity="true"><type>float</type> <name>y</name></member>
+            <member noautovalidity="true"><type>float</type> <name>width</name></member>
+            <member noautovalidity="true"><type>float</type> <name>height</name></member>
+            <member><type>float</type>                       <name>minDepth</name></member>
+            <member><type>float</type>                       <name>maxDepth</name></member>
         </type>
         <type category="struct" name="VkRect2D">
             <member><type>VkOffset2D</type>     <name>offset</name></member>
@@ -642,11 +642,11 @@ server.
         </type>
         <type category="struct" name="VkAllocationCallbacks">
             <member optional="true"><type>void</type>*           <name>pUserData</name></member>
-            <member><type>PFN_vkAllocationFunction</type>   <name>pfnAllocation</name></member>
-            <member><type>PFN_vkReallocationFunction</type> <name>pfnReallocation</name></member>
-            <member><type>PFN_vkFreeFunction</type>    <name>pfnFree</name></member>
-            <member optional="true"><type>PFN_vkInternalAllocationNotification</type> <name>pfnInternalAllocation</name></member>
-            <member optional="true"><type>PFN_vkInternalFreeNotification</type> <name>pfnInternalFree</name></member>
+            <member noautovalidity="true"><type>PFN_vkAllocationFunction</type>   <name>pfnAllocation</name></member>
+            <member noautovalidity="true"><type>PFN_vkReallocationFunction</type> <name>pfnReallocation</name></member>
+            <member noautovalidity="true"><type>PFN_vkFreeFunction</type>    <name>pfnFree</name></member>
+            <member optional="true" noautovalidity="true"><type>PFN_vkInternalAllocationNotification</type> <name>pfnInternalAllocation</name></member>
+            <member optional="true" noautovalidity="true"><type>PFN_vkInternalFreeNotification</type> <name>pfnInternalFree</name></member>
         </type>
         <type category="struct" name="VkDeviceQueueCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -874,9 +874,9 @@ server.
             <member><type>VkImageSubresourceRange</type> <name>subresourceRange</name></member>
         </type>
         <type category="struct" name="VkBufferCopy">
-            <member><type>VkDeviceSize</type>           <name>srcOffset</name><comment>Specified in bytes</comment></member>
-            <member><type>VkDeviceSize</type>           <name>dstOffset</name><comment>Specified in bytes</comment></member>
-            <member><type>VkDeviceSize</type>           <name>size</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>                       <name>srcOffset</name><comment>Specified in bytes</comment></member>
+            <member><type>VkDeviceSize</type>                       <name>dstOffset</name><comment>Specified in bytes</comment></member>
+            <member noautovalidity="true"><type>VkDeviceSize</type> <name>size</name><comment>Specified in bytes</comment></member>
         </type>
         <type category="struct" name="VkSparseMemoryBind">
             <member><type>VkDeviceSize</type>           <name>resourceOffset</name><comment>Specified in bytes</comment></member>
@@ -991,13 +991,13 @@ server.
             <member len="descriptorSetCount">const <type>VkDescriptorSetLayout</type>* <name>pSetLayouts</name></member>
         </type>
         <type category="struct" name="VkSpecializationMapEntry">
-            <member><type>uint32_t</type>               <name>constantID</name><comment>The SpecConstant ID specified in the BIL</comment></member>
-            <member><type>uint32_t</type>               <name>offset</name><comment>Offset of the value in the data block</comment></member>
-            <member><type>size_t</type>                 <name>size</name><comment>Size in bytes of the SpecConstant</comment></member>
+            <member><type>uint32_t</type>                     <name>constantID</name><comment>The SpecConstant ID specified in the BIL</comment></member>
+            <member><type>uint32_t</type>                     <name>offset</name><comment>Offset of the value in the data block</comment></member>
+            <member noautovalidity="true"><type>size_t</type> <name>size</name><comment>Size in bytes of the SpecConstant</comment></member>
         </type>
         <type category="struct" name="VkSpecializationInfo">
             <member optional="true"><type>uint32_t</type>               <name>mapEntryCount</name><comment>Number of entries in the map</comment></member>
-            <member len="mapEntryCount" noautovalidity="true">const <type>VkSpecializationMapEntry</type>* <name>pMapEntries</name><comment>Array of map entries</comment></member>
+            <member len="mapEntryCount">const <type>VkSpecializationMapEntry</type>* <name>pMapEntries</name><comment>Array of map entries</comment></member>
             <member optional="true"><type>size_t</type>                 <name>dataSize</name><comment>Size in bytes of pData</comment></member>
             <member len="dataSize">const <type>void</type>*            <name>pData</name><comment>Pointer to SpecConstant data</comment></member>
         </type>
@@ -1518,22 +1518,22 @@ server.
             <member><type>uint32_t</type>               <name>layers</name></member>
         </type>
         <type category="struct" name="VkDrawIndirectCommand">
-            <member><type>uint32_t</type>               <name>vertexCount</name></member>
-            <member><type>uint32_t</type>               <name>instanceCount</name></member>
-            <member><type>uint32_t</type>               <name>firstVertex</name></member>
-            <member><type>uint32_t</type>               <name>firstInstance</name></member>
+            <member><type>uint32_t</type>                       <name>vertexCount</name></member>
+            <member><type>uint32_t</type>                       <name>instanceCount</name></member>
+            <member><type>uint32_t</type>                       <name>firstVertex</name></member>
+            <member noautovalidity="true"><type>uint32_t</type> <name>firstInstance</name></member>
         </type>
         <type category="struct" name="VkDrawIndexedIndirectCommand">
-            <member><type>uint32_t</type>               <name>indexCount</name></member>
-            <member><type>uint32_t</type>               <name>instanceCount</name></member>
-            <member><type>uint32_t</type>               <name>firstIndex</name></member>
-            <member><type>int32_t</type>                <name>vertexOffset</name></member>
-            <member><type>uint32_t</type>               <name>firstInstance</name></member>
+            <member><type>uint32_t</type>                       <name>indexCount</name></member>
+            <member><type>uint32_t</type>                       <name>instanceCount</name></member>
+            <member><type>uint32_t</type>                       <name>firstIndex</name></member>
+            <member><type>int32_t</type>                        <name>vertexOffset</name></member>
+            <member noautovalidity="true"><type>uint32_t</type> <name>firstInstance</name></member>
         </type>
         <type category="struct" name="VkDispatchIndirectCommand">
-            <member><type>uint32_t</type>               <name>x</name></member>
-            <member><type>uint32_t</type>               <name>y</name></member>
-            <member><type>uint32_t</type>               <name>z</name></member>
+            <member noautovalidity="true"><type>uint32_t</type> <name>x</name></member>
+            <member noautovalidity="true"><type>uint32_t</type> <name>y</name></member>
+            <member noautovalidity="true"><type>uint32_t</type> <name>z</name></member>
         </type>
         <type category="struct" name="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_SUBMIT_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -1562,7 +1562,7 @@ server.
         </type>
         <type category="struct" name="VkDisplayModeParametersKHR">
             <member><type>VkExtent2D</type>                       <name>visibleRegion</name><comment>Visible scanout region.</comment></member>
-            <member><type>uint32_t</type>                         <name>refreshRate</name><comment>Number of times per second the display is updated.</comment></member>
+            <member noautovalidity="true"><type>uint32_t</type>   <name>refreshRate</name><comment>Number of times per second the display is updated.</comment></member>
         </type>
         <type category="struct" name="VkDisplayModePropertiesKHR" returnedonly="true">
             <member><type>VkDisplayModeKHR</type>                 <name>displayMode</name><comment>Handle of this display mode.</comment></member>
@@ -1708,7 +1708,7 @@ server.
             <member values="VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT"><type>VkStructureType</type>                  <name>sType</name><comment>Must be VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT</comment></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>disabledValidationCheckCount</name><comment>Number of validation checks to disable</comment></member>
-            <member len="disabledValidationCheckCount"><type>VkValidationCheckEXT</type>* <name>pDisabledValidationChecks</name><comment>Validation checks to disable</comment></member>
+            <member len="disabledValidationCheckCount">const <type>VkValidationCheckEXT</type>* <name>pDisabledValidationChecks</name><comment>Validation checks to disable</comment></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationStateRasterizationOrderAMD" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD"><type>VkStructureType</type> <name>sType</name></member>
@@ -1971,7 +1971,7 @@ server.
         </type>
         <type category="struct" name="VkRectLayerKHR">
             <member><type>VkOffset2D</type>                       <name>offset</name><comment>upper-left corner of a rectangle that has not changed, in pixels of a presentation images</comment></member>
-            <member><type>VkExtent2D</type>                       <name>extent</name><comment>Dimensions of a rectangle that has not changed, in pixels of a presentation images</comment></member>
+            <member noautovalidity="true"><type>VkExtent2D</type> <name>extent</name><comment>Dimensions of a rectangle that has not changed, in pixels of a presentation images</comment></member>
             <member><type>uint32_t</type>                         <name>layer</name><comment>Layer of a swapchain's image(s), for stereoscopic-3D images</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVariablePointerFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
@@ -2440,10 +2440,10 @@ server.
             <member><type>float</type>          <name>maxContentLightLevel</name><comment>Content maximum luminance</comment></member>
             <member><type>float</type>          <name>maxFrameAverageLightLevel</name></member>
         </type>
-        <type category="struct" name="VkRefreshCycleDurationGOOGLE">
+        <type category="struct" name="VkRefreshCycleDurationGOOGLE" returnedonly="true">
             <member><type>uint64_t</type>                         <name>refreshDuration</name><comment>Number of nanoseconds from the start of one refresh cycle to the next</comment></member>
         </type>
-        <type category="struct" name="VkPastPresentationTimingGOOGLE">
+        <type category="struct" name="VkPastPresentationTimingGOOGLE" returnedonly="true">
             <member><type>uint32_t</type>                         <name>presentID</name><comment>Application-provided identifier, previously given to vkQueuePresentKHR</comment></member>
             <member><type>uint64_t</type>                         <name>desiredPresentTime</name><comment>Earliest time an image should have been presented, previously given to vkQueuePresentKHR</comment></member>
             <member><type>uint64_t</type>                         <name>actualPresentTime</name><comment>Time the image was actually displayed</comment></member>


### PR DESCRIPTION
- update script to detect better structs that do not need "valid"
- update `vk.xml` and schema to say `noautovalidity` as a hint to the script
- fix missing `const` in `VkValidationFlagsEXT`
- update some cases that were probably avoiding the bug

complements changes in PR #589