### PR TITLE
Remove duplicate present layout note

### DIFF
--- a/doc/specs/vulkan/chapters/VK_KHR_swapchain/wsi.txt
+++ b/doc/specs/vulkan/chapters/VK_KHR_swapchain/wsi.txt
@@ -810,29 +810,6 @@ react appropriately.
 If presentation fails because of a mismatch in the surface and presented
 image sizes, a ename:VK_ERROR_OUT_OF_DATE_KHR error will be returned.
 
-Before an application can: present an image, the image's layout must: be
-transitioned to the ename:VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
-ifdef::VK_KHR_shared_presentable_image[]
-layout, or for a shared presentable image the
-ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
-endif::VK_KHR_shared_presentable_image[]
-layout.
-
-.Note
-[NOTE]
-====
-When transitioning the image to
-ifdef::VK_KHR_shared_presentable_image[]
-ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR or
-endif::VK_KHR_shared_presentable_image[]
-ename:VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, there is no need to delay subsequent
-processing, or perform any visibility operations (as flink:vkQueuePresentKHR
-performs automatic visibility operations).
-To achieve this, the pname:dstAccessMask member of the
-slink:VkImageMemoryBarrier should: be set to `0`, and the pname:dstStageMask
-parameter should: be set to ename:VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT.
-====
-
 ifdef::VK_VERSION_1_1,VK_KHR_device_group[]
 
 [open,refpage='vkAcquireNextImage2KHR',desc='Retrieve the index of the next available presentable image',type='protos']


### PR DESCRIPTION
Remove duplicate present layout note.

The identical thing is already below `VkPresentInfoKHR` where it belongs.