### PR TITLE
Cute up external extension links

### DIFF
--- a/doc/specs/vulkan/appendices/VK_AMD_gcn_shader.txt
+++ b/doc/specs/vulkan/appendices/VK_AMD_gcn_shader.txt
@@ -12,7 +12,7 @@ include::meta/VK_AMD_gcn_shader.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_gcn_shader.html[+SPV_AMD_gcn_shader+]
+  * <<SPV_AMD_gcn_shader>>
 
 ifdef::editing-notes[]
 [NOTE]
@@ -22,6 +22,12 @@ Shouldn't the SPV extension be in the Interactions and External Dependencies
 block?
 ==================
 endif::editing-notes[]
+
+=== References
+
+[[SPV_AMD_gcn_shader, SPV_AMD_gcn_shader]]
+_SPIR-V Extension SPV_AMD_gcn_shader_::
+https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_gcn_shader.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_AMD_gpu_shader_half_float.txt
+++ b/doc/specs/vulkan/appendices/VK_AMD_gpu_shader_half_float.txt
@@ -14,7 +14,7 @@ include::meta/VK_AMD_gpu_shader_half_float.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_gpu_shader_half_float.html[+SPV_AMD_gpu_shader_half_float+]
+  * <<SPV_AMD_gpu_shader_half_float>>
 
 ifdef::editing-notes[]
 [NOTE]
@@ -24,6 +24,12 @@ Shouldn't the SPV extension be in the Interactions and External Dependencies
 block?
 ==================
 endif::editing-notes[]
+
+=== References
+
+[[SPV_AMD_gpu_shader_half_float, SPV_AMD_gpu_shader_half_float]]
+_SPIR-V Extension SPV_AMD_gpu_shader_half_float_::
+https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_gpu_shader_half_float.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_AMD_gpu_shader_int16.txt
+++ b/doc/specs/vulkan/appendices/VK_AMD_gpu_shader_int16.txt
@@ -5,9 +5,7 @@ include::meta/VK_AMD_gpu_shader_int16.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - Requires the
-    https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_gpu_shader_int16.html[+SPV_AMD_gpu_shader_int16+]
-    SPIR-V extension.
+  - Requires the <<SPV_AMD_gpu_shader_int16>> SPIR-V extension.
 *Contributors*::
   - Daniel Rakos, AMD
   - Dominik Witczak, AMD
@@ -18,7 +16,13 @@ include::meta/VK_AMD_gpu_shader_int16.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * +SPV_AMD_gpu_shader_int16+
+  * <<SPV_AMD_gpu_shader_int16>>
+
+=== References
+
+[[SPV_AMD_gpu_shader_int16, SPV_AMD_gpu_shader_int16]]
+_SPIR-V Extension SPV_AMD_gpu_shader_int16_::
+https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_gpu_shader_int16.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_AMD_shader_ballot.txt
+++ b/doc/specs/vulkan/appendices/VK_AMD_shader_ballot.txt
@@ -14,7 +14,7 @@ include::meta/VK_AMD_shader_ballot.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_ballot.html[+SPV_AMD_shader_ballot+]
+  * <<SPV_AMD_shader_ballot>>
 
 ifdef::editing-notes[]
 [NOTE]
@@ -24,6 +24,12 @@ Shouldn't the SPV extension be in the Interactions and External Dependencies
 block?
 ==================
 endif::editing-notes[]
+
+=== References
+
+[[SPV_AMD_shader_ballot, SPV_AMD_shader_ballot]]
+_SPIR-V Extension SPV_AMD_shader_ballot_::
+https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_ballot.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_AMD_shader_explicit_vertex_parameter.txt
+++ b/doc/specs/vulkan/appendices/VK_AMD_shader_explicit_vertex_parameter.txt
@@ -13,7 +13,7 @@ include::meta/VK_AMD_shader_explicit_vertex_parameter.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_explicit_vertex_parameter.html[+SPV_AMD_shader_explicit_vertex_parameter+]
+  * <<SPV_AMD_shader_explicit_vertex_parameter>>
 
 ifdef::editing-notes[]
 [NOTE]
@@ -23,6 +23,12 @@ Shouldn't the SPV extension be in the Interactions and External Dependencies
 block?
 ==================
 endif::editing-notes[]
+
+=== References
+
+[[SPV_AMD_shader_explicit_vertex_parameter, SPV_AMD_shader_explicit_vertex_parameter]]
+_SPIR-V Extension SPV_AMD_shader_explicit_vertex_parameter_::
+https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_explicit_vertex_parameter.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_AMD_shader_fragment_mask.txt
+++ b/doc/specs/vulkan/appendices/VK_AMD_shader_fragment_mask.txt
@@ -5,9 +5,7 @@ include::meta/VK_AMD_shader_fragment_mask.txt[]
 *IP Status*::
     No known IP claims.
 *Dependencies*::
-  - Requires the
-    https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_fragment_mask.html[+SPV_AMD_shader_fragment_mask+]
-    SPIR-V extension.
+  - Requires the <<SPV_AMD_shader_fragment_mask>> SPIR-V extension.
 *Contributors*::
   - Aaron Hagan, AMD
   - Daniel Rakos, AMD
@@ -92,6 +90,12 @@ void main()
     fragColor = fragOne;
 }
 ----------------------------------------
+
+=== References
+
+[[SPV_AMD_shader_fragment_mask, SPV_AMD_shader_fragment_mask]]
+_SPIR-V Extension SPV_AMD_shader_fragment_mask_::
+https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_fragment_mask.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_AMD_shader_image_load_store_lod.txt
+++ b/doc/specs/vulkan/appendices/VK_AMD_shader_image_load_store_lod.txt
@@ -3,12 +3,10 @@ include::meta/VK_AMD_shader_image_load_store_lod.txt[]
 *Last Modified Date*::
     2017-08-21
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_image_load_store_lod.html[+SPV_AMD_shader_image_load_store_lod+]
+  - This extension requires the <<SPV_AMD_shader_image_load_store_lod>>
     SPIR-V extension.
-  - This extension requires
-    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_shader_image_load_store_lod.txt[+GL_AMD_shader_image_load_store_lod+]
-    for GLSL-based source languages.
+  - This extension requires <<GL_AMD_shader_image_load_store_lod>> for
+    GLSL-based source languages.
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -18,7 +16,17 @@ include::meta/VK_AMD_shader_image_load_store_lod.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-* https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_image_load_store_lod.html[+SPV_AMD_shader_image_load_store_lod+]
+* <<SPV_AMD_shader_image_load_store_lod>>
+
+=== References
+
+[[SPV_AMD_shader_image_load_store_lod, SPV_AMD_shader_image_load_store_lod]]
+_SPIR-V Extension SPV_AMD_shader_image_load_store_lod_::
+https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_image_load_store_lod.html
+
+[[GL_AMD_shader_image_load_store_lod, GL_AMD_shader_image_load_store_lod]]
+_GL_AMD_shader_image_load_store_lod_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_shader_image_load_store_lod.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_AMD_shader_trinary_minmax.txt
+++ b/doc/specs/vulkan/appendices/VK_AMD_shader_trinary_minmax.txt
@@ -13,7 +13,7 @@ include::meta/VK_AMD_shader_trinary_minmax.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_trinary_minmax.html[+SPV_AMD_shader_trinary_minmax+]
+  * <<SPV_AMD_shader_trinary_minmax>>
 
 ifdef::editing-notes[]
 [NOTE]
