### PR TITLE
PR for automatic paired functions cross-referencing

### DIFF
--- a/doc/specs/vulkan/Makefile
+++ b/doc/specs/vulkan/Makefile
@@ -285,7 +285,7 @@ MANCOPYRIGHT = $(MANDIR)/copyright-ccby.txt $(MANDIR)/footer.txt
 # also generated, though they are not useable at present.
 
 LOGFILE = man/logfile
-man/apispec.txt: $(SPECFILES) genRef.py reflib.py vkapi.py
+man/apispec.txt: $(SPECFILES) genRef.py reflib.py vkapi.py config/vulkan-api-sorting.txt config/vulkan-api-tuples.txt
 	$(PYTHON) genRef.py -log $(LOGFILE) $(SPECFILES)
 
 # These dependencies don't take into account include directives

--- a/doc/specs/vulkan/chapters/pipelines.txt
+++ b/doc/specs/vulkan/chapters/pipelines.txt
@@ -107,7 +107,7 @@ an entry point from a shader module, where that entry point defines a valid
 compute shader, in the sname:VkPipelineShaderStageCreateInfo structure
 contained within the sname:VkComputePipelineCreateInfo structure.
 
-[open,refpage='vkCreateComputePipelines',desc='Creates a new compute pipeline object',type='protos']
+[open,refpage='vkCreateComputePipelines',desc='Creates a new compute pipeline object',type='protos',xrefs='vkDestroyPipeline']
 --
 
 To create compute pipelines, call:
@@ -363,7 +363,7 @@ include::../api/enums/VkShaderStageFlagBits.txt[]
 Graphics pipelines consist of multiple shader stages, multiple
 fixed-function pipeline stages, and a pipeline layout.
 
-[open,refpage='vkCreateGraphicsPipelines',desc='Create graphics pipelines',type='protos']
+[open,refpage='vkCreateGraphicsPipelines',desc='Create graphics pipelines',type='protos',xrefs='vkDestroyPipeline']
 --
 
 To create graphics pipelines, call:
@@ -1020,7 +1020,7 @@ pipeline has valid Tessellation Control and Tessellation Evaluation shaders.
 [[pipelines-destruction]]
 == Pipeline destruction
 
-[open,refpage='vkDestroyPipeline',desc='Destroy a pipeline object',type='protos']
+[open,refpage='vkDestroyPipeline',desc='Destroy a pipeline object',type='protos',xrefs='vkCreateComputePipelines vkCreateGraphicsPipelines']
 --
 
 To destroy a graphics or compute pipeline, call:

--- a/doc/specs/vulkan/config/vulkan-api-sorting.txt
+++ b/doc/specs/vulkan/config/vulkan-api-sorting.txt
@@ -9,4 +9,10 @@ vkCreate
 vkDestroy
 vkAllocate
 vkFree
+vkBegin
+vkEnd
+vkCmdBegin
+vkCmdEnd
+vkMap
+vkUnmap
 *

--- a/doc/specs/vulkan/config/vulkan-api-sorting.txt
+++ b/doc/specs/vulkan/config/vulkan-api-sorting.txt
@@ -1,0 +1,12 @@
+// This file contains API prefixes sorting order.
+//
+// If a function with matching prefix  is present in the references list, it
+// will be sorted according to the prefixes order. Within the prefix, functions
+// are sorted alphabetically.
+// * means 'all other functions', i.e. function didn't match any prefixes
+// listed.
+vkCreate
+vkDestroy
+vkAllocate
+vkFree
+*

--- a/doc/specs/vulkan/config/vulkan-api-tuples.txt
+++ b/doc/specs/vulkan/config/vulkan-api-tuples.txt
@@ -1,0 +1,12 @@
+// This file contains related API tuples.
+//
+// For a function that has prefix that belongs to the tuple, function name
+// will be transformed with all other members of the tuple will automatically
+// be added to the 'See Also' list.
+// Tuples separators are empty strings.
+// Example: for vkCreateFence, vkDestroyFence will automatically be added.
+vkCreate
+vkDestroy
+   
+vkAllocate
+vkFree

--- a/doc/specs/vulkan/config/vulkan-api-tuples.txt
+++ b/doc/specs/vulkan/config/vulkan-api-tuples.txt
@@ -10,3 +10,12 @@ vkDestroy
    
 vkAllocate
 vkFree
+
+vkBegin
+vkEnd
+
+vkCmdBegin
+vkCmdEnd
+
+vkMap
+vkUnmap

--- a/doc/specs/vulkan/genRef.py
+++ b/doc/specs/vulkan/genRef.py
@@ -73,7 +73,7 @@ def macroPrefix(name):
 # Vulkan entity 'name', based on the relationship mapping in vkapi.py and
 # the additional references in explicitRefs. If no relationships are
 # available, return None.
