### PR TITLE
Make VK_* constants into appropriate type

### DIFF
--- a/appendices/boilerplate.txt
+++ b/appendices/boilerplate.txt
@@ -292,7 +292,7 @@ handle.
 It may be passed to and returned from Vulkan commands only when
 <<fundamentals-validusage-handles, specifically allowed>>.
 
-include::../api/defines/VK_NULL_HANDLE.txt[]
+include::../api/consts/VK_NULL_HANDLE.txt[]
 
 --
 

--- a/include/vulkan/vulkan_core.h
+++ b/include/vulkan/vulkan_core.h
@@ -46,9 +46,6 @@ extern "C" {
 #define VK_HEADER_VERSION 91
 
 
-#define VK_NULL_HANDLE 0
-
-
 #define VK_DEFINE_HANDLE(object) typedef struct object##_T* object;
 
 
@@ -92,15 +89,16 @@ VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkDescriptorSet)
 VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkFramebuffer)
 VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkCommandPool)
 
+#define VK_NULL_HANDLE                    0
 #define VK_LOD_CLAMP_NONE                 1000.0f
-#define VK_REMAINING_MIP_LEVELS           (~0U)
-#define VK_REMAINING_ARRAY_LAYERS         (~0U)
-#define VK_WHOLE_SIZE                     (~0ULL)
-#define VK_ATTACHMENT_UNUSED              (~0U)
-#define VK_TRUE                           1
-#define VK_FALSE                          0
-#define VK_QUEUE_FAMILY_IGNORED           (~0U)
-#define VK_SUBPASS_EXTERNAL               (~0U)
+#define VK_REMAINING_MIP_LEVELS           UINT32_MAX
+#define VK_REMAINING_ARRAY_LAYERS         UINT32_MAX
+#define VK_WHOLE_SIZE                     UINT64_MAX
+#define VK_ATTACHMENT_UNUSED              UINT32_MAX
+#define VK_TRUE                           UINT32_C(1)
+#define VK_FALSE                          UINT32_C(0)
+#define VK_QUEUE_FAMILY_IGNORED           UINT32_MAX
+#define VK_SUBPASS_EXTERNAL               UINT32_MAX
 #define VK_MAX_PHYSICAL_DEVICE_NAME_SIZE  256
 #define VK_UUID_SIZE                      16
 #define VK_MAX_MEMORY_TYPES               32
@@ -3794,7 +3792,7 @@ VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkDescriptorUpdateTemplate)
 
 #define VK_MAX_DEVICE_GROUP_SIZE          32
 #define VK_LUID_SIZE                      8