@@ -23,6 +23,12 @@ Shouldn't the SPV extension be in the Interactions and External Dependencies
 block?
 ==================
 endif::editing-notes[]
+
+=== References
+
+[[SPV_AMD_shader_trinary_minmax, SPV_AMD_shader_trinary_minmax]]
+_SPIR-V Extension SPV_AMD_shader_trinary_minmax_::
+https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_shader_trinary_minmax.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_AMD_texture_gather_bias_lod.txt
+++ b/doc/specs/vulkan/appendices/VK_AMD_texture_gather_bias_lod.txt
@@ -5,9 +5,7 @@ include::meta/VK_AMD_texture_gather_bias_lod.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - Requires the
-    https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_texture_gather_bias_lod.html[+SPV_AMD_texture_gather_bias_lod+]
-    SPIR-V extension.
+  - Requires the <<SPV_AMD_texture_gather_bias_lod>> SPIR-V extension.
 *Contributors*::
   - Dominik Witczak, AMD
   - Daniel Rakos, AMD
@@ -21,7 +19,7 @@ This extension adds two related features.
 
 Firstly, support for the following SPIR-V extension in Vulkan is added:
 
-  * +SPV_AMD_texture_gather_bias_lod+
+  * <<SPV_AMD_texture_gather_bias_lod>>
 
 Secondly, the extension allows the application to query which formats can be
 used together with the new function prototypes introduced by the SPIR-V
@@ -97,6 +95,12 @@ else
     // specified format configuration.
 }
 --------------------------------------
+
+=== References
+
+[[SPV_AMD_texture_gather_bias_lod, SPV_AMD_texture_gather_bias_lod]]
+_SPIR-V Extension SPV_AMD_texture_gather_bias_lod_::
+https://www.khronos.org/registry/spir-v/extensions/AMD/SPV_AMD_texture_gather_bias_lod.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_EXT_post_depth_coverage.txt
+++ b/doc/specs/vulkan/appendices/VK_EXT_post_depth_coverage.txt
@@ -3,20 +3,16 @@ include::meta/VK_EXT_post_depth_coverage.txt[]
 *Last Modified Date*::
     2017-07-17
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_post_depth_coverage.html[+SPV_KHR_post_depth_coverage+]
-    SPIR-V extension.
-  - This extension requires
-    https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_post_depth_coverage.txt[+GL_ARB_post_depth_coverage+]
-    or
-    https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_post_depth_coverage.txt[+GL_EXT_post_depth_coverage+]
-    for GLSL-based source languages.
+  - This extension requires the <<SPV_KHR_post_depth_coverage>> SPIR-V
+    extension.
+  - This extension requires <<GL_ARB_post_depth_coverage>> or
+    <<GL_EXT_post_depth_coverage>> for GLSL-based source languages.
 *Contributors*::
   - Jeff Bolz, NVIDIA
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * +SPV_KHR_post_depth_coverage+
+  * <<SPV_KHR_post_depth_coverage>>
 
 which allows the fragment shader to control whether values in the
 code:SampleMask built-in input variable reflect the coverage after the
@@ -32,8 +28,8 @@ tests>> are applied.
 Otherwise, it reflects the coverage before the depth and stencil tests.
 
 When using GLSL source-based shading languages, the code:post_depth_coverage
-layout qualifier from GL_ARB_post_depth_coverage or
-GL_EXT_post_depth_coverage maps to the code:PostDepthCoverage execution
+layout qualifier from <<GL_ARB_post_depth_coverage>> or
+<<GL_EXT_post_depth_coverage>>  maps to the code:PostDepthCoverage execution
 mode.
 
 === New Object Types
@@ -71,6 +67,20 @@ None.
 === Issues
 
 None yet.
+
+=== References
+
+[[SPV_KHR_post_depth_coverage, SPV_KHR_post_depth_coverage]]
+_SPIR-V Extension SPV_KHR_post_depth_coverage_::
+https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_post_depth_coverage.html
+
+[[GL_ARB_post_depth_coverage, GL_ARB_post_depth_coverage]]
+_GL_ARB_post_depth_coverage_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_post_depth_coverage.txt
+
+[[GL_EXT_post_depth_coverage, GL_EXT_post_depth_coverage]]
+_GL_EXT_post_depth_coverage_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_post_depth_coverage.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_EXT_shader_stencil_export.txt
+++ b/doc/specs/vulkan/appendices/VK_EXT_shader_stencil_export.txt
@@ -5,19 +5,23 @@ include::meta/VK_EXT_shader_stencil_export.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - Requires the
-    https://www.khronos.org/registry/spir-v/extensions/EXT/SPV_EXT_shader_stencil_export.html[+SPV_EXT_shader_stencil_export+]
-    SPIR-V extension.
+  - Requires the <<SPV_EXT_shader_stencil_export>> SPIR-V extension.
 *Contributors*::
   - Dominik Witczak, AMD
   - Daniel Rakos, AMD
   - Rex Xu, AMD
 
 This extension adds support for the SPIR-V extension
-+SPV_EXT_shader_stencil_export+, providing a mechanism whereby a shader may
-generate the stencil reference value per invocation.
+<<SPV_EXT_shader_stencil_export>>, providing a mechanism whereby a shader
+may generate the stencil reference value per invocation.
 When stencil testing is enabled, this allows the test to be performed
 against the value generated in the shader.
+
+=== References
+
+[[SPV_EXT_shader_stencil_export, SPV_EXT_shader_stencil_export]]
+_SPIR-V Extension SPV_EXT_shader_stencil_export_::
+https://www.khronos.org/registry/spir-v/extensions/EXT/SPV_EXT_shader_stencil_export.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_EXT_shader_subgroup_ballot.txt
+++ b/doc/specs/vulkan/appendices/VK_EXT_shader_subgroup_ballot.txt
@@ -5,12 +5,9 @@ include::meta/VK_EXT_shader_subgroup_ballot.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_shader_ballot.html[+SPV_KHR_shader_ballot+]
-    SPIR-V extension.
-  - This extension requires the
-    https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_ballot.txt[+GL_ARB_shader_ballot+]
-    extension for GLSL source languages.
+  - This extension requires the <<SPV_KHR_shader_ballot>> SPIR-V extension.
+  - This extension requires the <<GL_ARB_shader_ballot>> extension for GLSL
+    source languages.
 *Contributors*::
   - Jeff Bolz, NVIDIA
   - Neil Henning, Codeplay
