### PR TITLE
Fix missing endif in Image Creation block

### DIFF
--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -788,6 +788,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
      *** sname:VkImageFormatPropertoies::pname:sampleCounts contains exactly
          ename:VK_SAMPLE_COUNT_1_BIT.
 endif::VK_ANDROID_external_memory_android_hardware_buffer[]
+endif::VK_VERSION_1_1,VK_KHR_external_memory[]
 
 * Let `uint32_t imageCreateMaxMipLevels` be
 ifndef::VK_VERSION_1_1,VK_KHR_external_memory[]


### PR DESCRIPTION
which breaks 1.0 no-extension spec
fixes #816