### PR TITLE
Make cond. rendering order relative to TOP and BOTTOM

### DIFF
--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -540,10 +540,13 @@ For the compute pipeline, the following stages occur in this order:
 ifdef::VK_EXT_conditional_rendering[]
 The conditional rendering stage is formally part of both the graphics, and
 the compute pipeline.
-The pipeline stage where the predicate read happens has unspecified order
-relative to other stages of these pipelines:
+But the pipeline stage where the predicate read happens has unspecified
+order relative to other stages of these pipelines.
+Only the following stages occur in this order:
 
+  * ename:VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT
   * ename:VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT
+  * ename:VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT
 endif::VK_EXT_conditional_rendering[]
 
 For the transfer pipeline, the following stages occur in this order:


### PR DESCRIPTION
Make `VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT` stage order relative to `VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT` and `VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT`.

Fixes #739.