### PR TITLE
Use [%inline] for all SVGs

### DIFF
--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -101,6 +101,7 @@ Invalid::
     Command buffers in the invalid state can: only be reset or freed.
 
 [[commandbuffer-lifecycle-diagram]]
+[%inline]
 image::images/commandbuffer_lifecycle.svg[title="Lifecycle of a command buffer",align="center"]
 
 Any given command that operates on a command buffer has its own requirements

--- a/chapters/drawing.txt
+++ b/chapters/drawing.txt
@@ -139,6 +139,7 @@ ename:VK_PRIMITIVE_TOPOLOGY_POINT_LIST.
 Each vertex defines a separate point.
 
 .Point Lists
+[%inline]
 image::images/primitive_topology_point_list.svg[align="center"]
 
 
@@ -151,6 +152,7 @@ vertices each defining one more segment.
 If the number of vertices is odd, then the last vertex is ignored.
 
 .Line Lists
+[%inline]
 image::images/primitive_topology_line_list.svg[align="center"]
 
 
@@ -167,6 +169,7 @@ The last vertex specifies the end of the last segment.
 If only one vertex is specified, then no primitive is generated.
 
 .Line Strips
+[%inline]
 image::images/primitive_topology_line_strip.svg[align="center"]
 
 
@@ -181,6 +184,7 @@ where there are [eq]#3 n {plus} k# vertices drawn.
 vertices are ignored.
 
 .Triangle Lists
+[%inline]
 image::images/primitive_topology_triangle_list.svg[align="center"]
 
 
@@ -197,6 +201,7 @@ The order of vertices in successive triangles changes as shown in the figure
 below, so that all triangle faces have the same orientation.
 
 .Triangle Strips
+[%inline]
 image::images/primitive_topology_triangle_strip.svg[align="center"]
 
 
@@ -208,6 +213,7 @@ It is similar to a triangle strip, but changes the vertex replaced from the
 previous triangle so that all triangles in the fan share a common vertex.
 
 .Triangle Fans
+[%inline]
 image::images/primitive_topology_triangle_fan.svg[align="center"]
 
 
@@ -229,6 +235,7 @@ are considered adjacent to vertices [eq]#4 i {plus} 1# and [eq]#4 i {plus}
 2#, respectively.
 
 .Line Lists With Adjacency
+[%inline]
 image::images/primitive_topology_line_list_with_adjacency.svg[align="center"]
 
 
@@ -249,6 +256,7 @@ considered adjacent to vertices [eq]#i {plus} 1# and [eq]#i {plus} 2#,
 respectively.
 
 .Line Strips With Adjacency
+[%inline]
 image::images/primitive_topology_line_strip_with_adjacency.svg[align="center"]
 
 
@@ -271,6 +279,7 @@ For triangle [eq]#i#, vertices [eq]#6 i {plus} 1#, [eq]#6 i {plus} 3#, and
 4#, and from [eq]#6 i {plus} 4# to [eq]#6 i# vertices, respectively.
 
 .Triangle Lists With Adjacency
+[%inline]
 image::images/primitive_topology_triangle_list_with_adjacency.svg[align="center"]
 
 
@@ -288,6 +297,7 @@ are [eq]#2 (n {plus} 2) {plus} k# vertices.
 If there are fewer than 6 vertices, the entire primitive is ignored.
 
 .Triangle Strips With Adjacency
+[%inline]
 image::images/primitive_topology_triangle_strip_with_adjacency.svg[align="center"]
 
 The table below illustrates the vertices and order used to draw each

--- a/chapters/pipelines.txt
+++ b/chapters/pipelines.txt
@@ -56,6 +56,7 @@ Actual ordering guarantees between pipeline stages are explained in detail
 in the <<synchronization-pipeline-stages-order, synchronization chapter>>.
 
 [[pipelines-block-diagram]]
+[%inline]
 image::images/pipeline.svg[title="Block diagram of the Vulkan pipeline",align="center"]
 
 Each pipeline is controlled by a monolithic object created from a

--- a/chapters/primsrast.txt
+++ b/chapters/primsrast.txt
@@ -420,6 +420,7 @@ instructions enabling the application to get direct access to the fragment
 mask and the individual color fragment values.
 
 [[vk-amd-shader-fragment-mask-diagram]]
+[%inline]
 image::images/fragment_mask.svg[align="center",title="Fragment Mask",align="center"]
 
 endif::VK_AMD_shader_fragment_mask[]
@@ -832,6 +833,7 @@ triangles where each pair of vertices at each end of the line has identical
 attributes.
 
 [[fig-non-strict-lines]]
+[%inline]
 image::images/non_strict_lines.svg[align="center",title="Non strict lines"]
 
 

--- a/chapters/sparsemem.txt
+++ b/chapters/sparsemem.txt
@@ -278,6 +278,7 @@ ename:VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT and
 ename:VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT alter memory usage and
 requirements.
 
+[%inline]
 image::images/sparseimage.svg[align="center", title="Sparse Image"]
 
 In the absence of ename:VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT and
@@ -292,11 +293,13 @@ used sparse blocks.
 Any bound partially-used-sparse-blocks must: still have their full sparse
 block size in bytes allocated in memory.
 
