### PR TITLE
Add self-dependency `VK_DEPENDENCY_BY_REGION_BIT` VU

### DIFF
--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1115,12 +1115,16 @@ layouts as follows:
     Any access flag included in pname:srcAccessMask must: be supported by
     one of the pipeline stages in pname:srcStageMask, as specified in the
     <<synchronization-access-types-supported, table of supported access
-    types>>.
+    types>>
   * [[VUID-VkSubpassDependency-dstAccessMask-00869]]
     Any access flag included in pname:dstAccessMask must: be supported by
     one of the pipeline stages in pname:dstStageMask, as specified in the
     <<synchronization-access-types-supported, table of supported access
-    types>>.
+    types>>
+  * If pname:srcSubpass equals pname:dstSubpass, and pname:srcStageMask and
+    pname:dstStageMask both include a
+    <<synchronization-framebuffer-regions,framebuffer-space stage>>, then
+    pname:dependencyFlags must: include ename:VK_DEPENDENCY_BY_REGION_BIT
 ifdef::VK_VERSION_1_1,VK_KHR_multiview[]
   * [[VUID-VkSubpassDependency-dependencyFlags-00870]]
     If pname:dependencyFlags includes ename:VK_DEPENDENCY_VIEW_LOCAL_BIT,
@@ -1843,6 +1847,10 @@ corresponding subpass dependency.
   * [[VUID-VkSubpassDependency2KHR-dependencyFlags-03091]]
     If pname:dependencyFlags includes ename:VK_DEPENDENCY_VIEW_LOCAL_BIT,
     pname:dstSubpass must: not be equal to ename:VK_SUBPASS_EXTERNAL
+  * If pname:srcSubpass equals pname:dstSubpass, and pname:srcStageMask and
+    pname:dstStageMask both include a
+    <<synchronization-framebuffer-regions,framebuffer-space stage>>, then
+    pname:dependencyFlags must: include ename:VK_DEPENDENCY_BY_REGION_BIT
   * [[VUID-VkSubpassDependency2KHR-dependencyFlags-03092]]
     If pname:dependencyFlags does not include
     ename:VK_DEPENDENCY_VIEW_LOCAL_BIT, pname:viewOffset must: be `0`


### PR DESCRIPTION
as required in the 6.6.1. Subpass Self-dependency chapter:

> If the source and destination stage masks both include _framebuffer-space stages_, then `dependencyFlags` **must** include `VK_DEPENDENCY_BY_REGION_BIT`.