### PR TITLE
Fix typo: Change 'FENCE_FD' to 'SYNC_FD'

### DIFF
--- a/doc/specs/vulkan/chapters/features.txt
+++ b/doc/specs/vulkan/chapters/features.txt
@@ -6576,7 +6576,7 @@ following table:
 | ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT | Must match | Must match
 | ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT | Must match | Must match
 | ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT | Must match | Must match
-| ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_FENCE_FD_BIT | No restriction | No restriction
+| ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT | No restriction | No restriction
 |====
 
 --


### PR DESCRIPTION
When this enum was renamed, this must have been overlooked.