-def seeAlsoList(apiName, explicitRefs = None):
+def seeAlsoList(apiName, explicitRefs = None, refSettings = None):
     refs = {}
 
     # Add all the implicit references to refs
@@ -86,32 +86,39 @@ def seeAlsoList(apiName, explicitRefs = None):
         for name in explicitRefs.split():
             refs[name] = None
 
-    # Check if the apiName belongs to one of the predefined pairs
-    # If it does, auto-generate matching pairApiName
-    def checkAddPair(apiName, srcApiPrefix, dstApiPrefix, refs):
-        srcApiPrefixLen = len(srcApiPrefix)
-        if apiName[:srcApiPrefixLen] == srcApiPrefix:
-            pairApiName = dstApiPrefix+apiName[srcApiPrefixLen:]
-            if pairApiName in mapDict.keys():
-                refs[pairApiName] = None
+    if refSettings:
+        # Check if the apiName belongs to one of the predefined prefixes
+        # If it does, auto-generate matching pairApiName for every
+        # other prefix in dstApiPrefixes
+        def checkAddPairs(apiName, srcApiPrefix, dstApiPrefixes, refs):
+            srcApiPrefixLen = len(srcApiPrefix)
+            if apiName[:srcApiPrefixLen] == srcApiPrefix:
+                for dstApiPrefix in dstApiPrefixes:
+                    if dstApiPrefix == srcApiPrefix:
+                        continue
+                    pairApiName = dstApiPrefix+apiName[srcApiPrefixLen:]
+                    if pairApiName in mapDict.keys():
+                        refs[pairApiName] = None
 
-    refPairs = [('vkCreate', 'vkDestroy'), ('vkAllocate','vkFree')]
-    for refPairF0, refPairF1 in refPairs:
-        checkAddPair(apiName, refPairF0, refPairF1, refs)
-        checkAddPair(apiName, refPairF1, refPairF0, refs)
+        refTuples = refSettings['tuples']
+        for refTuple in refTuples:
+            for refPrefix in refTuple:
+                checkAddPairs(apiName, refPrefix, refTuple, refs)
 
-    # Define prefixes that will be proiritized in the "See Also" list
-    priorityPrefixes = ['vkCreate', 'vkDestroy', 'vkAllocate','vkFree']
-    def priorityKeyMod(key):
-        priorityPrefix_idx = -1
-        for pPrefixIdx, pPrefix in enumerate(priorityPrefixes):
-            if key[:len(pPrefix)] == pPrefix:
-                priorityPrefix_idx = pPrefixIdx
+        # Define prefixes that will be proiritized in the "See Also" list
+        priorityPrefixes = refSettings['sorting']
+        def priorityKeyMod(key):
+            priorityPrefix_idx = -1
+            for pPrefixIdx, pPrefix in enumerate(priorityPrefixes):
+                if key[:len(pPrefix)] == pPrefix:
+                    priorityPrefix_idx = pPrefixIdx
 
-        if (priorityPrefix_idx != -1):
-            key_mod = " %03d%s" % (priorityPrefix_idx, key)
-            return key_mod
-        else:
+            if (priorityPrefix_idx == -1):
+                priorityPrefix_idx = priorityPrefixes.index('*')
+
+            return "%03d%s" % (priorityPrefix_idx, key)
+    else:
+        def priorityKeyMod(key):
             return key
 
     names = [macroPrefix(name) for name in sorted(refs.keys(), key=priorityKeyMod)]
@@ -246,7 +253,8 @@ def refPageTail(pageName, seeAlso, fp, auto = False):
 #   specDir - directory extracted page source came from
 #   pi - pageInfo for this page relative to file
 #   file - list of strings making up the file, indexed by pi
-def emitPage(baseDir, specDir, pi, file):
+#   refSettings - settings for the references section
+def emitPage(baseDir, specDir, pi, file, refSettings):
     pageName = baseDir + '/' + pi.name + '.txt'
     fp = open(pageName, 'w', encoding='utf-8')
 
@@ -295,7 +303,7 @@ def emitPage(baseDir, specDir, pi, file):
                 field, fieldText,
                 descText,
                 fp)
-    refPageTail(pi.name, seeAlsoList(pi.name, pi.refs), fp, auto = False)
+    refPageTail(pi.name, seeAlsoList(pi.name, pi.refs, refSettings), fp, auto = False)
     fp.close()
 
 # Autogenerate a single reference page in baseDir
@@ -303,7 +311,8 @@ def emitPage(baseDir, specDir, pi, file):
 #   baseDir - base directory to emit page into
 #   pi - pageInfo for this page relative to file
 #   file - list of strings making up the file, indexed by pi