@@ -18,7 +15,7 @@ include::meta/VK_EXT_shader_subgroup_ballot.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * +SPV_KHR_shader_ballot+
+  * <<SPV_KHR_shader_ballot>>
 
 This extension provides the ability for a group of invocations, which
 execute in parallel, to do limited forms of cross-invocation communication
@@ -50,7 +47,7 @@ Additionally, this extension provides access to the new SPIR-V instructions:
   * code:OpSubgroupReadInvocationKHR,
 
 When using GLSL source-based shader languages, the following variables and
-shader functions from GL_ARB_shader_ballot can map to these SPIR-V built-in
+shader functions from <<SPV_KHR_shader_ballot>> map to these SPIR-V built-in
 decorations and instructions:
 
   * `in uint64_t gl_SubGroupEqMaskARB;` -> code:SubgroupEqMaskKHR,
@@ -101,6 +98,16 @@ None.
 === Issues
 
 None.
+
+=== References
+
+[[SPV_KHR_shader_ballot, SPV_KHR_shader_ballot]]
+_SPIR-V Extension SPV_KHR_shader_ballot_::
+https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_shader_ballot.html
+
+[[GL_ARB_shader_ballot, GL_ARB_shader_ballot]]
+_GL_ARB_shader_ballot_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_ballot.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_EXT_shader_subgroup_vote.txt
+++ b/doc/specs/vulkan/appendices/VK_EXT_shader_subgroup_vote.txt
@@ -5,19 +5,16 @@ include::meta/VK_EXT_shader_subgroup_vote.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_subgroup_vote.html[+SPV_KHR_subgroup_vote+]
-    SPIR-V extension.
-  - This extension requires the
-    https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_group_vote.txt[+GL_ARB_shader_group_vote+]
-    extension for GLSL source languages.
+  - This extension requires the <<SPV_KHR_subgroup_vote>> SPIR-V extension.
+  - This extension requires the <<GL_ARB_shader_group_vote>> extension for
+    GLSL source languages.
 *Contributors*::
   - Neil Henning, Codeplay
   - Daniel Koch, NVIDIA Corporation
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * +SPV_KHR_subgroup_vote+
+  * <<SPV_KHR_subgroup_vote>>
 
 This extension provides new SPIR-V instructions:
 
@@ -31,7 +28,7 @@ These composite results may be used to execute shaders more efficiently on a
 slink:VkPhysicalDevice.
 
 When using GLSL source-based shader languages, the following shader
-functions from GL_ARB_shader_group_vote can map to these SPIR-V
+functions from <<GL_ARB_shader_group_vote>> map to these SPIR-V
 instructions:
 
   * code:anyInvocationARB() -> code:OpSubgroupAnyKHR,
@@ -125,6 +122,16 @@ None.
 === Issues
 
 None.
+
+=== References
+
+[[SPV_KHR_subgroup_vote, SPV_KHR_subgroup_vote]]
+_SPIR-V Extension SPV_KHR_subgroup_vote_::
+https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_subgroup_vote.html
+
+[[GL_ARB_shader_group_vote, GL_ARB_shader_group_vote]]
+_GL_ARB_shader_group_vote_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_group_vote.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_EXT_shader_viewport_index_layer.txt
+++ b/doc/specs/vulkan/appendices/VK_EXT_shader_viewport_index_layer.txt
@@ -3,16 +3,11 @@ include::meta/VK_EXT_shader_viewport_index_layer.txt[]
 *Last Modified Date*::
     2017-08-08
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/EXT/SPV_EXT_shader_viewport_index_layer.html[+SPV_EXT_shader_viewport_index_layer+]
+  - This extension requires the <<SPV_EXT_shader_viewport_index_layer>>
     SPIR-V extension.
-  - This extension requires the
-    https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_viewport_layer_array.txt[+GL_ARB_shader_viewport_layer_array+],
-    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_vertex_shader_layer.txt[+GL_AMD_vertex_shader_layer+],
-    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_vertex_shader_viewport_index.txt[+GL_AMD_vertex_shader_viewport_index+],
-    or
-    https://www.khronos.org/registry/OpenGL/extensions/NV/NV_viewport_array2.txt[+GL_NV_viewport_array2+]
-    extensions for GLSL source languages.
+  - This extension requires the <<GL_ARB_shader_viewport_layer_array>>,
+    <<GL_AMD_vertex_shader_layer>>, <<GL_AMD_vertex_shader_viewport_index>>,
+    or <<GL_NV_viewport_array2>> extensions for GLSL source languages.
   - This extension requires the pname:multiViewport feature.
   - This extension interacts with the pname:tessellationShader feature.
 *Contributors*::
@@ -23,7 +18,7 @@ include::meta/VK_EXT_shader_viewport_index_layer.txt[]
   - Slawomir Grajeswki, Intel
 
 This extension adds support for the code:ShaderViewportIndexLayerEXT
-capability from the +SPV_EXT_shader_viewport_index_layer+ extension in
+capability from the <<SPV_EXT_shader_viewport_index_layer>> extension in
 Vulkan.
 
 This extension allows variables decorated with the code:Layer and
@@ -34,9 +29,9 @@ When using GLSL source-based shading languages, the code:gl_ViewportIndex
 and code:gl_Layer built-in variables map to the SPIR-V code:ViewportIndex
 and code:Layer built-in decorations, respectively.
 Behaviour of these variables is extended as described in the
-+GL_ARB_shader_viewport_layer_array+ (or the precursor
-+GL_AMD_vertex_shader_layer+, +GL_AMD_vertex_shader_viewport_index+, and
-+GL_NV_viewport_array2 extensions+).
+<<GL_ARB_shader_viewport_layer_array>> (or the precursor
+<<GL_AMD_vertex_shader_layer>>, <<GL_AMD_vertex_shader_viewport_index>>,
+and <<GL_NV_viewport_array2>> extensions).
 
 ifdef::VK_NV_viewport_array2[]
 [NOTE]
@@ -85,6 +80,30 @@ None.
 === Issues
 
 None yet!
