### PR TITLE
Fix contacts split with comma

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -7065,13 +7065,13 @@ server.
                 <enum value="&quot;VK_AMD_extension_20&quot;"                   name="VK_AMD_EXTENSION_20_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_AMD_shader_trinary_minmax" number="21" type="device" author="AMD" contact="Qun Lin, AMD @linqun" supported="vulkan">
+        <extension name="VK_AMD_shader_trinary_minmax" number="21" type="device" author="AMD" contact="Qun Lin @linqun" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_AMD_SHADER_TRINARY_MINMAX_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_shader_trinary_minmax&quot;"          name="VK_AMD_SHADER_TRINARY_MINMAX_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_AMD_shader_explicit_vertex_parameter" number="22" type="device" author="AMD" contact="Qun Lin, AMD @linqun" supported="vulkan">
+        <extension name="VK_AMD_shader_explicit_vertex_parameter" number="22" type="device" author="AMD" contact="Qun Lin @linqun" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_shader_explicit_vertex_parameter&quot;" name="VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_EXTENSION_NAME"/>
@@ -8306,7 +8306,7 @@ server.
                 <enum value="&quot;VK_KHR_storage_buffer_storage_class&quot;" name="VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_AMD_gpu_shader_int16" number="133" type="device" author="AMD" contact="Qun Lin, AMD @linqun" supported="vulkan">
+        <extension name="VK_AMD_gpu_shader_int16" number="133" type="device" author="AMD" contact="Qun Lin @linqun" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_AMD_GPU_SHADER_INT16_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_gpu_shader_int16&quot;"           name="VK_AMD_GPU_SHADER_INT16_EXTENSION_NAME"/>


### PR DESCRIPTION
comma is a separator and cannot be within single contact item