### PR TITLE
WIP: Allow additional handle type safety in C++

### DIFF
--- a/include/vulkan/vulkan_core.h
+++ b/include/vulkan/vulkan_core.h
@@ -46,7 +46,12 @@ extern "C" {
 #define VK_HEADER_VERSION 82
 
 
-#define VK_NULL_HANDLE 0
+#if defined(__cplusplus) && ( __cplusplus >= 201100 || _MSC_VER >= 1800)
+    struct Null_t{ explicit operator uint64_t() const { return 0; } };
+    #define VK_NULL_HANDLE Null_t{}
+#else
+    #define VK_NULL_HANDLE 0
+#endif
         
 
 
@@ -54,7 +59,23 @@ extern "C" {
 
 
 #if !defined(VK_DEFINE_NON_DISPATCHABLE_HANDLE)
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+#if defined(__cplusplus) && ( __cplusplus >= 201100 || _MSC_VER >= 1800)
+        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) \
+            class object{ \
+            private: \
+                uint64_t h; \
+            public: \
+                object(){}; \
+                object( const Null_t& nh ){ h = static_cast<uint64_t>(nh); } \
+                explicit object( const uint64_t rh ){ h = rh; } \
+                explicit operator bool() const{ return this->h; } \
+                explicit operator uint64_t() const { return this->h; } \
+                bool operator==( const object& o ) const{ return this->h == o.h; } \
+                bool operator==( const Null_t& nh ) const{ return this->h == static_cast<uint64_t>(nh); } \
+                bool operator!=( const object& o ) const{ return this->h != o.h; } \
+                bool operator!=( const Null_t& nh ) const{ return this->h != static_cast<uint64_t>(nh); } \
+            };
+#elif defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
         #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object##_T *object;
 #else
         #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef uint64_t object;

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -154,7 +154,23 @@ server.
 
         <type category="define" name="VK_DEFINE_NON_DISPATCHABLE_HANDLE">
 #if !defined(VK_DEFINE_NON_DISPATCHABLE_HANDLE)
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) &amp;&amp; !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+#if defined(__cplusplus) &amp;&amp; ( __cplusplus >= 201100 || _MSC_VER >= 1800)
+        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) \
+            class object{ \
+            private: \
+                uint64_t h; \
+            public: \
+                object(){}; \
+                object( const Null_t&amp; nh ){ h = static_cast&lt;uint64_t&gt;(nh); } \
+                explicit object( const uint64_t rh ){ h = rh; } \
+                explicit operator bool() const{ return this->h; } \
+                explicit operator uint64_t() const { return this->h; } \
+                bool operator==( const object&amp; o ) const{ return this->h == o.h; } \
+                bool operator==( const Null_t&amp; nh ) const{ return this->h == static_cast&lt;uint64_t&gt;(nh); } \
+                bool operator!=( const object&amp; o ) const{ return this->h != o.h; } \
+                bool operator!=( const Null_t&amp; nh ) const{ return this->h != static_cast&lt;uint64_t&gt;(nh); } \
+            };
+#elif defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) &amp;&amp; !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
         #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object##_T *object;
 #else
         #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef uint64_t object;
@@ -162,8 +178,13 @@ server.
 #endif
         </type>
 
-        <type category="define">
-#define <name>VK_NULL_HANDLE</name> 0
+        <type category="define" name="VK_NULL_HANDLE">
+#if defined(__cplusplus) &amp;&amp; ( __cplusplus >= 201100 || _MSC_VER >= 1800)
+    struct Null_t{ explicit operator uint64_t() const { return 0; } };
+    #define VK_NULL_HANDLE Null_t{}
+#else
+    #define VK_NULL_HANDLE 0
+#endif
         </type>
 
         <type category="define">struct <name>ANativeWindow</name>;</type>


### PR DESCRIPTION
Allow additional handle type safety in C++ through use of classes.
Inspired by https://stackoverflow.com/questions/51743500/why-do-non-dispatchable-handles-use-a-ptr-on-64bit-platofrms which claimed "C and **C++** don't have strong typedefs".

Pros:
 - proper static handle types
 - control over what operations and conversions are allowed over handles
 - Actually seems to work on Windows (https://docs.microsoft.com/en-us/cpp/build/parameter-passing claims 64 bit structs behave as integers in ABI)
 - prolly can be same for 32 and 64 bits platform

Cons:
 - the XML mess
 - overhead risk ? (if compiler is dumb)
 - ?

WIP:
 - investigate ABI on other platforms (and gate this appropriatelly in the header)
 - investigate what operations people use (or would like to) on handles
 - make similar stuff for dispatchable handles
 - needs testing

Anyway, I would like your thoughts in the meantime.
