### PR TITLE
Correct mem VU ifdef scope in VkBindImageMemoryInfo 

### DIFF
--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -3918,10 +3918,12 @@ ifndef::VK_VERSION_1_1,VK_KHR_dedicated_allocation[]
     dedicated for a specific buffer or image
 endif::VK_VERSION_1_1,VK_KHR_dedicated_allocation[]
 endif::VK_NV_dedicated_allocation[]
-ifndef::VK_VERSION_1_1,VK_KHR_device_group[]
+ifndef::VK_VERSION_1_1+VK_KHR_swapchain[]
+ifndef::VK_KHR_device_group+VK_KHR_swapchain[]
   * [[VUID-VkBindImageMemoryInfo-memory-01625]]
     pname:memory must: be a valid dname:VkDeviceMemory handle
-endif::VK_VERSION_1_1,VK_KHR_device_group[]
+endif::VK_KHR_device_group+VK_KHR_swapchain[]
+endif::VK_VERSION_1_1+VK_KHR_swapchain[]
 ifdef::VK_VERSION_1_1,VK_KHR_device_group[]
   * [[VUID-VkBindImageMemoryInfo-pNext-01626]]
     If the pname:pNext chain includes


### PR DESCRIPTION
- previously VU exluded if `1.1` or `VK_KHR_device_group`, but if swapchain ext. not defined memory param should be valid too
=> now excluded iff `VK_KHR_swapchain` is defined too.

`(1.1 or VK_KHR_device_group) and VK_KHR_swapchain` should show swapchain specific VU (which provides memory through `pNext` instead). Negative of that should show the core VU ("`memory` must be valid").