### PR TITLE
Add synchronization VUs to vkAcquireNextImage

### DIFF
--- a/doc/specs/vulkan/chapters/VK_KHR_swapchain/wsi.txt
+++ b/doc/specs/vulkan/chapters/VK_KHR_swapchain/wsi.txt
@@ -612,10 +612,14 @@ include::../../api/protos/vkAcquireNextImageKHR.txt[]
     pname:swapchain must: not be in the retired state
   * [[VUID-vkAcquireNextImageKHR-semaphore-01286]]
     If pname:semaphore is not dlink:VK_NULL_HANDLE it must: be unsignaled
+  * If pname:semaphore is not dlink:VK_NULL_HANDLE it must: not have any
+    uncompleted signal or wait operations pending
   * [[VUID-vkAcquireNextImageKHR-fence-01287]]
     If pname:fence is not dlink:VK_NULL_HANDLE it must: be unsignaled and
     must: not be associated with any other queue command that has not yet
     completed execution on that queue
+  * pname:semaphore and pname:fence must: not both be equal to
+    dlink:VK_NULL_HANDLE
 ****
 
 include::../../validity/protos/vkAcquireNextImageKHR.txt[]
@@ -728,8 +732,6 @@ It will become signaled when the application can: use the image.
 Applications can: use this to meter their frame generation work to match the
 presentation rate.
 
-pname:semaphore and pname:fence must: not both be equal to
-dlink:VK_NULL_HANDLE.
 An application must: wait until either the pname:semaphore or pname:fence is
 signaled before using the presentable image.
 
@@ -923,10 +925,14 @@ succeeds, which the other physical device(s) can: wait upon.
     pname:swapchain must: not be in the retired state
   * [[VUID-VkAcquireNextImageInfoKHX-semaphore-01288]]
     If pname:semaphore is not dlink:VK_NULL_HANDLE it must: be unsignaled
+  * If pname:semaphore is not dlink:VK_NULL_HANDLE it must: not have any
+    uncompleted signal or wait operations pending
   * [[VUID-VkAcquireNextImageInfoKHX-fence-01289]]
     If pname:fence is not dlink:VK_NULL_HANDLE it must: be unsignaled and
     must: not be associated with any other queue command that has not yet
     completed execution on that queue
+  * pname:semaphore and pname:fence must: not both be equal to
+    dlink:VK_NULL_HANDLE
   * [[VUID-VkAcquireNextImageInfoKHX-deviceMask-01290]]
     pname:deviceMask must: be a valid device mask
   * [[VUID-VkAcquireNextImageInfoKHX-deviceMask-01291]]


### PR DESCRIPTION
Add to `vkAcquireNextImageKHR` and `VkAcquireNextImageInfoKHX` VUs:
- semaphore must not have pending ops
- app must use semaphore and/or fence