### PR TITLE
Fix a small typo in chapter 24.6.1: Basic Line Segment Rasterization

### DIFF
--- a/chapters/primsrast.txt
+++ b/chapters/primsrast.txt
@@ -770,7 +770,7 @@ t = {{( \mathbf{p}_r - \mathbf{p}_a ) \cdot ( \mathbf{p}_b - \mathbf{p}_a )}
     \over {\| \mathbf{p}_b - \mathbf{p}_a \|^2 }}
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-(Note that [eq]#t = 0# at [eq]#**p**_a# and [eq]#t = 1# at [eq]#**p**~b~#.
+(Note that [eq]#t = 0# at [eq]#**p**~a~# and [eq]#t = 1# at [eq]#**p**~b~#.
 Also note that this calculation projects the vector from [eq]#**p**~a~# to
 [eq]#**p**~r~# onto the line, and thus computes the normalized distance of
 the fragment along the line.)


### PR DESCRIPTION
A small typo. PTAL. 

For your convenience, you can find out the text by search "Note that t = 0" at the latest Vulkan spec (1.1.83): https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html. 