### PR TITLE
Refine swapchain association with surface

### DIFF
--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -23,8 +23,8 @@ presentation.
 An application renders to the image, and then queues the image for
 presentation to the surface.
 
-A native window cannot: be associated with more than one swapchain at a
-time.
+A native window cannot: be associated with more than one non-retired
+swapchain at a time.
 Further, swapchains cannot: be created for native windows that have a
 non-Vulkan graphics API surface associated with them.
 
@@ -338,8 +338,9 @@ ifdef::VK_VERSION_1_1,VK_KHR_device_group[]
     1, pname:flags must: not contain
     ename:VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR
 endif::VK_VERSION_1_1,VK_KHR_device_group[]
-  * [[VUID-VkSwapchainCreateInfoKHR-oldSwapchain-01674]]
-    pname:oldSwapchain must: not be in the retired state
+  * If pname:oldSwapchain is not dlink:VK_NULL_HANDLE, pname:oldSwapchain
+    must: be a non-retired swapchain associated with native window referred
+    to by pname:surface
   * [[VUID-VkSwapchainCreateInfoKHR-imageFormat-01778]]
     pname:imageFormat, pname:imageUsage, pname:imageExtent, and
     pname:imageArrayLayers must: be supported for ename:VK_IMAGE_TYPE_2D
@@ -454,14 +455,17 @@ endif::VK_VERSION_1_1,VK_KHR_device_group[]
 The pname:surface must: not be destroyed until after the swapchain is
 destroyed.
 
-If pname:oldSwapchain is not dlink:VK_NULL_HANDLE then pname:surface must:
-be associated with pname:oldSwapchain.
-Otherwise, the native window referred to by pname:surface must: not already
-be associated with another swapchain, and must: not already be associated
-with a non-Vulkan graphics API surface.
+If pname:oldSwapchain is dlink:VK_NULL_HANDLE, and the native window
+referred to by pname:surface is already associated with a Vulkan swapchain,
+ename:VK_ERROR_NATIVE_WINDOW_IN_USE_KHR must: be returned.
+
+If the native window referred to by pname:surface is already associated with
+a non-Vulkan graphics API surface, ename:VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+must: be returned.
+
 The native window referred to by pname:surface must: not become associated
-with a non-Vulkan graphics API surface before the swapchain has been
-destroyed.
+with a non-Vulkan graphics API surface before all associated Vulkan
+swapchains have been destroyed.
 
 Like core functions, several WSI functions, including
 fname:vkCreateSwapchainKHR return ename:VK_ERROR_DEVICE_LOST if the logical


### PR DESCRIPTION
- make **must** statement a proper VU
- fix sentence saying only one swapchain can be associated
- fix languge saying **must** not instead of **cannot**
- clarify all the cases when swapcahin cannot be created
- fixes #438