+
+=== References
+
+[[SPV_EXT_shader_viewport_index_layer, SPV_EXT_shader_viewport_index_layer]]
+_SPIR-V Extension SPV_EXT_shader_viewport_index_layer_::
+https://www.khronos.org/registry/spir-v/extensions/EXT/SPV_EXT_shader_viewport_index_layer.html
+
+[[GL_ARB_shader_viewport_layer_array, GL_ARB_shader_viewport_layer_array]]
+_GL_ARB_shader_viewport_layer_array_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_viewport_layer_array.txt
+
+[[GL_AMD_vertex_shader_layer, GL_AMD_vertex_shader_layer]]
+_GL_AMD_vertex_shader_layer_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_vertex_shader_layer.txt
+
+[[GL_AMD_vertex_shader_viewport_index, GL_AMD_vertex_shader_viewport_index]]
+_GL_AMD_vertex_shader_viewport_index_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_vertex_shader_viewport_index.txt
+
+ifndef::VK_NV_viewport_array2[]
+[[GL_NV_viewport_array2, GL_NV_viewport_array2]]
+_GL_NV_viewport_array2_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/NV/NV_viewport_array2.txt
+endif::VK_NV_viewport_array2[]
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_GOOGLE_display_timing.txt
+++ b/doc/specs/vulkan/appendices/VK_GOOGLE_display_timing.txt
@@ -76,6 +76,12 @@ https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/dem
 ).
 ====
 
+=== References
+
+[[clock_gettime(2), clock_gettime(2)]]
+_Linux Programmer's Manual -- CLOCK_GETRES(2)_::
+http://man7.org/linux/man-pages/man2/clock_gettime.2.html
+
 === Version History
 
  * Revision 1, 2017-02-14 (Ian Elliott)

--- a/doc/specs/vulkan/appendices/VK_KHR_16bit_storage.txt
+++ b/doc/specs/vulkan/appendices/VK_KHR_16bit_storage.txt
@@ -5,8 +5,7 @@
 include::meta/VK_KHR_16bit_storage.txt[]
 
 *Interactions and External Dependencies*::
-  - This extension requires
-    https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_16bit_storage.html[+SPV_KHR_16bit_storage+]
+  - This extension requires <<SPV_KHR_16bit_storage>>
 *Last Modified Date*::
     2017-03-23
 *IP Status*::
@@ -48,6 +47,12 @@ assignment and component assignment rules.
   * <<spirvenv-capabilities-table-16bitstorage,code:StorageInputOutput16>>
 
 === Issues
+
+=== References
+
+[[SPV_KHR_16bit_storage, SPV_KHR_16bit_storage]]
+_SPIR-V Extension SPV_KHR_16bit_storage_::
+https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_16bit_storage.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_KHR_incremental_present.txt
+++ b/doc/specs/vulkan/appendices/VK_KHR_incremental_present.txt
@@ -27,7 +27,7 @@ small portion of the presentable images within a swapchain, since it enables
 the presentation engine to avoid wasting time presenting parts of the
 surface that haven't changed.
 
-This extension is leveraged from the +EGL_KHR_swap_buffers_with_damage+
+This extension is leveraged from the <<EGL_KHR_swap_buffers_with_damage>>
 extension.
 
 === New Object Types
@@ -96,6 +96,12 @@ The presentation engine may use such a hint and not update any pixels for
 the swapchain.
 However, all other semantics of flink:vkQueuePresentKHR must still be
 honored, including waiting for semaphores to signal.
+
+=== References
+
+[[EGL_KHR_swap_buffers_with_damage, EGL_KHR_swap_buffers_with_damage]]
+_EGL_KHR_swap_buffers_with_damage_ specification::
+https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_swap_buffers_with_damage.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_KHR_shader_draw_parameters.txt
+++ b/doc/specs/vulkan/appendices/VK_KHR_shader_draw_parameters.txt
@@ -9,12 +9,8 @@ include::meta/VK_KHR_shader_draw_parameters.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - Requires the
-    https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_shader_draw_parameters.html[+SPV_KHR_shader_draw_parameters+]
-    SPIR-V extension.
-  - Requires
-    https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_draw_parameters.txt[+GL_ARB_shader_draw_parameters+]
-    for GLSL source languages.
+  - Requires the <<SPV_KHR_shader_draw_parameters>> SPIR-V extension.
+  - Requires <<GL_ARB_shader_draw_parameters>> for GLSL source languages.
 *Contributors*::
   - Daniel Koch, NVIDIA Corporation
   - Jeff Bolz, NVIDIA
@@ -25,7 +21,7 @@ include::meta/VK_KHR_shader_draw_parameters.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * +SPV_KHR_shader_draw_parameters+
+  * <<SPV_KHR_shader_draw_parameters>>
 
 The extension provides access to three additional built-in shader variables
 in Vulkan:
@@ -38,7 +34,7 @@ in Vulkan:
     being processed from an indirect draw call.
 
 When using GLSL source-based shader languages, the following variables from
-+GL_ARB_shader_draw_parameters+ can map to these SPIR-V built-in
+<<GL_ARB_shader_draw_parameters>> can map to these SPIR-V built-in
 decorations:
 
   * `in int gl_BaseInstanceARB;` -> code:BaseInstance,
@@ -77,12 +73,12 @@ None.
 
 === Issues
 
-1) Is this the same functionality as +GL_ARB_shader_draw_parameters+?
+1) Is this the same functionality as <<GL_ARB_shader_draw_parameters>>?
 
 *RESOLVED*: It's actually a superset as it also adds in support for arrayed
 drawing commands.
 
-In GL for +GL_ARB_shader_draw_parameters+, code:gl_BaseVertexARB holds the
+In GL for <<GL_ARB_shader_draw_parameters>>, code:gl_BaseVertexARB holds the
 integer value passed to the parameter to the command that resulted in the
 current shader invocation.
 In the case where the command has no code:baseVertex parameter, the value of
@@ -95,6 +91,16 @@ code:baseVertex parameter.
 Now in Vulkan, we have code:BaseVertex = pname:vertexOffset (for indexed
 drawing commands) or pname:firstVertex (for arrayed drawing commands), and
 so Vulkan's version is really a superset of GL functionality.
+
+=== References
+
+[[SPV_KHR_shader_draw_parameters, SPV_KHR_shader_draw_parameters]]
+_SPIR-V Extension SPV_KHR_shader_draw_parameters_::
+https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_shader_draw_parameters.html
+
+[[GL_ARB_shader_draw_parameters, GL_ARB_shader_draw_parameters]]
+_GL_ARB_shader_draw_parameters_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_draw_parameters.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_KHR_storage_buffer_storage_class.txt
+++ b/doc/specs/vulkan/appendices/VK_KHR_storage_buffer_storage_class.txt
@@ -9,8 +9,7 @@ include::meta/VK_KHR_storage_buffer_storage_class.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_storage_buffer_storage_class.html[+SPV_KHR_storage_buffer_storage_class+]
+  - This extension requires the <<SPV_KHR_storage_buffer_storage_class>>
     SPIR-V extension.
 *Contributors*::
   - Alexander Galazin, ARM
