### PR TITLE
Add some missing "optional" attributes

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -747,9 +747,9 @@ server.
             <member><type>VkDeviceSize</type>           <name>range</name><comment>Size in bytes of the buffer resource for this descriptor update.</comment></member>
         </type>
         <type category="struct" name="VkDescriptorImageInfo">
-            <member noautovalidity="true"><type>VkSampler</type>       <name>sampler</name><comment>Sampler to write to the descriptor in case it is a SAMPLER or COMBINED_IMAGE_SAMPLER descriptor. Ignored otherwise.</comment></member>
-            <member noautovalidity="true"><type>VkImageView</type>     <name>imageView</name><comment>Image view to write to the descriptor in case it is a SAMPLED_IMAGE, STORAGE_IMAGE, COMBINED_IMAGE_SAMPLER, or INPUT_ATTACHMENT descriptor. Ignored otherwise.</comment></member>
-            <member noautovalidity="true"><type>VkImageLayout</type>   <name>imageLayout</name><comment>Layout the image is expected to be in when accessed using this descriptor (only used if imageView is not VK_NULL_HANDLE).</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkSampler</type>       <name>sampler</name><comment>Sampler to write to the descriptor in case it is a SAMPLER or COMBINED_IMAGE_SAMPLER descriptor. Ignored otherwise.</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkImageView</type>     <name>imageView</name><comment>Image view to write to the descriptor in case it is a SAMPLED_IMAGE, STORAGE_IMAGE, COMBINED_IMAGE_SAMPLER, or INPUT_ATTACHMENT descriptor. Ignored otherwise.</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkImageLayout</type>   <name>imageLayout</name><comment>Layout the image is expected to be in when accessed using this descriptor (only used if imageView is not VK_NULL_HANDLE).</comment></member>
         </type>
         <type category="struct" name="VkWriteDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET"><type>VkStructureType</type> <name>sType</name></member>
@@ -1558,7 +1558,7 @@ server.
             <member><type>VkBool32</type>                         <name>persistentContent</name><comment>VK_TRUE if this is a "smart" display that supports self-refresh/internal buffering.</comment></member>
         </type>
         <type category="struct" name="VkDisplayPlanePropertiesKHR" returnedonly="true">
-            <member><type>VkDisplayKHR</type>                     <name>currentDisplay</name><comment>Display the plane is currently associated with.  Will be VK_NULL_HANDLE if the plane is not in use.</comment></member>
+            <member optional="true"><type>VkDisplayKHR</type>                     <name>currentDisplay</name><comment>Display the plane is currently associated with.  Will be VK_NULL_HANDLE if the plane is not in use.</comment></member>
             <member><type>uint32_t</type>                         <name>currentStackIndex</name><comment>Current z-order of the plane.</comment></member>
         </type>
         <type category="struct" name="VkDisplayModeParametersKHR">

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -738,7 +738,7 @@ server.
             <member><type>VkExtent3D</type>             <name>maxExtent</name><comment>max image dimensions for this resource type</comment></member>
             <member><type>uint32_t</type>               <name>maxMipLevels</name><comment>max number of mipmap levels for this resource type</comment></member>
             <member><type>uint32_t</type>               <name>maxArrayLayers</name><comment>max array size for this resource type</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampleCounts</name><comment>supported sample counts for this resource type</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>sampleCounts</name><comment>supported sample counts for this resource type</comment></member>
             <member><type>VkDeviceSize</type>           <name>maxResourceSize</name><comment>max size (in bytes) of this resource type</comment></member>
         </type>
         <type category="struct" name="VkDescriptorBufferInfo">
@@ -1467,16 +1467,16 @@ server.
             <member><type>uint32_t</type>               <name>maxFramebufferWidth</name><comment>max width for a framebuffer</comment></member>
             <member><type>uint32_t</type>               <name>maxFramebufferHeight</name><comment>max height for a framebuffer</comment></member>
             <member><type>uint32_t</type>               <name>maxFramebufferLayers</name><comment>max layer count for a layered framebuffer</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferColorSampleCounts</name><comment>supported color sample counts for a framebuffer</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferDepthSampleCounts</name><comment>supported depth sample counts for a framebuffer</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferStencilSampleCounts</name><comment>supported stencil sample counts for a framebuffer</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>framebufferNoAttachmentsSampleCounts</name><comment>supported sample counts for a framebuffer with no attachments</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>framebufferColorSampleCounts</name><comment>supported color sample counts for a framebuffer</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>framebufferDepthSampleCounts</name><comment>supported depth sample counts for a framebuffer</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>framebufferStencilSampleCounts</name><comment>supported stencil sample counts for a framebuffer</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>framebufferNoAttachmentsSampleCounts</name><comment>supported sample counts for a framebuffer with no attachments</comment></member>
             <member><type>uint32_t</type>               <name>maxColorAttachments</name><comment>max number of color attachments per subpass</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageColorSampleCounts</name><comment>supported color sample counts for a non-integer sampled image</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageIntegerSampleCounts</name><comment>supported sample counts for an integer image</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageDepthSampleCounts</name><comment>supported depth sample counts for a sampled image</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageStencilSampleCounts</name><comment>supported stencil sample counts for a sampled image</comment></member>
-            <member optional="true"><type>VkSampleCountFlags</type>     <name>storageImageSampleCounts</name><comment>supported sample counts for a storage image</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>sampledImageColorSampleCounts</name><comment>supported color sample counts for a non-integer sampled image</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>sampledImageIntegerSampleCounts</name><comment>supported sample counts for an integer image</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>sampledImageDepthSampleCounts</name><comment>supported depth sample counts for a sampled image</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>sampledImageStencilSampleCounts</name><comment>supported stencil sample counts for a sampled image</comment></member>
+            <member><type>VkSampleCountFlags</type>     <name>storageImageSampleCounts</name><comment>supported sample counts for a storage image</comment></member>
             <member><type>uint32_t</type>               <name>maxSampleMaskWords</name><comment>max number of sample mask words</comment></member>
             <member><type>VkBool32</type>               <name>timestampComputeAndGraphics</name><comment>timestamps on graphics and compute queues</comment></member>
             <member><type>float</type>                  <name>timestampPeriod</name><comment>number of nanoseconds it takes for timestamp query value to increment by 1</comment></member>


### PR DESCRIPTION
The comments on these members suggest that it is sometimes legal for them to contain `VK_NULL_HANDLE`, or in some cases an undefined value. Unless I've misunderstood the schema, it seems like they should therefore be marked as optional.