### PR TITLE
Clarify the interaction between multi-planar images and VK_IMAGE_USAGE_STORAGE_BIT

### DIFF
--- a/doc/specs/vulkan/chapters/resources.txt
+++ b/doc/specs/vulkan/chapters/resources.txt
@@ -1226,6 +1226,11 @@ include::../api/enums/VkImageUsageFlagBits.txt[]
     to create a sname:VkImageView suitable for occupying a
     sname:VkDescriptorSet slot of type
     ename:VK_DESCRIPTOR_TYPE_STORAGE_IMAGE.
+    If this bit is set for any elink:VkFormat which is multi-planar, then
+    any created sname:VkImageView of a single-plane of the image may be
+    used to create a sname:VkDescriptorSet slot of type
+    ename:VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, however the multi-planar
+    itself elink:VkFormat may not be used to create sname:VkImageView.
   * ename:VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT specifies that the image can:
     be used to create a sname:VkImageView suitable for use as a color or
     resolve attachment in a sname:VkFramebuffer.


### PR DESCRIPTION
Whilst the specifications are very clear that users may create single-plane VkImageView from multi-plane images, there's a concern from one implementor that flagging VK_IMAGE_USAGE_STORAGE_BIT as supported for such VkFormat will mean that creating a VkImageView with a format set to the original multi-plane VkFormat would be supported.
Hence, clarify that for multi-planar images, the VK_IMAGE_USAGE_STORAGE_BIT only applies to any single-plane VkImageViews created with a compatible VkFormat and not to VkImageViews created with the original multi-planar format.