@@ -18,7 +17,7 @@ include::meta/VK_KHR_storage_buffer_storage_class.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * +SPV_KHR_storage_buffer_storage_class+
+  * <<SPV_KHR_storage_buffer_storage_class>>
 
 This extension provides a new SPIR-V code:StorageBuffer storage class.
 A code:Block-decorated object in this class is equivalent to a
@@ -35,6 +34,12 @@ None.
 === Issues
 
 None.
+
+=== References
+
+[[SPV_KHR_storage_buffer_storage_class, SPV_KHR_storage_buffer_storage_class]]
+_SPIR-V Extension SPV_KHR_storage_buffer_storage_class_::
+https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_storage_buffer_storage_class.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_KHR_variable_pointers.txt
+++ b/doc/specs/vulkan/appendices/VK_KHR_variable_pointers.txt
@@ -9,9 +9,7 @@ include::meta/VK_KHR_variable_pointers.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - Requires the
-    https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_variable_pointers.html[+SPV_KHR_variable_pointers+]
-    SPIR-V extension.
+  - Requires the <<SPV_KHR_variable_pointers>> SPIR-V extension.
 *Contributors*::
   - John Kessenich, Google
   - Neil Henning, Codeplay
@@ -24,12 +22,13 @@ include::meta/VK_KHR_variable_pointers.txt[]
   - Jesse Hall, Google
 
 The `VK_KHR_variable_pointers` extension allows implementations to indicate
-their level of support for the +SPV_KHR_variable_pointers+ SPIR-V extension.
+their level of support for the <<SPV_KHR_variable_pointers>> SPIR-V
+extension.
 The SPIR-V extension allows shader modules to use invocation-private
 pointers into uniform and/or storage buffers, where the pointer values can
 be dynamic and non-uniform.
 
-The +SPV_KHR_variable_pointers+ extension introduces two capabilities.
+The <<SPV_KHR_variable_pointers>> extension introduces two capabilities.
 The first, code:VariablePointersStorageBuffer, must: be supported by all
 implementations of this extension.
 The second, code:VariablePointers, is optional.
@@ -70,6 +69,12 @@ supported in all stages.
 
 *RESOLVED*: Features, primarily for consistency with other similar
 extensions.
+
+=== References
+
+[[SPV_KHR_variable_pointers, SPV_KHR_variable_pointers]]
+_SPIR-V Extension SPV_KHR_variable_pointers_::
+https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_variable_pointers.html
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_KHX_multiview.txt
+++ b/doc/specs/vulkan/appendices/VK_KHX_multiview.txt
@@ -11,7 +11,7 @@ include::meta/VK_KHX_multiview.txt[]
 *Contributors*::
   - Jeff Bolz, NVIDIA
 
-This extension has the same goal as the OpenGL ES +GL_OVR_multiview+
+This extension has the same goal as the OpenGL ES <<GL_OVR_multiview>>
 extension - it enables rendering to multiple "`views`" by recording a single
 set of commands to be executed with slightly different behavior for each
 view.
@@ -61,6 +61,12 @@ None.
 === Examples
 
 None.
+
+=== References
+
+[[GL_OVR_multiview, GL_OVR_multiview]]
+_GL_OVR_multiview_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/OVR/OVR_multiview.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_NVX_multiview_per_view_attributes.txt
+++ b/doc/specs/vulkan/appendices/VK_NVX_multiview_per_view_attributes.txt
@@ -5,10 +5,9 @@ include::meta/VK_NVX_multiview_per_view_attributes.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/NV/SPV_NVX_multiview_per_view_attributes.html[+SPV_NVX_multiview_per_view_attributes+]
+  - This extension requires the <<SPV_NVX_multiview_per_view_attributes>>
     SPIR-V extension.
-  - This extension requires the +GL_NVX_multiview_per_view_attributes+
+  - This extension requires the <<GL_NVX_multiview_per_view_attributes>>
     extension for GLSL source languages.
   - This extension interacts with <<VK_NV_viewport_array2>>.
 *Contributors*::
@@ -18,8 +17,8 @@ include::meta/VK_NVX_multiview_per_view_attributes.txt[]
 This extension adds a new way to write shaders to be used with multiview
 subpasses, where the attributes for all views are written out by a single
 invocation of the vertex processing stages.
-Related SPIR-V and GLSL extensions +SPV_NVX_multiview_per_view_attributes+
-and +GL_NVX_multiview_per_view_attributes+ introduce per-view position and
+Related SPIR-V and GLSL extensions <<SPV_NVX_multiview_per_view_attributes>>
+and <<GL_NVX_multiview_per_view_attributes>> introduce per-view position and
 viewport mask attributes arrays, and this extension defines how those
 per-view attribute arrays are interpreted by Vulkan.
 Pipelines using per-view attributes may: only execute the vertex processing
@@ -105,6 +104,16 @@ void main()
 
 ---------------------------------------------------
 
+
+=== References
+
+[[SPV_NVX_multiview_per_view_attributes, SPV_NVX_multiview_per_view_attributes]]
+_SPIR-V Extension SPV_NVX_multiview_per_view_attributes_::
+https://www.khronos.org/registry/spir-v/extensions/NV/SPV_NVX_multiview_per_view_attributes.html
+
+[[GL_NVX_multiview_per_view_attributes, GL_NVX_multiview_per_view_attributes]]
+_GL_NVX_multiview_per_view_attributes_ specification::
+https://www.khronos.org/registry/vulkan/specs/misc/GL_NVX_multiview_per_view_attributes.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_NV_framebuffer_mixed_samples.txt
+++ b/doc/specs/vulkan/appendices/VK_NV_framebuffer_mixed_samples.txt
@@ -23,7 +23,7 @@ where triangles share edges and may: not be suitable for normal triangle
 mesh rendering.
 
 One expected use case for this functionality is Stencil-then-Cover path
-rendering (similar to the OpenGL GL_NV_path_rendering extension).
+rendering (similar to the OpenGL <<GL_NV_path_rendering>> extension).
 The stencil step determines the coverage (in the stencil buffer) for an
 entire path at the higher sample frequency, and then the cover step draws
 the path into the lower frequency color buffer using the coverage
@@ -69,6 +69,12 @@ None.
 === Issues
 
 None.
+
+=== References
+
+[[GL_NV_path_rendering, GL_NV_path_rendering]]
+_GL_NV_path_rendering_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/NV/NV_path_rendering.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_NV_geometry_shader_passthrough.txt
+++ b/doc/specs/vulkan/appendices/VK_NV_geometry_shader_passthrough.txt
@@ -3,11 +3,9 @@ include::meta/VK_NV_geometry_shader_passthrough.txt[]
 *Last Modified Date*::
     2017-02-15
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/NV/SPV_NV_geometry_shader_passthrough.html[+SPV_NV_geometry_shader_passthrough+]
+  - This extension requires the <<SPV_NV_geometry_shader_passthrough>>
     SPIR-V extension.
