### PR TITLE
Better specify parameter mapping for VK_KHR_create_renderpass2 

### DIFF
--- a/appendices/VK_KHR_create_renderpass2.txt
+++ b/appendices/VK_KHR_create_renderpass2.txt
@@ -18,9 +18,24 @@ ptext:sType/ptext:pNext members.
 Additionally, the renderpass begin/next/end commands have been augmented
 with new extensible structures for passing additional subpass information.
 
-Parameters from the <<VK_KHR_multiview>> and <<VK_KHR_maintenance2>>
-extensions which previously extended slink:VkRenderPassCreateInfo are folded
-into the new structures in more appropriate locations.
+The slink:VkRenderPassMultiviewCreateInfo and
+slink:VkInputAttachmentAspectReference structures that extended the
+original slink:VkRenderPassCreateInfo are not accepted into the new
+creation functions, and instead their parameters are folded into this
+extension as follows:
+
+  * Elements of slink:VkRenderPassMultiviewCreateInfo::pname:pViewMasks are
+    now specified in slink:VkSubpassDescription2KHR::pname:viewMask.
+  * Elements of slink:VkRenderPassMultiviewCreateInfo::pname:pViewOffsets
+    are now specified in slink:VkSubpassDependency2KHR::pname:viewOffset.
+  * slink:VkRenderPassMultiviewCreateInfo::pname:correlationMaskCount and
+    slink:VkRenderPassMultiviewCreateInfo::pname:pCorrelationMasks are
+    directly specified in slink::VkRenderPassCreateInfo2KHR.
+  * slink:VkInputAttachmentAspectReference::pname:aspectMask is now
+    specified in the relevant input attachment description in
+    slink:VkAttachmentDescription2KHR::pname:aspectMask
+
+The details of these mappings are explained fully in the new structures.
 
 === New Enum Constants
 


### PR DESCRIPTION
The appendix for VK_KHR_create_renderpass2 now points explicitly at structures and parameters mapped into the new extension.

Addresses https://github.com/KhronosGroup/Vulkan-Docs/issues/736#issuecomment-403218142