### PR TITLE
Add VU for depth/stencil image descriptor

### DIFF
--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -2584,6 +2584,10 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
     pname:imageView must: not be 2D or 2D array image view created from a 3D
     image
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * If pname:imageView is created from a depth/stencil image, the
+    pname:aspectMask used to create the pname:imageView must: include either
+    ename:VK_IMAGE_ASPECT_DEPTH_BIT or ename:VK_IMAGE_ASPECT_STENCIL_BIT but
+    not both.
   * [[VUID-VkDescriptorImageInfo-imageLayout-00344]]
     pname:imageLayout must: match the actual elink:VkImageLayout of each
     subresource accessible from pname:imageView at the time this descriptor


### PR DESCRIPTION
There's a paragraph under VkImageSubresourceRange description that
contains this restriction but no VU under the vkUpdateDescriptors()
section. Adding the VU for clarity as the existing paragraph is easy
to miss.