### PR TITLE
Add compatibility with C++ `module` keyword

### DIFF
--- a/doc/specs/vulkan/registry.txt
+++ b/doc/specs/vulkan/registry.txt
@@ -466,6 +466,9 @@ contain several semantic tags:
     succeed. Builtin C types should not be wrapped in tag:type tags.
   * The tag:name tag is required, and contains the struct/union member
     name being described.
+  ** attr:cppcompatname is optional tag:name attribute. It contains
+     alternative name to be used if there is a collision with C++ standard
+     keywords.
   * The tag:enum tag is optional. It contains text which is a valid
     enumerant name found in another tag:type tag, and indicates that this
     enumerant must be previously defined for the definition of the command

--- a/src/spec/Makefile
+++ b/src/spec/Makefile
@@ -39,7 +39,7 @@ OUTDIR	= ../../out/1.0
 # clean - remove installed and intermediate files.
 
 VULKAN	    = ../vulkan
-HEADERS     = $(VULKAN)/vulkan.h
+HEADERS     = $(VULKAN)/vulkan.h $(VULKAN)/vulkan.cppcompat.h
 EXTLOADER   = ../ext_loader
 EXTSRCS     = $(EXTLOADER)/vulkan_ext.c
 
@@ -54,6 +54,9 @@ VKH_DEPENDS = vk.xml genvk.py reg.py generator.py
 
 $(VULKAN)/vulkan.h: $(VKH_DEPENDS)
 	$(PYTHON) genvk.py -registry vk.xml -o $(VULKAN) vulkan.h
+
+$(VULKAN)/vulkan.cppcompat.h: $(VKH_DEPENDS)
+	$(PYTHON) genvk.py -registry vk.xml -o $(VULKAN) vulkan.cppcompat.h
 
 # Verify registry XML file against the schema
 validate:

--- a/src/spec/cppcompatgenerator.py
+++ b/src/spec/cppcompatgenerator.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2013-2017 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os,re,sys
+from generator import *
+
+# CppcompatGeneratorOptions - subclass of GeneratorOptions.
+#
+# Adds options used by CppcompatOutputGenerator objects during C++
+# compatibility header generation.
+#
+# Additional members
+#   vulkanHeaderFile - Filename of the Vulkan header
+class CppcompatGeneratorOptions(GeneratorOptions):
+    """Represents options during C interface generation for headers"""
+    def __init__(self,
+                 filename = None,
+                 directory = '.',
+                 apiname = None,
+                 profile = None,
+                 versions = '.*',
+                 emitversions = '.*',
+                 defaultExtensions = None,
+                 addExtensions = None,
+                 removeExtensions = None,
+                 sortProcedure = regSortFeatures,
+                 vulkanHeaderFile = ""):
+        GeneratorOptions.__init__(self, filename, directory, apiname, profile,
+                                  versions, emitversions, defaultExtensions,
+                                  addExtensions, removeExtensions, sortProcedure)
+        self.vulkanHeaderFile = vulkanHeaderFile
+
+# CppcompatOutputGenerator - subclass of OutputGenerator.
+# Generates C++ compatibility wrapper for Vulkan header
+#
+# ---- methods ----
+# COutputGenerator(errFile, warnFile, diagFile) - args as for
+#   OutputGenerator. Defines additional internal state.
+# ---- methods overriding base class ----
+# beginFile(genOpts)
+# endFile()
+# beginFeature(interface, emit)
+# endFeature()
+# genType(typeinfo,name)
+# genStruct(typeinfo,name)
+# genGroup(groupinfo,name)
+# genEnum(enuminfo, name)
+# genCmd(cmdinfo)
+class CppcompatOutputGenerator(OutputGenerator):
+    """Generate specified API interfaces in a specific style, such as a C header"""
+    # This is an ordered list of sections in the header file.
+    TYPE_SECTIONS = ['include', 'define', 'basetype', 'handle', 'enum',
+                     'group', 'bitmask', 'funcpointer', 'struct']
+    ALL_SECTIONS = TYPE_SECTIONS + ['commandPointer', 'command']
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
+        # Internal state - accumulators for different inner block text
+        self.sections = dict([(section, []) for section in self.ALL_SECTIONS])
+    #
+    def beginFile(self, genOpts):
+        OutputGenerator.beginFile(self, genOpts)
+
+        headerSym = re.sub('\.h', '_h_', os.path.basename(self.genOpts.vulkanHeaderFile)).upper()
+        cppCompatHeaderSym = os.path.basename(self.genOpts.filename).upper().replace('.', '_') + '_'
+        write('#ifndef', cppCompatHeaderSym, file=self.outFile)
+        write('#define', cppCompatHeaderSym, '1', file=self.outFile)
+        self.newline()
+        write('#ifdef', headerSym, file=self.outFile)
+        write('    #error vulkan.h included before vulkan.cppcompat.h! Do not mix use of '
+            + self.genOpts.vulkanHeaderFile + ' and ' + self.genOpts.filename + '!',
+            file=self.outFile)
+        write('#endif', file=self.outFile)
+        self.newline()
+    #
+    def endFile(self):
+        write('#include "' + self.genOpts.vulkanHeaderFile + '"', file=self.outFile)
+        self.newline()
+        write('#endif', file=self.outFile)
+
+        # Finish processing in superclass
+        OutputGenerator.endFile(self)
+    #
+    # Type generation
+    def genType(self, typeinfo, name):
+        OutputGenerator.genType(self, typeinfo, name)
+        typeElem = typeinfo.elem
+        # If the type is a struct type, traverse the imbedded <member> tags
+        # generating a structure. Otherwise, emit the tag text.
+        category = typeElem.get('category')
+        if (category == 'struct' or category == 'union'):
+            self.genStruct(typeinfo, name)
+    #
+    # Struct (e.g. C "struct" type) generation.
+    # This is a special case of the <type> tag where the contents are
+    # interpreted as a set of <member> tags instead of freeform C
+    # C type declarations. The <member> tags are just like <param>
+    # tags - they are a declaration of a struct or union member.
+    # Only simple member declarations are supported (no nested
+    # structs etc.)
+    def genStruct(self, typeinfo, typeName):
+        OutputGenerator.genStruct(self, typeinfo, typeName)
+        placeholderDef = ''
+
+        for member in typeinfo.elem.findall('.//member'):
+            for elem in member:
+                if (elem.tag == 'name' and elem.attrib.get('cppcompatname') is not None):
+                    placeholderMacro = self.toPlaceholderMacro(typeName, elem.text)
+                    compatName = elem.attrib.get('cppcompatname')
+                    placeholderDef += '#define ' + placeholderMacro + ' ' + compatName + '\n'
+        if placeholderDef:
+            write(placeholderDef, file=self.outFile)