-  - This extension requires the
-    https://www.khronos.org/registry/OpenGL/extensions/NV/NV_geometry_shader_passthrough.txt[+GL_NV_geometry_shader_passthrough+]
+  - This extension requires the <<GL_NV_geometry_shader_passthrough>>
     extension for GLSL source languages.
   - This extension requires the pname:geometryShader feature.
 *Contributors*::
@@ -16,7 +14,7 @@ include::meta/VK_NV_geometry_shader_passthrough.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * +SPV_NV_geometry_shader_passthrough+
+  * <<SPV_NV_geometry_shader_passthrough>>
 
 Geometry shaders provide the ability for applications to process each
 primitive sent through the graphics pipeline using a programmable shader.
@@ -34,12 +32,12 @@ Adding this to a geometry shader input variable indicates that the values of
 this input are copied to the corresponding vertex of the output primitive.
 
 When using GLSL source-based shading languages, the code:passthrough layout
-qualifier from +GL_NV_geometry_shader_passthrough+ maps to the
+qualifier from <<GL_NV_geometry_shader_passthrough>> maps to the
 code:PassthroughNV decoration.
 To use the code:passthrough layout, in GLSL the
-+GL_NV_geometry_shader_passthrough+ extension must be enabled.
-Behaviour is described in the +GL_NV_geometry_shader_passthrough+ extension
-specification.
+<<GL_NV_geometry_shader_passthrough>> extension must be enabled.
+Behaviour is described in the <<GL_NV_geometry_shader_passthrough>>
+extension specification.
 
 === New Object Types
 
@@ -81,7 +79,7 @@ output layout qualifiers for the output primitive type and maximum vertex
 count in the SPIR-V?
 
 *RESOLVED*: Yes they should be required in the SPIR-V.
-Per GL_NV_geometry_shader_passthrough they are not permitted in the GLSL
+Per <<GL_NV_geometry_shader_passthrough>> they are not permitted in the GLSL
 source shader, but SPIR-V is lower-level.
 It is straightforward for the GLSL compiler to infer them from the input
 primitive type and to explicitly emit them in the SPIR-V according to the
@@ -177,6 +175,15 @@ void main()
 }
 ---------------------------------------------------
 
+=== References
+
+[[SPV_NV_geometry_shader_passthrough, SPV_NV_geometry_shader_passthrough]]
+_SPIR-V Extension SPV_NV_geometry_shader_passthrough_::
+https://www.khronos.org/registry/spir-v/extensions/NV/SPV_NV_geometry_shader_passthrough.html
+
+[[GL_NV_geometry_shader_passthrough, GL_NV_geometry_shader_passthrough]]
+_GL_NV_geometry_shader_passthrough_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/NV/NV_geometry_shader_passthrough.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_NV_glsl_shader.txt
+++ b/doc/specs/vulkan/appendices/VK_NV_glsl_shader.txt
@@ -7,7 +7,7 @@ include::meta/VK_NV_glsl_shader.txt[]
 *Contributors*::
   - Piers Daniell, NVIDIA
 
-This extension allows GLSL shaders written to the +GL_KHR_vulkan_glsl+
+This extension allows GLSL shaders written to the <<GL_KHR_vulkan_glsl>>
 extension specification to be used instead of SPIR-V.
 The implementation will automatically detect whether the shader is SPIR-V or
 GLSL, and compile it appropriately.
@@ -52,6 +52,12 @@ Passing in GLSL code
     VkShaderModule vertexShader;
     vkCreateShaderModule(device, &vertexShaderInfo, 0, &vertexShader);
 ----------------------------------------
+
+=== References
+
+[[GL_KHR_vulkan_glsl, GL_KHR_vulkan_glsl]]
+_GL_KHR_vulkan_glsl_ specification::
+https://www.khronos.org/registry/vulkan/specs/misc/GL_KHR_vulkan_glsl.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_NV_sample_mask_override_coverage.txt
+++ b/doc/specs/vulkan/appendices/VK_NV_sample_mask_override_coverage.txt
@@ -5,11 +5,9 @@ include::meta/VK_NV_sample_mask_override_coverage.txt[]
 *IP Status*::
     No known IP claims.
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/NV/SPV_NV_sample_mask_override_coverage.html[+SPV_NV_sample_mask_override_coverage+]
+  - This extension requires the <<SPV_NV_sample_mask_override_coverage>>
     SPIR-V extension.
-  - This extension requires the
-    https://www.khronos.org/registry/OpenGL/extensions/NV/NV_sample_mask_override_coverage.txt[+GL_NV_sample_mask_override_coverage+]
+  - This extension requires the <<GL_NV_sample_mask_override_coverage>>
     extension for GLSL source languages.
 *Contributors*::
   - Daniel Koch, NVIDIA
@@ -17,7 +15,7 @@ include::meta/VK_NV_sample_mask_override_coverage.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * +SPV_NV_sample_mask_override_coverage+
+  * <<SPV_NV_sample_mask_override_coverage>>
 
 The extension provides access to the code:OverrideCoverageNV decoration
 under the code:SampleMaskOverrideCoverageNV capability.
@@ -26,12 +24,12 @@ decoration allows the shader to modify the coverage mask and affect which
 samples are used to process the fragment.
 
 When using GLSL source-based shader languages, the code:override_coverage
-layout qualifier from +GL_NV_sample_mask_override_coverage+ maps to the
+layout qualifier from <<GL_NV_sample_mask_override_coverage>> maps to the
 code:OverrideCoverageNV decoration.
 To use the code:override_coverage layout qualifier in GLSL the
-+GL_NV_sample_mask_override_coverage+ extension must be enabled.
-Behavior is described in the +GL_NV_sample_mask_override_coverage+ extension
-spec.
+<<GL_NV_sample_mask_override_coverage>> extension must be enabled.
+Behavior is described in the <<GL_NV_sample_mask_override_coverage>>
+extension spec.
 
 === New Object Types
 
@@ -69,6 +67,16 @@ None.
 === Issues
 
 None.
+
+=== References
+
+[[SPV_NV_sample_mask_override_coverage, SPV_NV_sample_mask_override_coverage]]
+_SPIR-V Extension SPV_NV_sample_mask_override_coverage_::
+https://www.khronos.org/registry/spir-v/extensions/NV/SPV_NV_sample_mask_override_coverage.html
+
+[[GL_NV_sample_mask_override_coverage, GL_NV_sample_mask_override_coverage]]
+_GL_NV_sample_mask_override_coverage_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/NV/NV_sample_mask_override_coverage.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/VK_NV_viewport_array2.txt
+++ b/doc/specs/vulkan/appendices/VK_NV_viewport_array2.txt
@@ -3,12 +3,9 @@ include::meta/VK_NV_viewport_array2.txt[]
 *Last Modified Date*::
     2017-02-15
 *Interactions and External Dependencies*::