+[%inline]
 image::images/sparseimage_singlemiptail.svg[align="center", title="Sparse Image with Single Mip Tail"]
 
 When ename:VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT is present all array
 layers will share a single mip tail region.
 
+[%inline]
 image::images/sparseimage_alignedmipsize.svg[align="center", title="Sparse Image with Aligned Mip Size"]
 
 [NOTE]
@@ -317,6 +320,7 @@ Only the first [eq]#N# mip levels whose dimensions are an exact multiple of
 the sparse image block dimensions can: be bound and unbound on a sparse
 block basis.
 
+[%inline]
 image::images/sparseimage_alignedmipsize_singlemiptail.svg[align="center", title="Sparse Image with Aligned Mip Size and Single Mip Tail"]
 
 [NOTE]
@@ -432,6 +436,7 @@ memory allocation for implementation-private _metadata_ associated with the
 image.
 See the figure below:
 
+[%inline]
 image::images/sparseimage_multiaspect.svg[align="center",title="Multiple Aspect Sparse Image"]
 
 [NOTE]

--- a/chapters/tessellation.txt
+++ b/chapters/tessellation.txt
@@ -89,10 +89,12 @@ The domain space has an upper-left origin.
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
 
 [[img-tessellation-topology-ul]]
+[%inline]
 image::images/tessparamUL.svg[align="center",title="Domain parameterization for tessellation primitive modes (upper-left origin)"]
 
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
 [[img-tessellation-topology-ll]]
+[%inline]
 image::images/tessparam.svg[align="center",title="Domain parameterization for tessellation primitive modes (lower-left origin)"]
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
 
@@ -296,6 +298,7 @@ This subdivision process is illustrated in <<img-innertri,Inner Triangle
 Tessellation>>.
 
 [[img-innertri]]
+[%inline]
 image::images/innertri.svg[align="center",title="Inner Triangle Tessellation"]
 
 .Caption
@@ -406,6 +409,7 @@ This subdivision is illustrated in Figure <<img-innerquad,Inner Quad
 Tessellation>>.
 
 [[img-innerquad]]
+[%inline]
 image::images/innerquad.svg[align="center",title="Inner Quad Tessellation"]
 
 .Caption

--- a/chapters/textures.txt
+++ b/chapters/textures.txt
@@ -125,6 +125,7 @@ n is the sample index and is taken from the code:Sample image operand.
 For all coordinate types, unused coordinates are assigned a value of zero.
 
 [[textures-texel-coordinate-systems-diagrams]]
+[%inline]
 image::images/vulkantexture0.svg[align="center",title="Texel Coordinate Systems"]
 The Texel Coordinate Systems - For the example shown of an 8{times}4 texel
 two dimensional image.
@@ -166,6 +167,7 @@ the unnormalized coordinate space of the lower-resolution channels.
 ====
 endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
 
+[%inline]
 image::images/vulkantexture1.svg[align="center",title="Texel Coordinate Systems"]
 
 The Texel Coordinate Systems - For the example shown of an 8{times}4 texel
@@ -839,16 +841,22 @@ positions where required for interpolation.
 The limits of a sample for etext:NEAREST sampling is shown as a grid.
 ====
 
+[%inline]
 image::images/chromasamples_422_cosited.svg[align="center",title="422 downsampling, xChromaOffset=COSITED_EVEN"]
 
+[%inline]
 image::images/chromasamples_422_midpoint.svg[align="center",title="422 downsampling, xChromaOffset=MIDPOINT"]
 
+[%inline]
 image::images/chromasamples_420_xcosited_ycosited.svg[align="center",title="420 downsampling, xChromaOffset=COSITED_EVEN, yChromaOffset=COSITED_EVEN"]
 
+[%inline]
 image::images/chromasamples_420_xmidpoint_ycosited.svg[align="center",title="420 downsampling, xChromaOffset=MIDPOINT, yChromaOffset=COSITED_EVEN"]
 
+[%inline]
 image::images/chromasamples_420_xcosited_ymidpoint.svg[align="center",title="420 downsampling, xChromaOffset=COSITED_EVEN, yChromaOffset=MIDPOINT"]
 
+[%inline]
 image::images/chromasamples_420_xmidpoint_ymidpoint.svg[align="center",title="420 downsampling, xChromaOffset=MIDPOINT, yChromaOffset=MIDPOINT"]
 
 Reconstruction is implemented in one of two ways:
@@ -1290,6 +1298,7 @@ SPIR-V derivative instructions include code:OpDPdx, code:OpDPdy,
 code:OpDPdxFine, code:OpDPdyFine, code:OpDPdxCoarse, and code:OpDPdyCoarse.
 Derivative instructions are only available in a fragment shader.
 
+[%inline]
 image::images/vulkantexture2.svg[align="center",title="Implicit Derivatives"]
 
 Derivatives are computed as if there is a 2{times}2 neighborhood of


### PR DESCRIPTION
This inlines `<svg>` elements in the HTML, instead of using `<img>` tags with `src="data:..."`.

Provides a 12.6% size savings for vkspec.html
(697770 B -> 609679 B, when served gzipped, as on khronos.org), because:
1. plaintext is smaller than base64-encoded plaintext, and
2. base64 does not gzip as well as plaintext SVG.

Documentation on `[%inline]` can be found here:
https://github.com/asciidoctor/asciidoctor-bespoke#inserting-svgs