### PR TITLE
Require instance extension dependencies on vkCreateDevice

### DIFF
--- a/doc/specs/vulkan/chapters/devsandqueues.txt
+++ b/doc/specs/vulkan/chapters/devsandqueues.txt
@@ -674,11 +674,15 @@ ename:VK_ERROR_TOO_MANY_OBJECTS.
 
 .Valid Usage
 ****
+  * All <<extended-functionality-extensions-dependencies, required instance
+    extensions>> of each extension in the
+    slink:VkDeviceCreateInfo::pname:ppEnabledExtensionNames list must:
+    already be enabled for slink:VkInstance parent of pname:physicalDevice
   * [[VUID-vkCreateDevice-ppEnabledExtensionNames-01387]]
-    All <<extended-functionality-extensions-dependencies, required
-    extensions>> for each extension in the
+    All <<extended-functionality-extensions-dependencies, required device
+    extensions>> of each extension in the
     slink:VkDeviceCreateInfo::pname:ppEnabledExtensionNames list must: also
-    be present in that list.
+    be present in that list
 ****
 
 include::../validity/protos/vkCreateDevice.txt[]


### PR DESCRIPTION
- add VU requiring `VkDeviceCreateInfo::ppEnabledExtensionNames` to have its instance extension dependencies met