### PR TITLE
Fix some typos

### DIFF
--- a/doc/specs/vulkan/chapters/cmdbuffers.txt
+++ b/doc/specs/vulkan/chapters/cmdbuffers.txt
@@ -63,8 +63,8 @@ commands.
 Each command buffer is always in one of the following states:
 
 Initial::
-    When a command buffer is <<vkAllocateCommandBuffers, first allocated>>
-    is in the _initial state_.
+    When a command buffer is <<vkAllocateCommandBuffers, allocated>>, it is
+    in the _initial state_.
     Some commands are able to _reset_ a command buffer, or a set of command
     buffers, back to this state from any of the executable, recording or
     invalid state.

--- a/doc/specs/vulkan/chapters/descriptorsets.txt
+++ b/doc/specs/vulkan/chapters/descriptorsets.txt
@@ -48,23 +48,23 @@ Storage image loads are supported in all shader stages for image formats
 which report support for the
 <<features-formats-properties,ename:VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT>>
 feature bit via flink:vkGetPhysicalDeviceFormatProperties in
-slink:VkFormat::pname:linearTilingFeatures (for images with linear tiling)
-or slink:VkFormat::pname:optimalTilingFeatures (for images with optimal
+slink:VkFormatProperties::pname:linearTilingFeatures (for images with linear tiling)
+or slink:VkFormatProperties::pname:optimalTilingFeatures (for images with optimal
 tiling).
 
 Stores to storage images are supported in compute shaders for image formats
 which report support for the ename:VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT
 feature via flink:vkGetPhysicalDeviceFormatProperties in
-slink:VkFormat::pname:linearTilingFeatures (for images with linear tiling)
-or slink:VkFormat::pname:optimalTilingFeatures (for images with optimal
+slink:VkFormatProperties::pname:linearTilingFeatures (for images with linear tiling)
+or slink:VkFormatProperties::pname:optimalTilingFeatures (for images with optimal
 tiling).
 
 Atomic operations on storage images are supported in compute shaders for
 image formats which report support for the
 <<features-formats-properties,ename:VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT>>
 feature via flink:vkGetPhysicalDeviceFormatProperties in
-slink:VkFormat::pname:linearTilingFeatures (for images with linear tiling)
-or slink:VkFormat::pname:optimalTilingFeatures (for images with optimal
+slink:VkFormatProperties::pname:linearTilingFeatures (for images with linear tiling)
+or slink:VkFormatProperties::pname:optimalTilingFeatures (for images with optimal
 tiling).
 
 When the <<features-features-fragmentStoresAndAtomics,
@@ -108,8 +108,8 @@ Sampled images are supported in all shader stages for image formats which
 report support for the
 <<features-formats-properties,ename:VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT>>
 feature bit via flink:vkGetPhysicalDeviceFormatProperties in
-slink:VkFormat::pname:linearTilingFeatures (for images with linear tiling)
-or slink:VkFormat::pname:optimalTilingFeatures (for images with optimal
+slink:VkFormatProperties::pname:linearTilingFeatures (for images with linear tiling)
+or slink:VkFormatProperties::pname:optimalTilingFeatures (for images with optimal
 tiling).
 
 The image subresources for a sampled image must: be in the
@@ -185,7 +185,7 @@ Load operations from uniform texel buffers are supported in all shader
 stages for image formats which report support for the
 <<features-formats-properties,ename:VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT>>
 feature bit via flink:vkGetPhysicalDeviceFormatProperties in
-slink:VkFormat::pname:bufferFeatures.
+slink:VkFormatProperties::pname:bufferFeatures.
 
 
 [[descriptorsets-storagetexelbuffer]]
@@ -207,19 +207,19 @@ Storage texel buffer loads are supported in all shader stages for texel
 buffer formats which report support for the
 <<features-formats-properties,ename:VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT>>
 feature bit via flink:vkGetPhysicalDeviceFormatProperties in
-slink:VkFormat::pname:bufferFeatures.
+slink:VkFormatProperties::pname:bufferFeatures.
 
 Stores to storage texel buffers are supported in compute shaders for texel
 buffer formats which report support for the
 ename:VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT feature via
 flink:vkGetPhysicalDeviceFormatProperties in
-slink:VkFormat::pname:bufferFeatures.
+slink:VkFormatProperties::pname:bufferFeatures.
 
 Atomic operations on storage texel buffers are supported in compute shaders
 for texel buffer formats which report support for the
 <<features-formats-properties,ename:VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT>>
 feature via flink:vkGetPhysicalDeviceFormatProperties in
-slink:VkFormat::pname:bufferFeatures.
+slink:VkFormatProperties::pname:bufferFeatures.
 
 When the <<features-features-fragmentStoresAndAtomics,
 pname:fragmentStoresAndAtomics>> feature is enabled, stores and atomic

--- a/doc/specs/vulkan/chapters/initialization.txt
+++ b/doc/specs/vulkan/chapters/initialization.txt
@@ -188,7 +188,7 @@ To query properties that can: be used in creating an instance, call:
 
 include::../api/protos/vkEnumerateInstanceVersion.txt[]
 
-  * pname:pApiVersion points to a code:uint32_t, which is is the version of
+  * pname:pApiVersion points to a code:uint32_t, which is the version of
     Vulkan supported by instance-level functionality, encoded as described
     in the <<fundamentals-versionnum,API Version Numbers and Semantics>>
     section.

--- a/doc/specs/vulkan/style/markup.txt
+++ b/doc/specs/vulkan/style/markup.txt
@@ -63,13 +63,13 @@ in asciidoc markup).
 UTF-8 characters outside the ASCII subset should be used sparingly, only
 when needed for non-English names.
 Instead use asciidoc markup for special characters, if required.
-For example, two hyphens produces an en-dash:
+For example, two hyphens produces an em-dash:
 
 [NOTE]
 .Example Markup
 ====
 
-`An -- en-dash` -> An -- en-dash
+`An -- em-dash` -> An -- em-dash
 ====
 
 As an exception, multiplication should be marked with the unicode


### PR DESCRIPTION
- defeat "is is" in `vkEnumerateInstanceVersion`
- correct markup doc about em-dash (leftover from #642)
- fix #667 (cmdbuffer initial state mangled sentence)
- fix #687 (`VkFormat::` instead `VkFormatProperties::`)