### PR TITLE
Fix #788: make clear messageTypes is a bitmask + name fix

### DIFF
--- a/chapters/VK_EXT_debug_utils.txt
+++ b/chapters/VK_EXT_debug_utils.txt
@@ -393,7 +393,7 @@ include::../api/structs/VkDebugUtilsMessengerCreateInfoEXT.txt[]
   * pname:messageSeverity is a bitmask of
     elink:VkDebugUtilsMessageSeverityFlagBitsEXT specifying which severity
     of event(s) will cause this callback to be called.
-  * pname:messageTypes is a bitmask of
+  * pname:messageType is a bitmask of
     elink:VkDebugUtilsMessageTypeFlagBitsEXT specifying which type of
     event(s) will cause this callback to be called.
   * pname:pfnUserCallback is the application callback function to call.
@@ -401,7 +401,7 @@ include::../api/structs/VkDebugUtilsMessengerCreateInfoEXT.txt[]
 
 For each sname:VkDebugUtilsMessengerEXT that is created the
 sname:VkDebugUtilsMessengerCreateInfoEXT::pname:messageSeverity and
-sname:VkDebugUtilsMessengerCreateInfoEXT::pname:messageTypes determine when
+sname:VkDebugUtilsMessengerCreateInfoEXT::pname:messageType determine when
 that sname:VkDebugUtilsMessengerCreateInfoEXT::pname:pfnUserCallback is
 called.
 The process to determine if the user's pfnUserCallback is triggered when an
@@ -496,7 +496,7 @@ addition of new severities in between the existing values.
 --
 
 Bits which can: be set in
-slink:VkDebugUtilsMessengerCreateInfoEXT::pname:messageTypes, specifying
+slink:VkDebugUtilsMessengerCreateInfoEXT::pname:messageType, specifying
 event types which cause a debug messenger to call the callback, are:
 
 include::../api/enums/VkDebugUtilsMessageTypeFlagBitsEXT.txt[]
@@ -527,8 +527,9 @@ include::../api/funcpointers/PFN_vkDebugUtilsMessengerCallbackEXT.txt[]
   * pname:messageSeverity specifies the
     elink:VkDebugUtilsMessageSeverityFlagBitsEXT that triggered this
     callback.
-  * pname:messageTypes specifies the
-    elink:VkDebugUtilsMessageTypeFlagBitsEXT that triggered this callback.
+  * pname:messageTypes is a bitmask of
+    elink:VkDebugUtilsMessageTypeFlagBitsEXT specifying which type of
+    event(s) triggered this callback.
   * pname:pCallbackData contains all the callback related data in the
     slink:VkDebugUtilsMessengerCallbackDataEXT structure.
   * pname:pUserData is the user data provided when the

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -557,7 +557,7 @@ server.
             <comment>The PFN_vkDebugUtilsMessengerCallbackEXT type are used by the VK_EXT_debug_utils extension</comment>
         <type category="funcpointer" requires="VkDebugUtilsMessengerCallbackDataEXT">typedef VkBool32 (VKAPI_PTR *<name>PFN_vkDebugUtilsMessengerCallbackEXT</name>)(
     <type>VkDebugUtilsMessageSeverityFlagBitsEXT</type>           messageSeverity,
-    <type>VkDebugUtilsMessageTypeFlagsEXT</type>                  messageType,
+    <type>VkDebugUtilsMessageTypeFlagsEXT</type>                  messageTypes,
     const <type>VkDebugUtilsMessengerCallbackDataEXT</type>*      pCallbackData,
     <type>void</type>*                                            pUserData);</type>
 


### PR DESCRIPTION
fixes #788 

Decided to change the name of the callback parameter in the XML. The name of a parameter should not matter in a function pointer, I think.