### PR TITLE
Remove C99/C++ style '//' comments

### DIFF
--- a/include/vulkan/vk_platform.h
+++ b/include/vulkan/vk_platform.h
@@ -1,6 +1,3 @@
-//
-// File: vk_platform.h
-//
 /*
 ** Copyright (c) 2014-2017 The Khronos Group Inc.
 **
@@ -24,7 +21,7 @@
 #ifdef __cplusplus
 extern "C"
 {
-#endif // __cplusplus
+#endif /* __cplusplus */
 
 /*
 ***************************************************************************************************
@@ -47,22 +44,22 @@ extern "C"
  * Function pointer type: typedef void (VKAPI_PTR *PFN_vkCommand)(void);
  */
 #if defined(_WIN32)
-    // On Windows, Vulkan commands use the stdcall convention
+    /* On Windows, Vulkan commands use the stdcall convention */
     #define VKAPI_ATTR
     #define VKAPI_CALL __stdcall
     #define VKAPI_PTR  VKAPI_CALL
 #elif defined(__ANDROID__) && defined(__ARM_ARCH) && __ARM_ARCH < 7
     #error "Vulkan isn't supported for the 'armeabi' NDK ABI"
 #elif defined(__ANDROID__) && defined(__ARM_ARCH) && __ARM_ARCH >= 7 && defined(__ARM_32BIT_STATE)
-    // On Android 32-bit ARM targets, Vulkan functions use the "hardfloat"
-    // calling convention, i.e. float parameters are passed in registers. This
-    // is true even if the rest of the application passes floats on the stack,
-    // as it does by default when compiling for the armeabi-v7a NDK ABI.
+    /* On Android 32-bit ARM targets, Vulkan functions use the "hardfloat"
+       calling convention, i.e. float parameters are passed in registers. This
+       is true even if the rest of the application passes floats on the stack,
+       as it does by default when compiling for the armeabi-v7a NDK ABI. */
     #define VKAPI_ATTR __attribute__((pcs("aapcs-vfp")))
     #define VKAPI_CALL
     #define VKAPI_PTR  VKAPI_ATTR
 #else
-    // On other platforms, use the default calling convention
+    /* On other platforms, use the default calling convention */
     #define VKAPI_ATTR
     #define VKAPI_CALL
     #define VKAPI_PTR
@@ -83,10 +80,10 @@ extern "C"
     #else
         #include <stdint.h>
     #endif
-#endif // !defined(VK_NO_STDINT_H)
+#endif /* !defined(VK_NO_STDINT_H) */
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif

--- a/include/vulkan/vulkan.h
+++ b/include/vulkan/vulkan.h
@@ -76,4 +76,4 @@
 #include "vulkan_xlib_xrandr.h"
 #endif
 
-#endif // VULKAN_H_
+#endif