-#define VK_QUEUE_FAMILY_EXTERNAL          (~0U-1)
+#define VK_QUEUE_FAMILY_EXTERNAL          UINT32_C(0xFFFFFFFE)
 
 
 typedef enum VkPointClippingBehavior {
@@ -5258,6 +5256,7 @@ VKAPI_ATTR void VKAPI_CALL vkTrimCommandPoolKHR(
 #define VK_KHR_device_group_creation 1
 #define VK_KHR_DEVICE_GROUP_CREATION_SPEC_VERSION 1
 #define VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME "VK_KHR_device_group_creation"
+
 #define VK_MAX_DEVICE_GROUP_SIZE_KHR      VK_MAX_DEVICE_GROUP_SIZE
 
 typedef VkPhysicalDeviceGroupProperties VkPhysicalDeviceGroupPropertiesKHR;
@@ -5277,6 +5276,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDeviceGroupsKHR(
 #define VK_KHR_external_memory_capabilities 1
 #define VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION 1
 #define VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME "VK_KHR_external_memory_capabilities"
+
 #define VK_LUID_SIZE_KHR                  VK_LUID_SIZE
 
 typedef VkExternalMemoryHandleTypeFlags VkExternalMemoryHandleTypeFlagsKHR;
@@ -5313,6 +5313,7 @@ VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalBufferPropertiesKHR(
 #define VK_KHR_external_memory 1
 #define VK_KHR_EXTERNAL_MEMORY_SPEC_VERSION 1
 #define VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME "VK_KHR_external_memory"
+
 #define VK_QUEUE_FAMILY_EXTERNAL_KHR      VK_QUEUE_FAMILY_EXTERNAL
 
 typedef VkExternalMemoryImageCreateInfo VkExternalMemoryImageCreateInfoKHR;
@@ -6085,10 +6086,11 @@ typedef struct VkPhysicalDeviceShaderAtomicInt64FeaturesKHR {
 
 
 #define VK_KHR_driver_properties 1
-#define VK_MAX_DRIVER_NAME_SIZE_KHR       256
-#define VK_MAX_DRIVER_INFO_SIZE_KHR       256
 #define VK_KHR_DRIVER_PROPERTIES_SPEC_VERSION 1
 #define VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME "VK_KHR_driver_properties"
+
+#define VK_MAX_DRIVER_NAME_SIZE_KHR       256
+#define VK_MAX_DRIVER_INFO_SIZE_KHR       256
 
 
 typedef enum VkDriverIdKHR {
@@ -7384,7 +7386,8 @@ VKAPI_ATTR void VKAPI_CALL vkSetHdrMetadataEXT(
 #define VK_EXT_queue_family_foreign 1
 #define VK_EXT_QUEUE_FAMILY_FOREIGN_SPEC_VERSION 1
 #define VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME "VK_EXT_queue_family_foreign"
-#define VK_QUEUE_FAMILY_FOREIGN_EXT       (~0U-2)
+
+#define VK_QUEUE_FAMILY_FOREIGN_EXT       UINT32_C(0xFFFFFFFD)
 
 
 #define VK_EXT_debug_utils 1
@@ -8118,7 +8121,8 @@ VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkAccelerationStructureNV)
 
 #define VK_NV_RAY_TRACING_SPEC_VERSION    2
 #define VK_NV_RAY_TRACING_EXTENSION_NAME  "VK_NV_ray_tracing"
-#define VK_SHADER_UNUSED_NV               (~0U)
+
+#define VK_SHADER_UNUSED_NV               UINT32_MAX
 
 
 typedef enum VkRayTracingShaderGroupTypeNV {

--- a/registry.txt
+++ b/registry.txt
@@ -241,6 +241,9 @@ Zero or more of each of the following tags, normally in this order
     Conventions`" document.
   * <<tag-types,tag:types>> - defines API types. Usually only one
     tag is used.
+  * <<tag-constants,tag:constants>> - defines API constant names and values.
+    Usually one tag is used. Typically produces a `#define` of named value
+    in C.
   * <<tag-enums,tag:enums>> - defines API token names and values.
     Usually multiple tags are used. Related groups may be tagged as an
     enumerated type corresponding to a tag:type tag, and resulting in a
@@ -617,18 +620,8 @@ using entities is preferred.
 = Enumerant Blocks (tag:enums tag)
 
 The tag:enums tags contain individual tag:enum tags describing each of
-the token names used in the API. In some cases these correspond to a C
-`enum`, and in some cases they are simply compile time constants (e.g.
-`#define`).
-
-[NOTE]
-.Note
-====
-It would make more sense to call these `const` or `define` tags.
-This is a historical hangover from the OpenGL XML format which this schema
-was based on.
-====
-
+the token names used in the API. These correspond to a C
+`enum`.
 
 == Attributes of tag:enums tags
 
@@ -656,25 +649,7 @@ sorting on enumerant values, to improve human readability).
 == Example of tag:enums tags
 
 <<tag-types:example,An example>> showing a tag with attribute
-attr:type`="enum"` is given above. The following example is for
-non-enumerated tokens.
-
-[source,xml]
---------------------------------------
-<enums>
-    <enum value="256" name="VK_MAX_EXTENSION_NAME"/>
-    <enum value="MAX_FLOAT"  name="VK_LOD_CLAMP_NONE"/>
-</enums>
---------------------------------------
-
-When processed into a C header, and assuming all these tokens were
-required, this results in
-
-[source,c]
---------------------------------------
-#define VK_MAX_EXTENSION_NAME   256
-#define VK_LOD_CLAMP_NONE       MAX_FLOAT
---------------------------------------
+attr:type`="enum"` is given above.
 
 
 [[tag-enum]]
@@ -742,6 +717,84 @@ was based on.
 == Contents of tag:unused tags
 
 None.
+
+[[tag-constants]]
+= Constant Blocks (tag:constants tag)
+
+The tag:constants tags contain individual tag:constant tags describing each
+of the constant names used in the API. They are simply compile time
+constants (e.g. `#define`).
+
+[NOTE]
+.Note
+====
+This was forked from tag:enum, which was used for constants in previous
+versions.
+====
+
+
+== Attributes of tag:constants tags
+
+  * attr:name - optional. String naming the group of constants. Currently
+    unused.
+  * attr:comment - optional. Arbitrary string (unused).
+
+== Contents of tag:constants tags
+
+Each tag:constants block contains zero or more tag:constant, and tag:comment
+tags, in arbitrary order.
+
+== Example of tag:constants tags
+
+[source,xml]
+--------------------------------------
+<constants>
+    <constant value="32" name="VK_MAX_DEVICE_GROUP_SIZE"/>
+    <constant value="0xFFFFFFFF" type="uint32_t" name="VK_SUBPASS_EXTERNAL"/>
+    <constant value="1000.0" type="float" name="VK_LOD_CLAMP_NONE"/>
+    <constant value="1" type="VkBool32" name="VK_TRUE"/>
+    <constant name="VK_MAX_DEVICE_GROUP_SIZE_KHR" alias="VK_MAX_DEVICE_GROUP_SIZE"/>
+</constants>
+--------------------------------------
+
+When processed into a C header, and assuming all these tokens were
+required, this results in
+
+[source,c]
+--------------------------------------
+#define VK_MAX_DEVICE_GROUP_SIZE          32
+#define VK_MAX_EXTENSION_NAME_SIZE        256
+#define VK_SUBPASS_EXTERNAL               UINT32_MAX
+#define VK_LOD_CLAMP_NONE                 1000.0f
+#define VK_TRUE                           UINT32_C(1)
+#define VK_MAX_DEVICE_GROUP_SIZE_KHR      VK_MAX_DEVICE_GROUP_SIZE
+--------------------------------------
+
+
+[[tag-constant]]
+= Constants (tag:constant tag)
+
+Each tag:constant tag defines a single Vulkan (or other API) constant.
+
+== Attributes of tag:constant tags
+
+  * attr:value - required, unless attr:alias. attr:value is an enumerant value
+    in the form of a legal C constant (for now, literal decimal or hexadecimal
+    integer, or decimal floating point value is expected).
+  * attr:name - required. Constant name, a legal C preprocessor token name.
+  * attr:type - optional. Used only when attr:value is specified. Typename
+    of a type of this attr:value. Used by generator to provide literal of
+    correct type. If missing, resulting type is untyped (which defaults to
+    `int`, or `double` in C).
+  * attr:alias - optional. Name of another constant this is an alias of, used
+    where token names have been changed as a result of profile changes or for
+    consistency purposes. An constant alias is simply a different attr:name for
+    the exact same attr:value.
+
+== Contents of tag:constant tags
+
+tag:constant tags have no allowed contents. All information is contained
+in the attributes.
 
 
 [[tag-commands]]

--- a/xml/cgenerator.py
+++ b/xml/cgenerator.py
@@ -109,12 +109,13 @@ class CGeneratorOptions(GeneratorOptions):
 # genStruct(typeinfo,name)
 # genGroup(groupinfo,name)
 # genEnum(enuminfo, name)
+# genConst(constinfo, name)
 # genCmd(cmdinfo)
 class COutputGenerator(OutputGenerator):
     """Generate specified API interfaces in a specific style, such as a C header"""
     # This is an ordered list of sections in the header file.
     TYPE_SECTIONS = ['include', 'define', 'basetype', 'handle', 'enum',
-                     'group', 'bitmask', 'funcpointer', 'struct']
+                     'constant', 'group', 'bitmask', 'funcpointer', 'struct']
     ALL_SECTIONS = TYPE_SECTIONS + ['commandPointer', 'command']
     def __init__(self,
                  errFile = sys.stderr,
@@ -400,7 +401,13 @@ class COutputGenerator(OutputGenerator):
         body = '#define ' + name.ljust(33) + ' ' + strVal
         self.appendSection('enum', body)
 
-    #
+    # Constant generation
+    def genConst(self, constinfo, name, alias):
+        OutputGenerator.genConst(self, constinfo, name, alias)
+        value = self.constToValue(constinfo.elem)
+        body = '#define ' + name.ljust(33) + ' ' + value
+        self.appendSection('constant', body)
+
     # Command generation
     def genCmd(self, cmdinfo, name, alias):
         OutputGenerator.genCmd(self, cmdinfo, name, alias)

--- a/xml/docgenerator.py
+++ b/xml/docgenerator.py
@@ -316,6 +316,13 @@ class DocOutputGenerator(OutputGenerator):
         self.logMsg('diag', '# NOT writing compile-time constant', name)
         # self.writeInclude('consts', name, body)
     #
+    # Constant generation
+    def genConst(self, constinfo, name, alias):
+        OutputGenerator.genConst(self, constinfo, name, alias)
+        value = self.constToValue(constinfo.elem)
+        body = '#define ' + name.ljust(33) + ' ' + value
+        self.writeInclude('consts', name, body)
+    #
     # Command generation
     def genCmd(self, cmdinfo, name, alias):
         OutputGenerator.genCmd(self, cmdinfo, name, alias)

--- a/xml/reg.py
+++ b/xml/reg.py
@@ -137,6 +137,15 @@ class EnumInfo(BaseInfo):
         if (self.type == None):
             self.type = ''
 
+# ConstInfo - registry information about an constant type 
+class ConstInfo(BaseInfo):
+    """Represents the state of a registry constant"""
+    def __init__(self, elem):
+        BaseInfo.__init__(self, elem)
+        self.type = elem.get('type')
+        if (self.type == None):
+            self.type = ''
+
 # CmdInfo - registry information about a command
 class CmdInfo(BaseInfo):
     """Represents the state of a registry command"""
@@ -225,6 +234,7 @@ class Registry:
         self.typedict     = {}
         self.groupdict    = {}
         self.enumdict     = {}
+        self.constdict    = {}
         self.cmddict      = {}
         self.apidict      = {}
         self.extensions   = []
@@ -340,6 +350,15 @@ class Registry:
                 self.addElementInfo(enum, enumInfo, 'enum', self.enumdict)
                 # self.gen.logMsg('diag', 'parseTree: marked req =',
                 #                 required, 'for', enum.get('name'))
+        #
+        # Create dictionary of registry constants from <constant> tags
+        self.constdict = {}
+        for consts in self.reg.findall('constants'):
+            required = (enums.get('type') != None)
+            for const in consts.findall('constant'):
+                constInfo = ConstInfo(const)
+                constInfo.required = required
+                self.addElementInfo(const, constInfo, 'constant', self.constdict)
         #
         # Create dictionary of registry commands from <command> tags
         # and add 'name' attribute to each <command> tag (where missing)
@@ -843,6 +862,8 @@ class Registry:
             if alias:
                 self.generateFeature(alias, 'enum', self.enumdict)
             genProc = self.gen.genEnum
+        elif (ftype == 'constant'):
+            genProc = self.gen.genConst
 
         # Actually generate the type only if emitting declarations
         if self.emitFeatures:
@@ -865,6 +886,8 @@ class Registry:
                 self.generateFeature(t.get('name'), 'type', self.typedict)
             for e in features.findall('enum'):
                 self.generateFeature(e.get('name'), 'enum', self.enumdict)
+            for c in features.findall('constant'):
+                self.generateFeature(c.get('name'), 'constant', self.constdict)
             for c in features.findall('command'):
                 self.generateFeature(c.get('name'), 'command', self.cmddict)
 

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -29,6 +29,7 @@ start = element registry {
         Tags       * |
         Types      * |
         Enums      * |
+        Constants  * |
         Commands   * |
         Feature    * |
         Extensions *
@@ -260,6 +261,38 @@ Unused = element unused {
     Comment ?
 }
 
+# <constants> defines a group of constants
+#   name - a name associated with this group.
+#   comment - unused
+Constants = element constants {
+    attribute name { text } ? ,
+    Comment ? ,
+    (
+        Constant |
+        element comment { text }
+    ) *
+}
+
+# <constant> defines or references a single constant. There are two places it
+# can be used: in a <constants> block, providing a global definition which may
+# later be required by a feature or an extension; or in a feature or extension,
+# referencing an constant specific to that feature.
+#
+#   name - constant name
+#   value - integer (including hex) or floating-point value of the constant
+#   type - typename for which the constant is intended. Has to be type
+#          compatible with the provided value.
+#   alias - another constant this is semantically identical to
+#   comment - unused
+Constant = element constant {
+    (
+      attribute name { text } &
+      attribute value { Integer | Float } &
+      attribute type { Typename } ? &
+      Comment ?
+    )
+}
+
 # <commands> defines a group of commands
 Commands = element commands {
     Comment ? ,
@@ -478,6 +511,9 @@ InterfaceElement =
 # as a placeholder.
 Integer = text
 
+# Floats are allowed to be decimal floating point values
+Float = text
+
 # EnumName is an compile-time constant name
 EnumName = text
 
@@ -490,6 +526,9 @@ TypeSuffix = text
 # StringGroup is a regular expression with an implicit
 #   '^(' and ')$' bracketing it.
 StringGroup = text
+
+# Typename is a type name of previously defined type
+Typename = text
 
 # Repeatedly used attributes
 ProfileName = attribute profile { text }

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -160,9 +160,6 @@ server.
 #endif
 #endif</type>
 
-        <type category="define">
-#define <name>VK_NULL_HANDLE</name> 0</type>
-
         <type category="define">struct <name>ANativeWindow</name>;</type>
         <type category="define">struct <name>AHardwareBuffer</name>;</type>
 
@@ -634,20 +631,20 @@ server.
             <member><type>uint32_t</type>       <name>vendorID</name></member>
             <member><type>uint32_t</type>       <name>deviceID</name></member>
             <member><type>VkPhysicalDeviceType</type> <name>deviceType</name></member>
-            <member><type>char</type>           <name>deviceName</name>[<enum>VK_MAX_PHYSICAL_DEVICE_NAME_SIZE</enum>]</member>
-            <member><type>uint8_t</type>        <name>pipelineCacheUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
+            <member><type>char</type>           <name>deviceName</name>[<constant>VK_MAX_PHYSICAL_DEVICE_NAME_SIZE</constant>]</member>
+            <member><type>uint8_t</type>        <name>pipelineCacheUUID</name>[<constant>VK_UUID_SIZE</constant>]</member>
             <member><type>VkPhysicalDeviceLimits</type> <name>limits</name></member>
             <member><type>VkPhysicalDeviceSparseProperties</type> <name>sparseProperties</name></member>
         </type>
         <type category="struct" name="VkExtensionProperties" returnedonly="true">
-            <member><type>char</type>            <name>extensionName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]<comment>extension name</comment></member>
+            <member><type>char</type>            <name>extensionName</name>[<constant>VK_MAX_EXTENSION_NAME_SIZE</constant>]<comment>extension name</comment></member>
             <member><type>uint32_t</type>        <name>specVersion</name><comment>version of the extension specification implemented</comment></member>
         </type>
         <type category="struct" name="VkLayerProperties" returnedonly="true">
-            <member><type>char</type>            <name>layerName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]<comment>layer name</comment></member>
+            <member><type>char</type>            <name>layerName</name>[<constant>VK_MAX_EXTENSION_NAME_SIZE</constant>]<comment>layer name</comment></member>
             <member><type>uint32_t</type>        <name>specVersion</name><comment>version of the layer specification implemented</comment></member>
             <member><type>uint32_t</type>        <name>implementationVersion</name><comment>build or release version of the layer's library</comment></member>
-            <member><type>char</type>            <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]<comment>Free-form description of the layer</comment></member>
+            <member><type>char</type>            <name>description</name>[<constant>VK_MAX_DESCRIPTION_SIZE</constant>]<comment>Free-form description of the layer</comment></member>
         </type>
         <type category="struct" name="VkApplicationInfo">
             <member values="VK_STRUCTURE_TYPE_APPLICATION_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -704,9 +701,9 @@ server.
         </type>
         <type category="struct" name="VkPhysicalDeviceMemoryProperties" returnedonly="true">
             <member><type>uint32_t</type>               <name>memoryTypeCount</name></member>
-            <member><type>VkMemoryType</type>           <name>memoryTypes</name>[<enum>VK_MAX_MEMORY_TYPES</enum>]</member>
+            <member><type>VkMemoryType</type>           <name>memoryTypes</name>[<constant>VK_MAX_MEMORY_TYPES</constant>]</member>
             <member><type>uint32_t</type>               <name>memoryHeapCount</name></member>
-            <member><type>VkMemoryHeap</type>           <name>memoryHeaps</name>[<enum>VK_MAX_MEMORY_HEAPS</enum>]</member>
+            <member><type>VkMemoryHeap</type>           <name>memoryHeaps</name>[<constant>VK_MAX_MEMORY_HEAPS</constant>]</member>
         </type>
         <type category="struct" name="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -1986,8 +1983,8 @@ server.
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkDriverIdKHR</type>                    <name>driverID</name></member>
-            <member><type>char</type>                             <name>driverName</name>[<enum>VK_MAX_DRIVER_NAME_SIZE_KHR</enum>]</member>
-            <member><type>char</type>                             <name>driverInfo</name>[<enum>VK_MAX_DRIVER_INFO_SIZE_KHR</enum>]</member>
+            <member><type>char</type>                             <name>driverName</name>[<constant>VK_MAX_DRIVER_NAME_SIZE_KHR</constant>]</member>
+            <member><type>char</type>                             <name>driverInfo</name>[<constant>VK_MAX_DRIVER_INFO_SIZE_KHR</constant>]</member>
             <member><type>VkConformanceVersionKHR</type>          <name>conformanceVersion</name></member>
         </type>
         <type category="struct" name="VkPresentRegionsKHR" structextends="VkPresentInfoKHR">
@@ -2047,9 +2044,9 @@ server.
         <type category="struct" name="VkPhysicalDeviceIDProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member><type>void</type>*                            <name>pNext</name></member>
-            <member><type>uint8_t</type>                          <name>deviceUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
-            <member><type>uint8_t</type>                          <name>driverUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
-            <member><type>uint8_t</type>                          <name>deviceLUID</name>[<enum>VK_LUID_SIZE</enum>]</member>
+            <member><type>uint8_t</type>                          <name>deviceUUID</name>[<constant>VK_UUID_SIZE</constant>]</member>
+            <member><type>uint8_t</type>                          <name>driverUUID</name>[<constant>VK_UUID_SIZE</constant>]</member>
+            <member><type>uint8_t</type>                          <name>deviceLUID</name>[<constant>VK_LUID_SIZE</constant>]</member>
             <member><type>uint32_t</type>                         <name>deviceNodeMask</name></member>
             <member><type>VkBool32</type>                         <name>deviceLUIDValid</name></member>
         </type>
@@ -2310,7 +2307,7 @@ server.
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>physicalDeviceCount</name></member>
-            <member><type>VkPhysicalDevice</type>                 <name>physicalDevices</name>[<enum>VK_MAX_DEVICE_GROUP_SIZE</enum>]</member>
+            <member><type>VkPhysicalDevice</type>                 <name>physicalDevices</name>[<constant>VK_MAX_DEVICE_GROUP_SIZE</constant>]</member>
             <member><type>VkBool32</type>                         <name>subsetAllocation</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceGroupPropertiesKHR"                      alias="VkPhysicalDeviceGroupProperties"/>
@@ -2388,7 +2385,7 @@ server.
         <type category="struct" name="VkDeviceGroupPresentCapabilitiesKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                      <name>pNext</name></member>
-            <member><type>uint32_t</type>                         <name>presentMask</name>[<enum>VK_MAX_DEVICE_GROUP_SIZE</enum>]</member>
+            <member><type>uint32_t</type>                         <name>presentMask</name>[<constant>VK_MAX_DEVICE_GROUP_SIZE</constant>]</member>
             <member><type>VkDeviceGroupPresentModeFlagsKHR</type> <name>modes</name></member>
         </type>
         <type category="struct" name="VkImageSwapchainCreateInfoKHR" structextends="VkImageCreateInfo">
@@ -3594,33 +3591,34 @@ server.
 
     <comment>Vulkan enumerant (token) definitions</comment>
 
-    <enums name="API Constants" comment="Vulkan hardcoded constants - not an enumerated type, part of the header boilerplate">
-        <enum value="256"   name="VK_MAX_PHYSICAL_DEVICE_NAME_SIZE"/>
-        <enum value="16"    name="VK_UUID_SIZE"/>
-        <enum value="8"     name="VK_LUID_SIZE"/>
-        <enum               name="VK_LUID_SIZE_KHR" alias="VK_LUID_SIZE"/>
-        <enum value="256"   name="VK_MAX_EXTENSION_NAME_SIZE"/>
-        <enum value="256"   name="VK_MAX_DESCRIPTION_SIZE"/>
-        <enum value="32"    name="VK_MAX_MEMORY_TYPES"/>
-        <enum value="16"    name="VK_MAX_MEMORY_HEAPS" comment="The maximum number of unique memory heaps, each of which supporting 1 or more memory types"/>
-        <enum value="1000.0f" name="VK_LOD_CLAMP_NONE"/>
-        <enum value="(~0U)" name="VK_REMAINING_MIP_LEVELS"/>
-        <enum value="(~0U)" name="VK_REMAINING_ARRAY_LAYERS"/>
-        <enum value="(~0ULL)" name="VK_WHOLE_SIZE"/>
-        <enum value="(~0U)" name="VK_ATTACHMENT_UNUSED"/>
-        <enum value="1"     name="VK_TRUE"/>
-        <enum value="0"     name="VK_FALSE"/>
-        <enum value="(~0U)" name="VK_QUEUE_FAMILY_IGNORED"/>
-        <enum value="(~0U-1)" name="VK_QUEUE_FAMILY_EXTERNAL"/>
-        <enum               name="VK_QUEUE_FAMILY_EXTERNAL_KHR" alias="VK_QUEUE_FAMILY_EXTERNAL"/>
-        <enum value="(~0U-2)" name="VK_QUEUE_FAMILY_FOREIGN_EXT"/>
-        <enum value="(~0U)" name="VK_SUBPASS_EXTERNAL"/>
-        <enum value="32"    name="VK_MAX_DEVICE_GROUP_SIZE"/>
-        <enum               name="VK_MAX_DEVICE_GROUP_SIZE_KHR" alias="VK_MAX_DEVICE_GROUP_SIZE"/>
-        <enum value="256"   name="VK_MAX_DRIVER_NAME_SIZE_KHR"/>
-        <enum value="256"   name="VK_MAX_DRIVER_INFO_SIZE_KHR"/>
-        <enum value="(~0U)" name="VK_SHADER_UNUSED_NV"/>
-    </enums>
+    <constants name="API Constants" comment="Vulkan hardcoded constants -- part of the header boilerplate">
+        <constant value="0"                                      name="VK_NULL_HANDLE"/>
+        <constant value="256"                                    name="VK_MAX_PHYSICAL_DEVICE_NAME_SIZE"/>
+        <constant value="16"                                     name="VK_UUID_SIZE"/>
+        <constant value="8"                                      name="VK_LUID_SIZE"/>
+        <constant                                                name="VK_LUID_SIZE_KHR" alias="VK_LUID_SIZE"/>
+        <constant value="256"                                    name="VK_MAX_EXTENSION_NAME_SIZE"/>
+        <constant value="256"                                    name="VK_MAX_DESCRIPTION_SIZE"/>
+        <constant value="32"                                     name="VK_MAX_MEMORY_TYPES"/>
+        <constant value="16"                                     name="VK_MAX_MEMORY_HEAPS" comment="The maximum number of unique memory heaps, each of which supporting 1 or more memory types"/>
+        <constant value="1000.0"             type="float"        name="VK_LOD_CLAMP_NONE"/>
+        <constant value="0xFFFFFFFF"         type="uint32_t"     name="VK_REMAINING_MIP_LEVELS"/>
+        <constant value="0xFFFFFFFF"         type="uint32_t"     name="VK_REMAINING_ARRAY_LAYERS"/>
+        <constant value="0xFFFFFFFFFFFFFFFF" type="VkDeviceSize" name="VK_WHOLE_SIZE"/>
+        <constant value="0xFFFFFFFF"         type="uint32_t"     name="VK_ATTACHMENT_UNUSED"/>
+        <constant value="1"                  type="VkBool32"     name="VK_TRUE"/>
+        <constant value="0"                  type="VkBool32"     name="VK_FALSE"/>
+        <constant value="0xFFFFFFFF"         type="uint32_t"     name="VK_QUEUE_FAMILY_IGNORED"/>
+        <constant value="0xFFFFFFFE"         type="uint32_t"     name="VK_QUEUE_FAMILY_EXTERNAL"/>
+        <constant                                                name="VK_QUEUE_FAMILY_EXTERNAL_KHR" alias="VK_QUEUE_FAMILY_EXTERNAL"/>
+        <constant value="0xFFFFFFFD"         type="uint32_t"     name="VK_QUEUE_FAMILY_FOREIGN_EXT"/>
+        <constant value="0xFFFFFFFF"         type="uint32_t"     name="VK_SUBPASS_EXTERNAL"/>
+        <constant value="32"                                     name="VK_MAX_DEVICE_GROUP_SIZE"/>
+        <constant                                                name="VK_MAX_DEVICE_GROUP_SIZE_KHR" alias="VK_MAX_DEVICE_GROUP_SIZE"/>
+        <constant value="256"                                    name="VK_MAX_DRIVER_NAME_SIZE_KHR"/>
+        <constant value="256"                                    name="VK_MAX_DRIVER_INFO_SIZE_KHR"/>
+        <constant value="0xFFFFFFFF"         type="uint32_t"     name="VK_SHADER_UNUSED_NV"/>
+    </constants>
 
     <comment>
         Unlike OpenGL, most tokens in Vulkan are actual typed enumerants in
@@ -6964,16 +6962,22 @@ server.
             <type name="VK_HEADER_VERSION"/>
         </require>
         <require comment="API constants">
-            <enum name="VK_LOD_CLAMP_NONE"/>
-            <enum name="VK_REMAINING_MIP_LEVELS"/>
-            <enum name="VK_REMAINING_ARRAY_LAYERS"/>
-            <enum name="VK_WHOLE_SIZE"/>
-            <enum name="VK_ATTACHMENT_UNUSED"/>
-            <enum name="VK_TRUE"/>
-            <enum name="VK_FALSE"/>
-            <type name="VK_NULL_HANDLE"/>
-            <enum name="VK_QUEUE_FAMILY_IGNORED"/>
-            <enum name="VK_SUBPASS_EXTERNAL"/>
+            <constant name="VK_NULL_HANDLE"/>
+            <constant name="VK_LOD_CLAMP_NONE"/>
+            <constant name="VK_REMAINING_MIP_LEVELS"/>
+            <constant name="VK_REMAINING_ARRAY_LAYERS"/>
+            <constant name="VK_WHOLE_SIZE"/>
+            <constant name="VK_ATTACHMENT_UNUSED"/>
+            <constant name="VK_TRUE"/>
+            <constant name="VK_FALSE"/>
+            <constant name="VK_QUEUE_FAMILY_IGNORED"/>
+            <constant name="VK_SUBPASS_EXTERNAL"/>
+            <constant name="VK_MAX_PHYSICAL_DEVICE_NAME_SIZE"/>
+            <constant name="VK_UUID_SIZE"/>
+            <constant name="VK_MAX_MEMORY_TYPES"/>
+            <constant name="VK_MAX_MEMORY_HEAPS"/>
+            <constant name="VK_MAX_EXTENSION_NAME_SIZE"/>
+            <constant name="VK_MAX_DESCRIPTION_SIZE"/>
             <type name="VkPipelineCacheHeaderVersion"/>
         </require>
         <require comment="Device initialization">
@@ -7246,7 +7250,7 @@ server.
         <require comment="Promoted from VK_KHR_device_group_creation">
             <enum extends="VkStructureType" extnumber="71"  offset="0"          name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES"/>
             <enum extends="VkStructureType" extnumber="71"  offset="1"          name="VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO"/>
-            <enum name="VK_MAX_DEVICE_GROUP_SIZE"/>
+            <constant name="VK_MAX_DEVICE_GROUP_SIZE"/>
             <type name="VkPhysicalDeviceGroupProperties"/>
             <type name="VkDeviceGroupDeviceCreateInfo"/>
             <command name="vkEnumeratePhysicalDeviceGroups"/>
@@ -7436,7 +7440,7 @@ server.
             <enum extends="VkStructureType" extnumber="72"  offset="2"          name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO"/>
             <enum extends="VkStructureType" extnumber="72"  offset="3"          name="VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES"/>
             <enum extends="VkStructureType" extnumber="72"  offset="4"          name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES"/>
-            <enum name="VK_LUID_SIZE"/>
+            <constant name="VK_LUID_SIZE"/>
             <type name="VkExternalMemoryHandleTypeFlags"/>
             <type name="VkExternalMemoryHandleTypeFlagBits"/>
             <type name="VkExternalMemoryFeatureFlags"/>
@@ -7454,7 +7458,7 @@ server.
             <enum extends="VkStructureType" extnumber="73"  offset="1"          name="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO"/>
             <enum extends="VkStructureType" extnumber="73"  offset="2"          name="VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO"/>
             <enum extends="VkResult"        extnumber="73"  offset="3"  dir="-" name="VK_ERROR_INVALID_EXTERNAL_HANDLE"/>
-            <enum name="VK_QUEUE_FAMILY_EXTERNAL"/>
+            <constant name="VK_QUEUE_FAMILY_EXTERNAL"/>
             <type name="VkExternalMemoryImageCreateInfo"/>
             <type name="VkExternalMemoryBufferCreateInfo"/>
             <type name="VkExportMemoryAllocateInfo"/>
@@ -8233,11 +8237,11 @@ server.
         </extension>
         <extension name="VK_KHR_device_group_creation" number="71" type="instance" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1">
             <require>
-                <enum value="1"                                                 name="VK_KHR_DEVICE_GROUP_CREATION_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_device_group_creation&quot;"          name="VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME"/>
-                <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES"/>
-                <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO_KHR" alias="VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO"/>
-                <enum name="VK_MAX_DEVICE_GROUP_SIZE_KHR"/>
+                <enum value="1"                                                 name="VK_KHR_DEVICE_GROUP_CREATION_SPEC_VERSION"/> 
+                <enum value="&quot;VK_KHR_device_group_creation&quot;"          name="VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME"/> 
+                <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES"/> 
+                <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO_KHR" alias="VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO"/> 
+                <constant name="VK_MAX_DEVICE_GROUP_SIZE_KHR"/>
                 <type name="VkPhysicalDeviceGroupPropertiesKHR"/>
                 <type name="VkDeviceGroupDeviceCreateInfoKHR"/>
                 <command name="vkEnumeratePhysicalDeviceGroupsKHR"/>
@@ -8253,7 +8257,7 @@ server.
                 <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO"/>
                 <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR" alias="VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES"/>
                 <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES"/>
-                <enum name="VK_LUID_SIZE_KHR"/>
+                <constant name="VK_LUID_SIZE_KHR"/>
                 <type name="VkExternalMemoryHandleTypeFlagsKHR"/>
                 <type name="VkExternalMemoryHandleTypeFlagBitsKHR"/>
                 <enum extends="VkExternalMemoryHandleTypeFlagBits"              name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR" alias="VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT"/>
@@ -8285,7 +8289,7 @@ server.
                 <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_KHR" alias="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO"/>
                 <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR" alias="VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO"/>
                 <enum extends="VkResult"                                        name="VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR" alias="VK_ERROR_INVALID_EXTERNAL_HANDLE"/>
-                <enum name="VK_QUEUE_FAMILY_EXTERNAL_KHR"/>
+                <constant name="VK_QUEUE_FAMILY_EXTERNAL_KHR"/>
                 <type name="VkExternalMemoryImageCreateInfoKHR"/>
                 <type name="VkExternalMemoryBufferCreateInfoKHR"/>
                 <type name="VkExportMemoryAllocateInfoKHR"/>
@@ -8335,7 +8339,7 @@ server.
                 <enum value="&quot;VK_KHR_external_semaphore_capabilities&quot;" name="VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME"/>
                 <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO"/>
                 <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR" alias="VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES"/>
-                <enum name="VK_LUID_SIZE_KHR"/>
+                <constant name="VK_LUID_SIZE_KHR"/>
                 <type name="VkExternalSemaphoreHandleTypeFlagsKHR"/>
                 <type name="VkExternalSemaphoreHandleTypeFlagBitsKHR"/>
                 <enum extends="VkExternalSemaphoreHandleTypeFlagBits"       name="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR" alias="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT"/>
@@ -8772,7 +8776,7 @@ server.
                 <enum value="&quot;VK_KHR_external_fence_capabilities&quot;" name="VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME"/>
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO"/>
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES_KHR" alias="VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES"/>
-                <enum name="VK_LUID_SIZE_KHR"/>
+                <constant name="VK_LUID_SIZE_KHR"/>
                 <type name="VkExternalFenceHandleTypeFlagsKHR"/>
                 <type name="VkExternalFenceHandleTypeFlagBitsKHR"/>
                 <enum extends="VkExternalFenceHandleTypeFlagBits"           name="VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR" alias="VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT"/>
@@ -8940,9 +8944,9 @@ server.
         </extension>
         <extension name="VK_EXT_queue_family_foreign" number="127" type="device" author="EXT" requires="VK_KHR_external_memory" contact="Chad Versace @chadversary" supported="vulkan">
             <require>
-                <enum value="1"                                             name="VK_EXT_QUEUE_FAMILY_FOREIGN_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_queue_family_foreign&quot;"       name="VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME"/>
-                <enum                                                       name="VK_QUEUE_FAMILY_FOREIGN_EXT"/>
+                <enum value="1"                                             name="VK_EXT_QUEUE_FAMILY_FOREIGN_SPEC_VERSION"/> 
+                <enum value="&quot;VK_EXT_queue_family_foreign&quot;"       name="VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME"/> 
+                <constant                                                   name="VK_QUEUE_FAMILY_FOREIGN_EXT"/>
             </require>
         </extension>
         <extension name="VK_KHR_dedicated_allocation" number="128" type="device" author="KHR" requires="VK_KHR_get_memory_requirements2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1">
@@ -9482,7 +9486,7 @@ server.
             <require>
                 <enum value="2"                                          name="VK_NV_RAY_TRACING_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_ray_tracing&quot;"              name="VK_NV_RAY_TRACING_EXTENSION_NAME"/>
-                <enum                                                    name="VK_SHADER_UNUSED_NV"/>
+                <constant                                                name="VK_SHADER_UNUSED_NV"/>
                 <enum offset="0" extends="VkStructureType"               name="VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV"/>
                 <enum offset="1" extends="VkStructureType"               name="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV"/>
                 <enum offset="3" extends="VkStructureType"               name="VK_STRUCTURE_TYPE_GEOMETRY_NV"/>
@@ -9783,8 +9787,8 @@ server.
                 <enum value="1"                                         name="VK_KHR_DRIVER_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_driver_properties&quot;"      name="VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR"/>
-                <enum name="VK_MAX_DRIVER_NAME_SIZE_KHR"/>
-                <enum name="VK_MAX_DRIVER_INFO_SIZE_KHR"/>
+                <constant name="VK_MAX_DRIVER_NAME_SIZE_KHR"/>
+                <constant name="VK_MAX_DRIVER_INFO_SIZE_KHR"/>
                 <type name="VkDriverIdKHR"/>
                 <type name="VkConformanceVersionKHR"/>
                 <type name="VkPhysicalDeviceDriverPropertiesKHR"/>


### PR DESCRIPTION
Constants should have a type appropriate to their use.
It potentially helps in C++ with template instantiation, function overloading, `auto`, and `decltype` ...

fixes #662 
fixes #717