### PR TITLE
Reapply #742:  Make STAGE_CONDITIONAL_RENDERING part of graphics pipe

### DIFF
--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -537,6 +537,14 @@ For the compute pipeline, the following stages occur in this order:
   * ename:VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
   * ename:VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT
 
+ifdef::VK_EXT_conditional_rendering[]
+The conditional rendering stage is formally part of both the graphics, and
+the compute pipeline. The pipeline stage where the predicate read happens
+has unspecified order relative to other stages of these pipelines:
+
+  * ename:VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT
+endif::VK_EXT_conditional_rendering[]
+
 For the transfer pipeline, the following stages occur in this order:
 
   * ename:VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT
@@ -547,13 +555,6 @@ For host operations, only one pipeline stage occurs, so no order is
 guaranteed:
 
   * ename:VK_PIPELINE_STAGE_HOST_BIT
-
-ifdef::VK_EXT_conditional_rendering[]
-For conditional rendering operations, the pipeline stage where predicate
-read happens has no particular order relative to other stages.
-
-  * ename:VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT
-endif::VK_EXT_conditional_rendering[]
 
 ifdef::VK_NVX_device_generated_commands[]
 For the command processing pipeline, the following stages occur in this


### PR DESCRIPTION
` VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT` has to be defined as part of graphics pipeline in order for VU modified in #742 to be accurate