### PR TITLE
Fix python 3.7 warning

### DIFF
--- a/xml/genvk.py
+++ b/xml/genvk.py
@@ -30,11 +30,11 @@ startTime = None
 
 def startTimer(timeit):
     global startTime
-    startTime = time.clock()
+    startTime = time.process_time()
 
 def endTimer(timeit, msg):
     global startTime
-    endTime = time.clock()
+    endTime = time.process_time()
     if (timeit):
         write(msg, endTime - startTime, file=sys.stderr)
         startTime = None


### PR DESCRIPTION
Python 3.8 will remove the "time.clock()" option we currently use.
Instead, we should "time.process_time()".