### PR TITLE
Fix VkSubpassDependency self-dependency stage VU

### DIFF
--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1097,10 +1097,9 @@ layouts as follows:
   * [[VUID-VkSubpassDependency-srcSubpass-00865]]
     pname:srcSubpass and pname:dstSubpass must: not both be equal to
     ename:VK_SUBPASS_EXTERNAL
-  * [[VUID-VkSubpassDependency-srcSubpass-00866]]
-    If pname:srcSubpass is equal to pname:dstSubpass, pname:srcStageMask and
-    pname:dstStageMask must: only contain
-    ename:VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, or one of the
+  * If pname:srcSubpass is equal to pname:dstSubpass, pname:srcStageMask and
+    pname:dstStageMask must: not set any bits that are not
+    ename:VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, or not one of the
     <<synchronization-pipeline-stages-types,graphics pipeline stages>>
   * [[VUID-VkSubpassDependency-srcSubpass-00867]]
     If pname:srcSubpass is equal to pname:dstSubpass and not all of the

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1099,23 +1099,9 @@ layouts as follows:
     ename:VK_SUBPASS_EXTERNAL
   * [[VUID-VkSubpassDependency-srcSubpass-00866]]
     If pname:srcSubpass is equal to pname:dstSubpass, pname:srcStageMask and
-    pname:dstStageMask must: only contain one of
-    ename:VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-ifdef::VK_EXT_conditional_rendering[]
-    ename:VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT,
-endif::VK_EXT_conditional_rendering[]
-    ename:VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT,
-    ename:VK_PIPELINE_STAGE_VERTEX_INPUT_BIT,
-    ename:VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
-    ename:VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT,
-    ename:VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT,
-    ename:VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT,
-    ename:VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-    ename:VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
-    ename:VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
-    ename:VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-    ename:VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, or
-    ename:VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT
+    pname:dstStageMask must: only contain
+    ename:VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, or one of the
+    <<synchronization-pipeline-stages-types,graphics pipeline stages>>
   * [[VUID-VkSubpassDependency-srcSubpass-00867]]
     If pname:srcSubpass is equal to pname:dstSubpass and not all of the
     stages in pname:srcStageMask and pname:dstStageMask are

--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -549,8 +549,9 @@ guaranteed:
   * ename:VK_PIPELINE_STAGE_HOST_BIT
 
 ifdef::VK_EXT_conditional_rendering[]
-For conditional rendering operations, the pipeline stage where predicate
-read happens has no particular order relative to other stages.
+The conditional rendering stage is formally part of both the graphics, and
+the compute pipeline. The pipeline stage where the predicate read happens
+has unspecified order relative to other stages of these pipelines:
 
   * ename:VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT
 endif::VK_EXT_conditional_rendering[]


### PR DESCRIPTION
Fix VkSubpassDependency self-dependency stage VU

- Fix `ifdef` inside VU entry, which e.g. breaks the `validusage.json`.
- Allow multiple stage bits to be set, not just one. (Other VUs seem to expect multiple bits, and there's no reason to ban it I think).