### PR TITLE
Added some constants for working with vkCmdUpdateBuffer to prevent magic constants in user code

### DIFF
--- a/doc/specs/vulkan/chapters/clears.txt
+++ b/doc/specs/vulkan/chapters/clears.txt
@@ -495,13 +495,13 @@ include::../api/protos/vkCmdUpdateBuffer.txt[]
     recorded.
   * pname:dstBuffer is a handle to the buffer to be updated.
   * pname:dstOffset is the byte offset into the buffer to start updating,
-    and must: be a multiple of 4.
+    and must: be a multiple of ename:VK_UPDATE_BUFFER_OFFSET_ALIGNMENT.
   * pname:dataSize is the number of bytes to update, and must: be a multiple
-    of 4.
+    of ename:VK_UPDATE_BUFFER_SIZE_MULTIPLE.
   * pname:pData is a pointer to the source data for the buffer update, and
     must: be at least pname:dataSize bytes in size.
 
-pname:dataSize must: be less than or equal to 65536 bytes.
+pname:dataSize must: be less than or equal to ename:VK_UPDATE_BUFFER_MAX_SIZE bytes.
 For larger updates, applications can: use buffer to buffer
 <<copies-buffers,copies>>.
 
@@ -547,11 +547,11 @@ fname:vkCmdUpdateBuffer.
     If pname:dstBuffer is non-sparse then it must: be bound completely and
     contiguously to a single sname:VkDeviceMemory object
   * [[VUID-vkCmdUpdateBuffer-dstOffset-00036]]
-    pname:dstOffset must: be a multiple of `4`
+    pname:dstOffset must: be a multiple of `ename:VK_UPDATE_BUFFER_OFFSET_ALIGNMENT`
   * [[VUID-vkCmdUpdateBuffer-dataSize-00037]]
-    pname:dataSize must: be less than or equal to `65536`
+    pname:dataSize must: be less than or equal to `ename:VK_UPDATE_BUFFER_MAX_SIZE`
   * [[VUID-vkCmdUpdateBuffer-dataSize-00038]]
-    pname:dataSize must: be a multiple of `4`
+    pname:dataSize must: be a multiple of `ename:VK_UPDATE_BUFFER_SIZE_MULTIPLE`
 ****
 
 include::../validity/protos/vkCmdUpdateBuffer.txt[]

--- a/src/spec/vk.xml
+++ b/src/spec/vk.xml
@@ -2668,6 +2668,9 @@ private version is maintained in the 1.0 branch of the member gitlab server.
         <enum value="(~0U)" name="VK_QUEUE_FAMILY_IGNORED"/>
         <enum value="(~0U-1)" name="VK_QUEUE_FAMILY_EXTERNAL_KHR"/>
         <enum value="(~0U)" name="VK_SUBPASS_EXTERNAL"/>
+        <enum value="65536"    name="VK_UPDATE_BUFFER_MAX_SIZE"/>        
+        <enum value="4"    name="VK_UPDATE_BUFFER_SIZE_MULTIPLE"/>
+        <enum value="4"    name="VK_UPDATE_BUFFER_OFFSET_ALIGNMENT"/>
         <enum value="32"    name="VK_MAX_DEVICE_GROUP_SIZE_KHX"/>
     </enums>
 


### PR DESCRIPTION
It appears that there are 3 different constants that come in to play when calling vkCmdUpdateBuffer that are mentioned in the spec. It would be really nice if there were defines in vulkan.h corresponding to these constants.

I may have missed updating some part of the spec / the naming might not be what we'll agree upon but it's a bit odd that these values are hard-coded as-is in the spec so I created this PR to clean it up a bit.