### PR TITLE
debug_utils: Fix issues discovered by @krOoze

### DIFF
--- a/chapters/VK_EXT_debug_utils.txt
+++ b/chapters/VK_EXT_debug_utils.txt
@@ -42,6 +42,12 @@ include::../api/protos/vkSetDebugUtilsObjectNameEXT.txt[]
     slink:VkDebugUtilsObjectNameInfoEXT structure specifying the parameters
     of the name to set on the object.
 
+.Valid Usage
+****
+  * pname:pNameInfo\->pname:objectType must: not be ename:VK_OBJECT_TYPE_UNKNOWN
+  * pname:pNameInfo\->pname:objectHandle must: not be dlink:VK_NULL_HANDLE
+****
+
 include::../validity/protos/vkSetDebugUtilsObjectNameEXT.txt[]
 
 --
@@ -68,13 +74,14 @@ removed.
 
 .Valid Usage
 ****
-  * [[VUID-VkDebugUtilsObjectNameInfoEXT-objectType-01905]]
-    pname:objectType must: not be ename:VK_OBJECT_TYPE_UNKNOWN
-  * [[VUID-VkDebugUtilsObjectNameInfoEXT-objectHandle-01906]]
+  * If pname:objectType is ename:VK_OBJECT_TYPE_UNKNOWN,
     pname:objectHandle must: not be dlink:VK_NULL_HANDLE
-  * [[VUID-VkDebugUtilsObjectNameInfoEXT-objectHandle-01907]]
-    pname:objectHandle must: be a Vulkan object of the type associated with
-    pname:objectType as defined in <<debugging-object-types>>.
+  * If pname:objectType is not ename:VK_OBJECT_TYPE_UNKNOWN,
+    pname:objectHandle must: be dlink:VK_NULL_HANDLE or
+    a valid Vulkan handle of the type associated with pname:objectType
+    as defined in the
+    <<debugging-object-types, VkObjectType and Vulkan Handle Relationship>>
+    table
 ****
 
 include::../validity/structs/VkDebugUtilsObjectNameInfoEXT.txt[]
@@ -134,11 +141,11 @@ be used by that implementation.
 ****
   * [[VUID-VkDebugUtilsObjectTagInfoEXT-objectType-01908]]
     pname:objectType must: not be ename:VK_OBJECT_TYPE_UNKNOWN
-  * [[VUID-VkDebugUtilsObjectTagInfoEXT-objectHandle-01909]]
-    pname:objectHandle must: not be dlink:VK_NULL_HANDLE
   * [[VUID-VkDebugUtilsObjectTagInfoEXT-objectHandle-01910]]
-    pname:objectHandle must: be a Vulkan object of the type associated with
-    pname:objectType as defined in <<debugging-object-types>>.
+    pname:objectHandle must: be a valid Vulkan handle of the type associated
+    with pname:objectType as defined in the
+    <<debugging-object-types, VkObjectType and Vulkan Handle Relationship>>
+    table
 ****
 
 include::../validity/structs/VkDebugUtilsObjectTagInfoEXT.txt[]
@@ -377,6 +384,10 @@ include::../api/protos/vkCreateDebugUtilsMessengerEXT.txt[]
     sname:VkDebugUtilsMessengerEXT object created.
 
 include::../validity/protos/vkCreateDebugUtilsMessengerEXT.txt[]
+
+The application must: ensure that flink:vkCreateDebugUtilsMessengerEXT is not
+executed in parallel with any Vulkan command that is also called with
+pname:instance or child of pname:instance as the dispatchable argument.
 
 --
 
@@ -648,7 +659,15 @@ The parameters are passed on to the callback in addition to the
 pname:pUserData value that was defined at the time the messenger was
 registered.
 
+.Valid Usage
+****
+  * pname:objectType member of each element of
+    pname:pCallbackData\->pname:pObjects must: not be
+    ename:VK_OBJECT_TYPE_UNKNOWN
+****
+
 include::../validity/protos/vkSubmitDebugUtilsMessageEXT.txt[]
+
 
 --
 
@@ -679,6 +698,10 @@ include::../api/protos/vkDestroyDebugUtilsMessengerEXT.txt[]
 ****
 
 include::../validity/protos/vkDestroyDebugUtilsMessengerEXT.txt[]
+
+The application must: ensure that flink:vkDestroyDebugUtilsMessengerEXT is not
+executed in parallel with any Vulkan command that is also called with
+pname:instance or child of pname:instance as the dispatchable argument.
 
 --
 

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -2998,11 +2998,11 @@ server.
             <member optional="true"><type>int32_t</type>                                                            <name>messageIdNumber</name></member>
             <member len="null-terminated">const <type>char</type>*                                                  <name>pMessage</name></member>
             <member optional="true"><type>uint32_t</type>                                                           <name>queueLabelCount</name></member>
-            <member noautovalidity="true" optional="true" len="queueLabelCount"><type>VkDebugUtilsLabelEXT</type>*  <name>pQueueLabels</name></member>
+            <member len="queueLabelCount">const <type>VkDebugUtilsLabelEXT</type>*                  <name>pQueueLabels</name></member>
             <member optional="true"><type>uint32_t</type>                                                           <name>cmdBufLabelCount</name></member>
-            <member noautovalidity="true" optional="true" len="cmdBufLabelCount"><type>VkDebugUtilsLabelEXT</type>* <name>pCmdBufLabels</name></member>
-            <member><type>uint32_t</type>                                                                           <name>objectCount</name></member>
-            <member noautovalidity="true" len="objectCount"><type>VkDebugUtilsObjectNameInfoEXT</type>*             <name>pObjects</name></member>
+            <member len="cmdBufLabelCount">const <type>VkDebugUtilsLabelEXT</type>*                 <name>pCmdBufLabels</name></member>
+            <member optional="true"><type>uint32_t</type>                                                           <name>objectCount</name></member>
+            <member len="objectCount">const <type>VkDebugUtilsObjectNameInfoEXT</type>*             <name>pObjects</name></member>
         </type>
         <type category="struct" name="VkImportMemoryHostPointerInfoEXT" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>


### PR DESCRIPTION
Fixing a few items discovered by @krOoze with the EXT_debug_utils
extension spec language validation.  Namely in two issues:

Issue #789:
 The problem was the manual VUs should have been applied to
 the `vkSetDebugUtilsObjectNameEXT` command and not the
 general `VkDebugUtilsObjectNameInfoEXT` structure.

Issue #790:
 Here, we needed to remove the "noautovalidity" tag on
 the XML and add the "optional" tag to `pObjects` and
 `objectCount`.