--- a/src/spec/generator.py
+++ b/src/spec/generator.py
@@ -390,10 +390,13 @@ class OutputGenerator:
     # param - Element (<param> or <member>) to format
     # aligncol - if non-zero, attempt to align the nested <name> element
     #   at this column
-    def makeCParamDecl(self, param, aligncol):
+    def makeCParamDecl(self, param, aligncol, placeholderMacro = None):
         paramdecl = '    ' + noneStr(param.text)
         for elem in param:
             text = noneStr(elem.text)
+            if (elem.tag == 'name' and placeholderMacro is not None):
+                text = placeholderMacro
+
             tail = noneStr(elem.tail)
             if (elem.tag == 'name' and aligncol > 0):
                 self.logMsg('diag', 'Aligning parameter', elem.text, 'to column', self.genOpts.alignFuncParam)
@@ -504,4 +507,15 @@ class OutputGenerator:
 
     def setRegistry(self, registry):
         self.registry = registry
-        #
+    #
+    def toPlaceholderMacro(self, typeName, paramName):
+        nameMacro = re.findall('[a-z]+(?=[A-Z0-9]|$)', paramName)
+        nameMacro = [x.upper() for x in nameMacro]
+        nameMacro = '_'.join(nameMacro)
+
+        typeNameMacro = re.findall('[A-Z][^A-Z]*', typeName)
+        typeNameMacro = [x.upper() for x in typeNameMacro]
+        typeNameMacro = '_'.join(typeNameMacro)
+
+        macro = typeNameMacro + '_MEMBER_' + nameMacro + '_NAME'
+        return macro

--- a/src/spec/genvk.py
+++ b/src/spec/genvk.py
@@ -18,6 +18,7 @@ import argparse, cProfile, pdb, string, sys, time
 from reg import *
 from generator import write
 from cgenerator import CGeneratorOptions, COutputGenerator
+from cppcompatgenerator import CppcompatGeneratorOptions, CppcompatOutputGenerator
 from docgenerator import DocGeneratorOptions, DocOutputGenerator
 from extensionmetadocgenerator import ExtensionMetaDocGeneratorOptions, ExtensionMetaDocOutputGenerator
 from pygenerator import PyOutputGenerator