-  - This extension requires the
-    https://www.khronos.org/registry/spir-v/extensions/NV/SPV_NV_viewport_array2.html[+SPV_NV_viewport_array2+]
-    SPIR-V extension.
-  - This extension requires the
-    https://www.khronos.org/registry/OpenGL/extensions/NV/NV_viewport_array2.txt[+GL_NV_viewport_array2+]
-    extension for GLSL source languages.
+  - This extension requires the <<SPV_NV_viewport_array2>> SPIR-V extension.
+  - This extension requires the <<GL_NV_viewport_array2>> extension for GLSL
+    source languages.
   - This extension requires the pname:geometryShader and pname:multiViewport
     features.
   - This extension interacts with the pname:tessellationShader feature.
@@ -18,7 +15,7 @@ include::meta/VK_NV_viewport_array2.txt[]
 
 This extension adds support for the following SPIR-V extension in Vulkan:
 
-  * +SPV_NV_viewport_array2+
+  * <<SPV_NV_viewport_array2>>
 
 which allows a single primitive to be broadcast to multiple viewports and/or
 multiple layers.
@@ -42,9 +39,9 @@ code:ShaderViewportMaskNV capability.
 
 When using GLSL source-based shading languages, the code:gl_ViewportMask[]
 built-in output variable and code:viewport_relative layout qualifier from
-+GL_NV_viewport_array2+ map to the code:ViewportMaskNV and
+<<GL_NV_viewport_array2>> map to the code:ViewportMaskNV and
 code:ViewportRelativeNV decorations, respectively.
-Behaviour is described in the +GL_NV_viewport_array2+ extension
+Behaviour is described in the <<GL_NV_viewport_array2>> extension
 specificiation.
 
 ifdef::VK_EXT_shader_viewport_index_layer[]
@@ -98,6 +95,16 @@ None.
 === Issues
 
 None yet!
+
+=== References
+
+[[SPV_NV_viewport_array2, SPV_NV_viewport_array2]]
+_SPIR-V Extension SPV_NV_viewport_array2_::
+https://www.khronos.org/registry/spir-v/extensions/NV/SPV_NV_viewport_array2.html
+
+[[GL_NV_viewport_array2, GL_NV_viewport_array2]]
+_GL_NV_viewport_array2_ specification::
+https://www.khronos.org/registry/OpenGL/extensions/NV/NV_viewport_array2.txt
 
 === Version History
 

