### PR TITLE
scripts:Account for extnumber key to fix warnings

### DIFF
--- a/xml/reg.py
+++ b/xml/reg.py
@@ -96,11 +96,11 @@ class BaseInfo:
         if selfKeys != infoKeys:
             return False
 
-        # Ignore value of 'extname', as this will inherently be different
-        # when redefining the same interface in different feature and/or
-        # extension blocks.
+        # Ignore value of 'extname' and 'extnumber', as these will inherently
+        # be different when redefining the same interface in different feature
+        # and/or extension blocks.
         for key in selfKeys:
-            if (key != 'extname' and
+            if (key != 'extname' and key != 'extnumber' and
                 (self.elem.get(key) != info.elem.get(key))):
                 return False
 


### PR DESCRIPTION
With the addition of the 'extnumber' key update comparison to skip over
the extnumber as well as extname in order to avoid a bunch of
irrelevant warnings.