@@ -120,7 +121,24 @@ def makeGenOpts(extensions = [], removeExtensions = [], protect = True, director
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
             apientryp         = 'VKAPI_PTR *',
-            alignFuncParam    = 48)
+            alignFuncParam    = 48,
+            cppCompat         = True)
+        ]
+
+    # C++ and C++ experimental compatibility wrapper header
+    genOpts['vulkan.cppcompat.h'] = [
+          CppcompatOutputGenerator,
+          CppcompatGeneratorOptions(
+            filename          = 'vulkan.cppcompat.h',
+            directory         = directory,
+            apiname           = 'vulkan',
+            profile           = None,
+            versions          = allVersions,
+            emitversions      = allVersions,
+            defaultExtensions = 'vulkan',
+            addExtensions     = None,
+            removeExtensions  = None,
+            vulkanHeaderFile  = 'vulkan.h')
         ]
 
     # API include files for spec and ref pages

--- a/src/spec/registry.rnc
+++ b/src/spec/registry.rnc
@@ -159,7 +159,10 @@ Type = element type {
                 attribute values { text } ? ,
                 mixed {
                     element type { TypeName } ? ,
-                    element name { text } ,
+                    element name {
+                        attribute cppcompatname { text } ? ,
+                        text
+                    } ,
                     element enum { EnumName } ? ,
                     element comment { text } ?
                 }
@@ -275,6 +278,7 @@ Commands = element commands {
 #     noautovalidity - tag stating that no automatic validity language should be generated
 #     <type> is a <type> name, if present
 #     <name> is the function / parameter name
+#       cppcompatname - alternative name for C++ compatibility
 # The textual contents of <proto> and <param> should be legal C
 # for those parts of a function declaration.
 #   <alias> - denotes function aliasing, if present

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -902,7 +902,7 @@ private version is maintained in the 1.0 branch of the member gitlab server.
             <member>const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineShaderStageCreateFlags</type>    <name>flags</name></member>
             <member><type>VkShaderStageFlagBits</type>  <name>stage</name><comment>Shader stage</comment></member>
-            <member><type>VkShaderModule</type>         <name>module</name><comment>Module containing entry point</comment></member>
+            <member><type>VkShaderModule</type>         <name cppcompatname="shaderModule">module</name><comment>Module containing entry point</comment></member>
             <member len="null-terminated">const <type>char</type>*            <name>pName</name><comment>Null-terminated entry point name</comment></member>
             <member optional="true">const <type>VkSpecializationInfo</type>* <name>pSpecializationInfo</name></member>
         </type>

--- a/src/vulkan/vulkan.cppcompat.h
+++ b/src/vulkan/vulkan.cppcompat.h
@@ -1,0 +1,12 @@
+#ifndef VULKAN_CPPCOMPAT_H_
+#define VULKAN_CPPCOMPAT_H_ 1
+
+#ifdef VULKAN_H_
+    #error vulkan.h included before vulkan.cppcompat.h! Do not mix use of vulkan.h and vulkan.cppcompat.h!
+#endif
+
+#define VK_PIPELINE_SHADER_STAGE_CREATE_INFO_MEMBER_MODULE_NAME shaderModule
+
+#include "vulkan.h"
+
+#endif

--- a/src/vulkan/vulkan.h
+++ b/src/vulkan/vulkan.h
@@ -2005,12 +2005,15 @@ typedef struct VkSpecializationInfo {
     const void*                        pData;
 } VkSpecializationInfo;
 
+#ifndef VK_PIPELINE_SHADER_STAGE_CREATE_INFO_MEMBER_MODULE_NAME
+    #define VK_PIPELINE_SHADER_STAGE_CREATE_INFO_MEMBER_MODULE_NAME module
+#endif
 typedef struct VkPipelineShaderStageCreateInfo {
     VkStructureType                     sType;
     const void*                         pNext;
     VkPipelineShaderStageCreateFlags    flags;
     VkShaderStageFlagBits               stage;
-    VkShaderModule                      module;
+    VkShaderModule                      VK_PIPELINE_SHADER_STAGE_CREATE_INFO_MEMBER_MODULE_NAME;
     const char*                         pName;
     const VkSpecializationInfo*         pSpecializationInfo;
 } VkPipelineShaderStageCreateInfo;


### PR DESCRIPTION
Add compatibility with C++ `module` keyword as required by issue #568 .

User wishing to use experimental modules support in compiler can use alternative (wrapper) header `vulkan.cppcompat.h` and access the member as `shaderModule`.

Alternativelly he can provide `VK_PIPELINE_SHADER_STAGE_CREATE_INFO_MEMBER_MODULE_NAME` directly himself before first including `vulkan.h`. But I am not sure such use should be encouraged...