--- a/doc/specs/vulkan/appendices/spirvenv.txt
+++ b/doc/specs/vulkan/appendices/spirvenv.txt
@@ -154,116 +154,112 @@ endif::VK_EXT_post_depth_coverage[]
 
 ifdef::VK_KHR_variable_pointers[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_KHR_variable_pointers+ SPIR-V extension.
+uses the <<SPV_KHR_variable_pointers>> SPIR-V extension.
 endif::VK_KHR_variable_pointers[]
 
 ifdef::VK_AMD_shader_explicit_vertex_parameter[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_AMD_shader_explicit_vertex_parameter+ SPIR-V extension.
+uses the <<SPV_AMD_shader_explicit_vertex_parameter>> SPIR-V extension.
 endif::VK_AMD_shader_explicit_vertex_parameter[]
 
 ifdef::VK_AMD_gcn_shader[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_AMD_gcn_shader+ SPIR-V extension.
+uses the <<SPV_AMD_gcn_shader>> SPIR-V extension.
 endif::VK_AMD_gcn_shader[]
 
 ifdef::VK_AMD_gpu_shader_half_float[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_AMD_gpu_shader_half_float+ SPIR-V extension.
+uses the <<SPV_AMD_gpu_shader_half_float>> SPIR-V extension.
 endif::VK_AMD_gpu_shader_half_float[]
 
 ifdef::VK_AMD_gpu_shader_int16[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_AMD_gpu_shader_int16+ SPIR-V extension.
+uses the <<SPV_AMD_gpu_shader_int16>> SPIR-V extension.
 endif::VK_AMD_gpu_shader_int16[]
 
 ifdef::VK_AMD_shader_ballot[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_AMD_shader_ballot+ SPIR-V extension.
+uses the <<SPV_AMD_shader_ballot>> SPIR-V extension.
 endif::VK_AMD_shader_ballot[]
 
 ifdef::VK_AMD_shader_fragment_mask[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_AMD_shader_fragment_mask+ SPIR-V extension.
+uses the <<SPV_AMD_shader_fragment_mask>> SPIR-V extension.
 endif::VK_AMD_shader_fragment_mask[]
 
 ifdef::VK_AMD_shader_image_load_store_lod[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_AMD_shader_image_load_store_lod+ SPIR-V extension.
+uses the <<SPV_AMD_shader_image_load_store_lod>> SPIR-V extension.
 endif::VK_AMD_shader_image_load_store_lod[]
 
 ifdef::VK_AMD_shader_trinary_minmax[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_AMD_shader_trinary_minmax+ SPIR-V extension.
+uses the <<SPV_AMD_shader_trinary_minmax>> SPIR-V extension.
 endif::VK_AMD_shader_trinary_minmax[]
 
 ifdef::VK_AMD_texture_gather_bias_lod[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_AMD_texture_gather_bias_lod+ SPIR-V extension.
+uses the <<SPV_AMD_texture_gather_bias_lod>> SPIR-V extension.
 endif::VK_AMD_texture_gather_bias_lod[]
 
 ifdef::VK_KHR_shader_draw_parameters[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_KHR_shader_draw_parameters+ SPIR-V extension.
+uses the <<SPV_KHR_shader_draw_parameters>> SPIR-V extension.
 endif::VK_KHR_shader_draw_parameters[]
 
 ifdef::VK_KHR_16bit_storage[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the
-https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_16bit_storage.html[+SPV_KHR_16bit_storage+]
-SPIR-V extension.
+uses the <<SPV_KHR_16bit_storage>> SPIR-V extension.
 endif::VK_KHR_16bit_storage[]
 
 ifdef::VK_KHR_storage_buffer_storage_class[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the
-https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_storage_buffer_storage_class.html[+SPV_KHR_storage_buffer_storage_class+]
-SPIR-V extension.
+uses the <<SPV_KHR_storage_buffer_storage_class>> SPIR-V extension.
 endif::VK_KHR_storage_buffer_storage_class[]
 
 ifdef::VK_EXT_post_depth_coverage[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_KHR_post_depth_coverage+ SPIR-V extension.
+uses the <<SPV_KHR_post_depth_coverage>> SPIR-V extension.
 endif::VK_EXT_post_depth_coverage[]
 
 ifdef::VK_EXT_shader_stencil_export[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_EXT_shader_stencil_export+ SPIR-V extension.
+uses the <<SPV_EXT_shader_stencil_export>> SPIR-V extension.
 endif::VK_EXT_shader_stencil_export[]
 
 ifdef::VK_EXT_shader_subgroup_ballot[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_KHR_shader_ballot+ SPIR-V extension.
+uses the <<SPV_KHR_shader_ballot>> SPIR-V extension.
 endif::VK_EXT_shader_subgroup_ballot[]
 
 ifdef::VK_EXT_shader_subgroup_vote[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_KHR_subgroup_vote+ SPIR-V extension.
+uses the <<SPV_KHR_subgroup_vote>> SPIR-V extension.
 endif::VK_EXT_shader_subgroup_vote[]
 
 ifdef::VK_NV_sample_mask_override_coverage[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_NV_sample_mask_override_coverage+ SPIR-V extension.
+uses the <<SPV_NV_sample_mask_override_coverage>> SPIR-V extension.
 endif::VK_NV_sample_mask_override_coverage[]
 
 ifdef::VK_NV_geometry_shader_passthrough[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_NV_geometry_shader_passthrough+ SPIR-V extension.
+uses the <<SPV_NV_geometry_shader_passthrough>> SPIR-V extension.
 endif::VK_NV_geometry_shader_passthrough[]
 
 ifdef::VK_NV_viewport_array2[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_NV_viewport_array2+ SPIR-V extension.
+uses the <<SPV_NV_viewport_array2>> SPIR-V extension.
 endif::VK_NV_viewport_array2[]
 
 ifdef::VK_EXT_shader_viewport_index_layer[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_EXT_shader_viewport_index_layer+ SPIR-V extension.
+uses the <<SPV_EXT_shader_viewport_index_layer>> SPIR-V extension.
 endif::VK_EXT_shader_viewport_index_layer[]
 
 ifdef::VK_NVX_multiview_per_view_attributes[]
 The application can: pass a SPIR-V module to flink:vkCreateShaderModule that
-uses the +SPV_NVX_multiview_per_view_attributes+ SPIR-V extension.
+uses the <<SPV_NVX_multiview_per_view_attributes>> SPIR-V extension.
 endif::VK_NVX_multiview_per_view_attributes[]
 
 The application must: not pass a SPIR-V module containing any of the
@@ -352,8 +348,7 @@ ifdef::VK_KHR_16bit_storage[]
      can: be used for the code:FPRoundingMode decoration.
   ** The code:FPRoundingMode decoration can: only be used for the
      floating-point conversion instructions as described in the
-     https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_16bit_storage.html[+SPV_KHR_16bit_storage+]
-     SPIR-V extension.
+     <<SPV_KHR_16bit_storage>> SPIR-V extension.
 endif::VK_KHR_16bit_storage[]
   * code:OpTypeRuntimeArray must: only be used for the last member of an
     code:OpTypeStruct

--- a/doc/specs/vulkan/chapters/VK_GOOGLE_display_timing/PresentTimeInfo.txt
+++ b/doc/specs/vulkan/chapters/VK_GOOGLE_display_timing/PresentTimeInfo.txt
@@ -58,7 +58,7 @@ include::../../api/structs/VkPresentTimeGOOGLE.txt[]
     displayed to the user any earlier than this time.
     pname:desiredPresentTime is a time in nanoseconds, relative to a
     monotonically-increasing clock (e.g. `CLOCK_MONOTONIC` (see
-    clock_gettime(2)) on Android and Linux).
+    <<clock_gettime(2)>>) on Android and Linux).
     A value of zero indicates that the presentation engine may: display the
     image at any time.
     This is useful when the application desires to provide pname:presentID,

--- a/doc/specs/vulkan/chapters/VK_GOOGLE_display_timing/queries.txt
+++ b/doc/specs/vulkan/chapters/VK_GOOGLE_display_timing/queries.txt
@@ -125,7 +125,8 @@ available some time later.
 These time values can be asynchronously queried, and will be returned if
 available.
 All time values are in nanoseconds, relative to a monotonically-increasing
-clock (e.g. `CLOCK_MONOTONIC` (see clock_gettime(2)) on Android and Linux).
+clock (e.g. `CLOCK_MONOTONIC` (see <<clock_gettime(2)>>) on Android and
+Linux).
 
 To asynchronously query the presentation engine, for newly-available timing
 information about one or more previous presents to a given swapchain, call:

--- a/doc/specs/vulkan/chapters/features.txt
+++ b/doc/specs/vulkan/chapters/features.txt
@@ -769,7 +769,7 @@ structure describe the following features:
     pname:variablePointersStorageBuffer indicates whether the implementation
     supports the SPIR-V +VariablePointersStorageBuffer+ capability.
     When this feature is not enabled, shader modules must: not declare the
-    +SPV_KHR_variable_pointers+ extension or the
+    <<SPV_KHR_variable_pointers>> extension or the
     +VariablePointersStorageBuffer+ capability.
   * [[features-features-variablePointers]] pname:variablePointers indicates
     whether the implementation supports the SPIR-V +VariablePointers+

--- a/doc/specs/vulkan/chapters/shaders.txt
+++ b/doc/specs/vulkan/chapters/shaders.txt
@@ -122,7 +122,7 @@ ifdef::VK_NV_glsl_shader[]
   * [[VUID-VkShaderModuleCreateInfo-pCode-01377]]
     pname:pCode must: point to either valid SPIR-V code, formatted and
     packed as described by the <<spirv-spec,Khronos SPIR-V Specification>>
-    or valid GLSL code which must: be written to the +GL_KHR_vulkan_glsl+
+    or valid GLSL code which must: be written to the <<GL_KHR_vulkan_glsl>>
     extension specification
   * [[VUID-VkShaderModuleCreateInfo-pCode-01378]]
     If pname:pCode points to SPIR-V code, that code must: adhere to the
@@ -131,7 +131,7 @@ ifdef::VK_NV_glsl_shader[]
     <<spirvenv-capabilities,SPIR-V Environment>> appendix
   * [[VUID-VkShaderModuleCreateInfo-pCode-01379]]
     If pname:pCode points to GLSL code, it must: be valid GLSL code written
-    to the +GL_KHR_vulkan_glsl+ GLSL extension specification
+    to the <<GL_KHR_vulkan_glsl>> GLSL extension specification
 endif::VK_NV_glsl_shader[]
   * [[VUID-VkShaderModuleCreateInfo-pCode-01089]]
     pname:pCode must: declare the code:Shader capability for SPIR-V code


### PR DESCRIPTION
cont. #631 

- make external extensions links
- centralize external links as a references in appropriate extension appendices 
  

PS: I am not sure what the deal is with Asciidoc adding some "[]" around the links, so I am providing the explicit link names into the anchors(which seems to work).