-def autoGenEnumsPage(baseDir, pi, file):
+#   refSettings - settings for the references section
+def autoGenEnumsPage(baseDir, pi, file, refSettings):
     pageName = baseDir + '/' + pi.name + '.txt'
     fp = open(pageName, 'w', encoding='utf-8')
 
@@ -338,7 +347,7 @@ def autoGenEnumsPage(baseDir, pi, file):
                 None, None,
                 txt,
                 fp)
-    refPageTail(pi.name, seeAlsoList(pi.name, pi.refs), fp, auto = True)
+    refPageTail(pi.name, seeAlsoList(pi.name, pi.refs, refSettings), fp, auto = True)
     fp.close()
 
 # Pattern to break apart a Vk*Flags{authorID} name, used in autoGenFlagsPage.
@@ -347,7 +356,8 @@ flagNamePat = re.compile('(?P<name>\w+)Flags(?P<author>[A-Z]*)')
 # Autogenerate a single reference page in baseDir for a Vk*Flags type
 #   baseDir - base directory to emit page into
 #   flagName - Vk*Flags name
-def autoGenFlagsPage(baseDir, flagName):
+#   refSettings - settings for the references section
+def autoGenFlagsPage(baseDir, flagName, refSettings):
     pageName = baseDir + '/' + flagName + '.txt'
     fp = open(pageName, 'w', encoding='utf-8')
 
@@ -387,15 +397,16 @@ def autoGenFlagsPage(baseDir, flagName):
                 None, None,
                 txt,
                 fp)
-    refPageTail(flagName, seeAlsoList(flagName), fp, auto = True)
+    refPageTail(flagName, seeAlsoList(flagName, refSettings=refSettings), fp, auto = True)
     fp.close()
 
 # Autogenerate a single handle page in baseDir for a Vk* handle type
 #   baseDir - base directory to emit page into
 #   handleName - Vk* handle name
+#   refSettings - settings for the references section
 # @@ Need to determine creation function & add handles/ include for the
 # @@ interface in generator.py.
-def autoGenHandlePage(baseDir, handleName):
+def autoGenHandlePage(baseDir, handleName, refSettings):
     pageName = baseDir + '/' + handleName + '.txt'
     fp = open(pageName, 'w', encoding='utf-8')
 
@@ -420,14 +431,14 @@ def autoGenHandlePage(baseDir, handleName):
                 None, None,
                 descText,
                 fp)
-    refPageTail(handleName, seeAlsoList(handleName), fp, auto = True)
+    refPageTail(handleName, seeAlsoList(handleName, refSettings=refSettings), fp, auto = True)
     fp.close()
 
 # Extract reference pages from a spec asciidoc source file
 #   specFile - filename to extract from
 #   baseDir - output directory to generate page in
-#
-def genRef(specFile, baseDir):
+#   refSettings - settings for the references section
+def genRef(specFile, baseDir, refSettings):
     file = loadFile(specFile)
     if file == None:
         return
@@ -454,11 +465,11 @@ def genRef(specFile, baseDir):
             logDiag('genRef:', pi.name + ':', pi.Warning)
 
         if pi.extractPage:
-            emitPage(baseDir, specDir, pi, file)
+            emitPage(baseDir, specDir, pi, file, refSettings)
         elif pi.type == 'enums':
-            autoGenEnumsPage(baseDir, pi, file)
+            autoGenEnumsPage(baseDir, pi, file, refSettings)
         elif pi.type == 'flags':
-            autoGenFlagsPage(baseDir, pi.name)
+            autoGenFlagsPage(baseDir, pi.name, refSettings)
         else:
             # Don't extract this page
             logWarn('genRef: Cannot extract or autogenerate:', pi.name)
@@ -536,6 +547,23 @@ def genSinglePageRef(baseDir):
     body.close()
     fp.close()
 
+def purify_text_lines(lines):
+    # Remove comment lines starting with //
+    # Remove leading and trailing whitespaces along the way
+    pure_lines = [line.strip() for line in lines if line[:2] != '//']
+    return pure_lines
+
+def get_api_touples_list(pure_content):
+    pairs = []
+    pairs.append(())
+    for line in pure_content:
+        if line:
+            pairs[-1] += (line,)
+        else:
+            # Empty line - new tuple should be started
+            pairs.append(())
+    return pairs
+
 if __name__ == '__main__':
     global genDict
     genDict = {}
@@ -565,8 +593,15 @@ if __name__ == '__main__':
 
     baseDir = results.baseDir
 
