### PR TITLE
Clean up VkViewport VU section

### DIFF
--- a/doc/specs/vulkan/chapters/vertexpostproc.txt
+++ b/doc/specs/vulkan/chapters/vertexpostproc.txt
@@ -680,32 +680,24 @@ The floating-point viewport bounds are represented with an
 
 .Valid Usage
 ****
-  * [[VUID-VkViewport-width-01227]]
-    pname:width must: be greater than `0.0` and less than or equal to
+  * pname:width must: be greater than `0.0`
+  * pname:width must: be less than or equal to
     sname:VkPhysicalDeviceLimits::pname:maxViewportDimensions[0]
-ifndef::VK_KHR_maintenance1[]
-  * [[VUID-VkViewport-height-01228]]
-    pname:height must: be greater than `0.0` and less than or equal to
+ifndef::VK_KHR_maintenance1,VK_AMD_negative_viewport_height[]
+  * pname:height must: be greater than `0.0`
+endif::VK_KHR_maintenance1,VK_AMD_negative_viewport_height[]
+  * The absolute value of pname:height must: be less than or equal to
     sname:VkPhysicalDeviceLimits::pname:maxViewportDimensions[1]
-endif::VK_KHR_maintenance1[]
-ifdef::VK_KHR_maintenance1[]
-  * [[VUID-VkViewport-height-01229]]
-    pname:height must: be greater than or equal to
-    -sname:VkPhysicalDeviceLimits::pname:maxViewportDimensions[1] and less
-    than or equal to
-    sname:VkPhysicalDeviceLimits::pname:maxViewportDimensions[1]
-endif::VK_KHR_maintenance1[]
-ifdef::VK_AMD_negative_viewport_height[]
-  * [[VUID-VkViewport-height-01230]]
-    If the +VK_AMD_negative_viewport_height+ extension is enabled,
-    pname:height can: also be negative.
-endif::VK_AMD_negative_viewport_height[]
-  * [[VUID-VkViewport-x-01231]]
-    pname:x and pname:y must: each be between pname:viewportBoundsRange[0]
-    and pname:viewportBoundsRange[1], inclusive
+  * pname:x must: be greater than or equal to pname:viewportBoundsRange[0]
   * [[VUID-VkViewport-x-01232]]
     [eq]#(pname:x {plus} pname:width)# must: be less than or equal to
     pname:viewportBoundsRange[1]
+  * pname:y must: be greater than or equal to pname:viewportBoundsRange[0]
+ifdef::VK_KHR_maintenance1,VK_AMD_negative_viewport_height[]
+  * pname:y must: be less than or equal to pname:viewportBoundsRange[1]
+  * [eq]#(pname:y {plus} pname:height)# must: be greater than or equal to
+    pname:viewportBoundsRange[0]
+endif::VK_KHR_maintenance1,VK_AMD_negative_viewport_height[]
   * [[VUID-VkViewport-y-01233]]
     [eq]#(pname:y {plus} pname:height)# must: be less than or equal to
     pname:viewportBoundsRange[1]


### PR DESCRIPTION
- fixes #622 
- fixes #584 

Should really say something like:

> - If `VK_KHR_maintenance1` or `VK_AMD_negative_viewport_height` is not enabled `height` **must** be greater than `0.0`
> - If `VK_EXT_depth_range_unrestricted` is not enabled `minDepth` **must** be between `0.0` and `1.0`, inclusive

but that's more of a systemic spec problem (#533)...