### PR TITLE
Restore support for regular manpage generation

### DIFF
--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -28,8 +28,8 @@ builds an HTML5 specification output.
 
     $ make all
 
-builds the spec targets `html`, `pdf`, `styleguide`, `manhtml`, `manpdf`,
-`manhtmlpages`, `checkinc`, and `checklinks`.
+builds the spec targets `html`, `pdf`, `styleguide`, `manpages`,
+`manhtml`, `manpdf`, `manhtmlpages`, `checkinc`, and `checklinks`.
 
 [NOTE]
 .Notes
@@ -58,6 +58,7 @@ targets, or they can individually be found as follows:
   * Diff spec:
   ** `diff_html` - Single-file HTML5 in `$(OUTDIR)/html/diff.html`
   * Reference pages:
+  ** `manpages` - Man pages in `$(OUTDIR)/man/*`
   ** `manhtml` - Single-file HTML in `$(OUTDIR)/apispec.html`
   ** `manpdf` - Single-file PDF in `$(OUTDIR)/apispec.html`
   ** `manhtmlpages` - File-per-entry-point HTML in `$(OUTDIR)/man/html/*`


### PR DESCRIPTION
* Rename make rules to remove ambiguous meaning, namely manpages and
manhtmlpages.
* The support is not full yet, there is still html specific constructs that
end up in the man.

This is not shipping-quality yet, but it does produce usable man pages already. If someone would spearhead the support of this useful format, that would be great. Otherwise I can try to find some spare time and modify the custom markup generation tools to have perfect man pages.

I accompagny this PR with a [usable AUR package](https://aur.archlinux.org/packages/vulkan-man-git/) that I will point to the upstream repo if my PR gets merged.