+    # Read 'See Also ' section genRef settings: API tuples and sorting
+    vk_api_sorting = purify_text_lines(loadFile('config/vulkan-api-sorting.txt'))
+    if not vk_api_sorting:
+        vk_api_sorting = ['*']
+    vk_api_tuples = get_api_touples_list(purify_text_lines(loadFile('config/vulkan-api-tuples.txt')))
+    vk_api_settings = {'tuples': vk_api_tuples, 'sorting': vk_api_sorting}
+
     for file in results.files:
-        genRef(file, baseDir)
+        genRef(file, baseDir, vk_api_settings)
 
     # Now figure out which pages *weren't* generated from the spec.
     # This relies on the dictionaries of API constructs in vkapi.py.
@@ -577,7 +612,7 @@ if __name__ == '__main__':
             if not (page in genDict.keys()):
                 logWarn('Autogenerating flags page:', page,
                         'which should be included in the spec')
-                autoGenFlagsPage(baseDir, page)
+                autoGenFlagsPage(baseDir, page, vk_api_settings)
 
         # autoGenHandlePage is no longer needed because they are added to
         # the spec sources now.

--- a/doc/specs/vulkan/genRef.py
+++ b/doc/specs/vulkan/genRef.py
@@ -86,7 +86,35 @@ def seeAlsoList(apiName, explicitRefs = None):
         for name in explicitRefs.split():
             refs[name] = None
 
-    names = [macroPrefix(name) for name in sorted(refs.keys())]
+    # Check if the apiName belongs to one of the predefined pairs
+    # If it does, auto-generate matching pairApiName
+    def checkAddPair(apiName, srcApiPrefix, dstApiPrefix, refs):
+        srcApiPrefixLen = len(srcApiPrefix)
+        if apiName[:srcApiPrefixLen] == srcApiPrefix:
+            pairApiName = dstApiPrefix+apiName[srcApiPrefixLen:]
+            if pairApiName in mapDict.keys():
+                refs[pairApiName] = None
+
+    refPairs = [('vkCreate', 'vkDestroy'), ('vkAllocate','vkFree')]
+    for refPairF0, refPairF1 in refPairs:
+        checkAddPair(apiName, refPairF0, refPairF1, refs)
+        checkAddPair(apiName, refPairF1, refPairF0, refs)
+
+    # Define prefixes that will be proiritized in the "See Also" list
+    priorityPrefixes = ['vkCreate', 'vkDestroy', 'vkAllocate','vkFree']
+    def priorityKeyMod(key):
+        priorityPrefix_idx = -1
+        for pPrefixIdx, pPrefix in enumerate(priorityPrefixes):
+            if key[:len(pPrefix)] == pPrefix:
+                priorityPrefix_idx = pPrefixIdx
+
+        if (priorityPrefix_idx != -1):
+            key_mod = " %03d%s" % (priorityPrefix_idx, key)
+            return key_mod
+        else:
+            return key
+
+    names = [macroPrefix(name) for name in sorted(refs.keys(), key=priorityKeyMod)]
     if len(names) > 0:
         return ', '.join(names) + '\n'
     else:


### PR DESCRIPTION
Originally defined in issue #608
**Short description**:
1. Two config files added: `doc/specs/vulkan/config/vulkan-api-tuples.txt` and `doc/specs/vulkan/config/vulkan-api-sorting.txt`.
2. `vulkan-api-tuples.txt` defines paired functions, pairs delimiter is empty string.
3. `vulkan-api-sorting.txt` defines the order how prefixes appear in the cross-references list, `*` (meaning "any other function) denotes place where functions that didn't match any prefix go; function keep case-sensitive alphabetical order within the prefix, as it was prior to this change.
4.  `doc/specs/vulkan/genRef.py` is modified to read, process and apply data supplied by the two config files mentioned.
5. `doc/specs/vulkan/Makefile` modified to have the config files as dependencies, to facilitate rebuild when config files changed
6. `doc/specs/vulkan/chapters/pipelines.txt` modified to have explicit cross references, due to the way paired functions are named: (vkCreateComputePipelines, vkCreateGraphicsPipelines) vs vkDestroyPipeline.


The idea behind this way of implementing the cross-references is [in this comment](https://github.com/KhronosGroup/Vulkan-Docs/issues/608#issuecomment-342226603).

There is a problem with pairing functions, provided by extensions (e.g. `vkCreateSwapchainKHR` vs `vkDestroySwapchainKHR`) - they are NOT automatically generated. Manual cross-referencing won't work too, because `doc/specs/vulkan/vkapi.py` simply doesn't have anything but the core functions, hence auto-cross-reference validation will fail and functions won't appear on the reference list. Manual referencing via adding `xref` - won't work either, because `macroPrefix` function in `doc/specs/vulkan/genRef.py` will not recognize the reference properly and return **"UNKNOWN"** prefix. Hence, in this revision paired extension functions do not get cross-references.