### PR TITLE
sRGB enabled based on image view format

### DIFF
--- a/chapters/textures.txt
+++ b/chapters/textures.txt
@@ -578,7 +578,7 @@ elink:VkFormat), using the appropriate equations in
 <<textures-sexp-RGB,Shared Exponent to RGB>>.
 Signed integer components smaller than 32 bits are sign-extended.
 
-If the image format is sRGB, the color components are first converted as if
+If the image view format is sRGB, the color components are first converted as if
 they are UNORM, and then sRGB to linear conversion is applied to the R, G,
 and B components as described in the "`sRGB EOTF`" section of the
 <<data-format,Khronos Data Format Specification>>.


### PR DESCRIPTION
Merge this branch if the sRGB conversion is enabled based on the **image view** format, and not based on the **image** format.