### PR TITLE
Fix special characters in GitHub contacts links (fix PR #770)

### DIFF
--- a/xml/extensionmetadocgenerator.py
+++ b/xml/extensionmetadocgenerator.py
@@ -254,7 +254,7 @@ class Extension:
             if handle.startswith('gitlab:'):
                 prettyHandle = 'icon:gitlab[alt=GitLab, role="red"]' + handle.replace('gitlab:@', '')
             elif handle.startswith('@'):
-                trackerLink = 'https://github.com/KhronosGroup/Vulkan-Docs/issues/new?title=' + self.name + ':%20&body=' + handle + '%20'
+                trackerLink = 'link:++https://github.com/KhronosGroup/Vulkan-Docs/issues/new?title=' + self.name + ':%20&body=' + handle + '%20++'
                 prettyHandle = trackerLink + '[icon:github[alt=GitHub, role="black"]' + handle[1:] + ']'
             else:
                 prettyHandle = handle


### PR DESCRIPTION
Fixes:

>asciidoctor: WARNING: image to embed not found or not readable: /mnt/c/Dev/_GitHub/Vulkan-Docs/%20&amp;body=@alonorbach%20+