--- a/include/vulkan/vulkan_core.h
+++ b/include/vulkan/vulkan_core.h
@@ -33,16 +33,16 @@ extern "C" {
 #define VK_MAKE_VERSION(major, minor, patch) \
     (((major) << 22) | ((minor) << 12) | (patch))
 
-// DEPRECATED: This define has been removed. Specific version defines (e.g. VK_API_VERSION_1_0), or the VK_MAKE_VERSION macro, should be used instead.
-//#define VK_API_VERSION VK_MAKE_VERSION(1, 0, 0) // Patch version should always be set to 0
+/* DEPRECATED: This define has been removed. Specific version defines (e.g. VK_API_VERSION_1_0), or the VK_MAKE_VERSION macro, should be used instead. */
+/*#define VK_API_VERSION VK_MAKE_VERSION(1, 0, 0)*/ /* Patch version should always be set to 0 */
 
-// Vulkan 1.0 version number
-#define VK_API_VERSION_1_0 VK_MAKE_VERSION(1, 0, 0)// Patch version should always be set to 0
+/* Vulkan 1.0 version number */
+#define VK_API_VERSION_1_0 VK_MAKE_VERSION(1, 0, 0) /* Patch version should always be set to 0 */
 
 #define VK_VERSION_MAJOR(version) ((uint32_t)(version) >> 22)
 #define VK_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3ff)
 #define VK_VERSION_PATCH(version) ((uint32_t)(version) & 0xfff)
-// Version of this file
+/* Version of this file */
 #define VK_HEADER_VERSION 72
 
 
@@ -3654,8 +3654,8 @@ VKAPI_ATTR void VKAPI_CALL vkCmdExecuteCommands(
 #endif
 
 #define VK_VERSION_1_1 1
-// Vulkan 1.1 version number
-#define VK_API_VERSION_1_1 VK_MAKE_VERSION(1, 1, 0)// Patch version should always be set to 0
+/* Vulkan 1.1 version number */
+#define VK_API_VERSION_1_1 VK_MAKE_VERSION(1, 1, 0) /* Patch version should always be set to 0 */
 
 
 VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkSamplerYcbcrConversion)

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -130,13 +130,13 @@ server.
         <type category="define">#define <name>VK_VERSION_MINOR</name>(version) (((uint32_t)(version) &gt;&gt; 12) &amp; 0x3ff)</type>
         <type category="define">#define <name>VK_VERSION_PATCH</name>(version) ((uint32_t)(version) &amp; 0xfff)</type>
 
-        <type category="define">// DEPRECATED: This define has been removed. Specific version defines (e.g. VK_API_VERSION_1_0), or the VK_MAKE_VERSION macro, should be used instead.
-//#define <name>VK_API_VERSION</name> <type>VK_MAKE_VERSION</type>(1, 0, 0) // Patch version should always be set to 0</type>
-        <type category="define">// Vulkan 1.0 version number
-#define <name>VK_API_VERSION_1_0</name> <type>VK_MAKE_VERSION</type>(1, 0, 0)// Patch version should always be set to 0</type>
-        <type category="define">// Vulkan 1.1 version number
-#define <name>VK_API_VERSION_1_1</name> <type>VK_MAKE_VERSION</type>(1, 1, 0)// Patch version should always be set to 0</type>
-        <type category="define">// Version of this file
+        <type category="define">/* DEPRECATED: This define has been removed. Specific version defines (e.g. VK_API_VERSION_1_0), or the VK_MAKE_VERSION macro, should be used instead. */
+/*#define <name>VK_API_VERSION</name> <type>VK_MAKE_VERSION</type>(1, 0, 0)*/ /* Patch version should always be set to 0 */</type>
+        <type category="define">/* Vulkan 1.0 version number */
+#define <name>VK_API_VERSION_1_0</name> <type>VK_MAKE_VERSION</type>(1, 0, 0) /* Patch version should always be set to 0 */</type>
+        <type category="define">/* Vulkan 1.1 version number */
+#define <name>VK_API_VERSION_1_1</name> <type>VK_MAKE_VERSION</type>(1, 1, 0) /* Patch version should always be set to 0 */</type>
+        <type category="define">/* Version of this file */
 #define <name>VK_HEADER_VERSION</name> 72</type>
 
         <type category="define">
@@ -1215,7 +1215,7 @@ server.
             <member optional="true"><type>uint32_t</type>               <name>clearValueCount</name></member>
             <member len="clearValueCount" noautovalidity="true">const <type>VkClearValue</type>*    <name>pClearValues</name></member>
         </type>
-        <type category="union" name="VkClearColorValue" comment="// Union allowing specification of floating point, integer, or unsigned integer color data. Actual value selected is based on image/attachment being cleared.">
+        <type category="union" name="VkClearColorValue" comment="/* Union allowing specification of floating point, integer, or unsigned integer color data. Actual value selected is based on image/attachment being cleared. */">
             <member><type>float</type>                  <name>float32</name>[4]</member>
             <member><type>int32_t</type>                <name>int32</name>[4]</member>
             <member><type>uint32_t</type>               <name>uint32</name>[4]</member>
@@ -1224,7 +1224,7 @@ server.
             <member><type>float</type>                  <name>depth</name></member>
             <member><type>uint32_t</type>               <name>stencil</name></member>
         </type>
-        <type category="union" name="VkClearValue" comment="// Union allowing specification of color or depth and stencil values. Actual value selected is based on attachment being cleared.">
+        <type category="union" name="VkClearValue" comment="/* Union allowing specification of color or depth and stencil values. Actual value selected is based on attachment being cleared. */">
             <member><type>VkClearColorValue</type>      <name>color</name></member>
             <member><type>VkClearDepthStencilValue</type> <name>depthStencil</name></member>
         </type>


### PR DESCRIPTION
For a project I need to Vulkan headers with a C90 compiler. This works fine except for a few occurrences of C99/C++ style `//` comments. This PR replaces those with `/* ... */` comment blocks.