### PR TITLE
Optimize page load time by hiding content during load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ ATTRIBOPTS   = -a revnumber="$(SPECREVISION)" \
 ADOCEXTS     = -r $(CURDIR)/config/vulkan-macros.rb -r $(CURDIR)/config/tilde_open_block.rb
 ADOCOPTS     = -d book $(ATTRIBOPTS) $(NOTEOPTS) $(VERBOSE) $(ADOCEXTS)
 
-ADOCHTMLEXTS = -r $(CURDIR)/config/katex_replace.rb
+ADOCHTMLEXTS = -r $(CURDIR)/config/katex_replace.rb -r $(CURDIR)/config/loadable_html.rb
 
 # ADOCHTMLOPTS relies on the relative runtime path from the output HTML
 # file to the katex scripts being set with KATEXDIR. This is overridden

--- a/config/loadable_html.rb
+++ b/config/loadable_html.rb
@@ -1,0 +1,21 @@
+# Copyright (c) 2016-2018 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+RUBY_ENGINE == 'opal' ? (require 'loadable_html/extension') : (require_relative 'loadable_html/extension')
+
+# All the inline macros we need
+Asciidoctor::Extensions.register do
+    postprocessor MakeHtmlLoadable
+end

--- a/config/loadable_html/extension.rb
+++ b/config/loadable_html/extension.rb
@@ -1,0 +1,62 @@
+# Copyright (c) 2016-2018 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'asciidoctor/extensions' unless RUBY_ENGINE == 'opal'
+
+include ::Asciidoctor
+
+class MakeHtmlLoadable < Extensions::Postprocessor
+
+  def process document, output
+
+    if document.attr? 'stem'
+
+      loading_msg = '
+<div id="loading_msg"><p>Loading... please wait.</p></div>
+'
+      loadable_class = 'class="loadable"'
+
+      loaded_script = '
+<style>
+    #loading_msg {
+        width: 100%;
+        margin-left: auto;
+        margin-right: auto;
+        margin-top: 1ex;
+        margin-bottom: 1ex;
+        max-width: 62.5em;
+        position: relative;
+        padding-left: 1.5em;
+        padding-right: 1.5em;
+    }
+    .loadable {display: none !important;}
+</style>
+<script>
+    function unhideLoadableContent(){
+        document.getElementById("loading_msg").style.display = "none";
+        var loadables = document.getElementsByClassName("loadable");
+        for( var i = 0; i < loadables.length; ++i ) loadables[i].classList.remove("loadable");
+    }
+
+    window.addEventListener("load", unhideLoadableContent);
+</script>
+'
+
+      output.sub! /(?=<\/head>)/, loaded_script
+      output.sub! /(<div id="content")/, '\1' + " " + loadable_class + " "
+      output.sub! /(?=<div id="content")/, loading_msg
+    end
+    output
+  end
+end


### PR DESCRIPTION
The specification html page load time have again gotten too long. It is a travesty that in 21st century with our buncha-core gazillion Hz CPUs it is in order of tens of seconds to load a page. So I once again look if there is some low hanging fruit to help the situation.

This hides the page until everything is ready, to prevent the browser from trying to do incremental display of partially loaded page. At least for me the browser is largely unresponsive during the load time anyway, so it is no great loss.

Informal measurements [s]:

Browser | Before | #702 | #704 | #708 | #702 + #704  | #702 +  #708 | #704 + #708 | #702 +  #704 + #708 
---------|-------- | ------|------  | ------| --------------- | ----------------| -------------- | ---------------------
Firefox *  | 28        | 12     |  9       |  28   | **6**               | 12                    |   7                  | **6**
Chrome| 30        | 21     |   23    |  23    | 18                  | 14                    |   12                | **10**

\* The Firefox measurements are invalid. I measured offline, and some security policy prevents loading fonts from superfolder in that case.

I also welcome some advice for aditional optimization from someone unlike me that knows and is friends with web technologies.

Some notes for future consideration:
- Math translation takes ~ 7 s &mdash; that can be eliminated by doing it offline (#704)
- The style and layout is calulated twice in Chrome &mdash; I have no idea why at the moment. It wastes ~8 s. (#708)
- I have a suspicion the TOC sidebar gives browsers some trouple. There may also be other tricky elements to layout (tables inside tables?)
- The binary images are inline in the html file. That is bound to create some performance problems...