### PR TITLE
Remove misleading wording in VkDescriptorBufferInfo::buffer comment

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -742,7 +742,7 @@ server.
             <member><type>VkDeviceSize</type>           <name>maxResourceSize</name><comment>max size (in bytes) of this resource type</comment></member>
         </type>
         <type category="struct" name="VkDescriptorBufferInfo">
-            <member><type>VkBuffer</type>               <name>buffer</name><comment>Buffer used for this descriptor slot when the descriptor is UNIFORM_BUFFER[_DYNAMIC] or STORAGE_BUFFER[_DYNAMIC]. VK_NULL_HANDLE otherwise.</comment></member>
+            <member><type>VkBuffer</type>               <name>buffer</name><comment>Buffer used for this descriptor slot.</comment></member>
             <member><type>VkDeviceSize</type>           <name>offset</name><comment>Base offset from buffer start in bytes to update in the descriptor set.</comment></member>
             <member><type>VkDeviceSize</type>           <name>range</name><comment>Size in bytes of the buffer resource for this descriptor update.</comment></member>
         </type>


### PR DESCRIPTION
This wording appears to refer to the conditions under which e.g. the `pBufferInfo` member of `VkWriteDescriptorSet` is not ignored, rather than the field in question, which to my reading must always be set to a valid buffer in a non-ignored `VkDescriptorBufferInfo`.

CC @krOoze