### PR TITLE
Cute up contact list

### DIFF
--- a/xml/extensionmetadocgenerator.py
+++ b/xml/extensionmetadocgenerator.py
@@ -248,6 +248,12 @@ class Extension:
         write('*Contact*::', file=fp)
         contacts = self.contact.split(',')
         for c in contacts:
+            # convert GitHub usernames to profile links
+            words = c.split();
+            for word in words:
+                if word[0] == '@':
+                    c = c.replace(word, 'link:https://github.com/' + word[1:] + '[' + word + ']')
+
             write('  * ' + c, file=fp)
 
         fp.close()


### PR DESCRIPTION
- <s>make it one contact person per line</s>
- make github handles links

ex #600.

BTW some contacts seem to be wrong. 
Some of those @ are possibly meant to be Twitter, rest I dunno.
Some don't have "sufficient contact" only name. Some don't have names...

- `@tobias` probably links to different person, I have seen him around as `TobiasHector`
- Jeff Bolz lists `jbolz`, but I seen him around as `jeffbolznv`
- `pdaniell` probably links to different person, I have seen him around as `pdaniell-nv`
- `johnk` probably links to different person, senn him as `johnkslang`
- Alexander lists @debater, but seems to be around as alegal-arm
- Courtney Goeltzenleuchter lists @courtney and @courtneygo, but seems to be around as courtney-lunarg
- Carsten Rohde has no contact
- dominik.witczak@amd.com does not have name
- baldurk@baldurk.org does not have name
- Dominik Witczak lists dead @dominikwitczak_amd, probably should be DominikWitczakAMD
- quentin.lin@amd.com does not have a name
- Matthaeus G. Chajdas seem to be misspelled
- @jaakko wrong person, probably jaakkowork?
