### PR TITLE
Fix vkCmdClearDepthStencilImage::aspectMask VU

### DIFF
--- a/chapters/clears.txt
+++ b/chapters/clears.txt
@@ -162,16 +162,19 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
     pname:imageLayout must: be either of
     ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_GENERAL
+  * The slink:VkImageSubresourceRange::pname:aspectMask member of each
+    element of the pname:pRanges array must: not include bits other than
+    ename:VK_IMAGE_ASPECT_DEPTH_BIT or ename:VK_IMAGE_ASPECT_STENCIL_BIT
   * [[VUID-vkCmdClearDepthStencilImage-aspectMask-02499]]
-    The slink:VkImageSubresourceRange::pname:aspectMask members of the
-    elements of the pname:pRanges array must: each only include
-    ename:VK_IMAGE_ASPECT_DEPTH_BIT if the image format has a depth
-    component
+    If the pname:image's format does not have a stencil component, then the
+    slink:VkImageSubresourceRange::pname:aspectMask member of each element
+    of the pname:pRanges array must: not include the
+    ename:VK_IMAGE_ASPECT_STENCIL_BIT bit
   * [[VUID-vkCmdClearDepthStencilImage-aspectMask-02500]]
-    The slink:VkImageSubresourceRange::pname:aspectMask members of the
-    elements of the pname:pRanges array must: each only include
-    ename:VK_IMAGE_ASPECT_STENCIL_BIT if the image format has a stencil
-    component
+    If the pname:image's format does not have a depth component, then the
+    slink:VkImageSubresourceRange::pname:aspectMask member of each element
+    of the pname:pRanges array must: not include the
+    ename:VK_IMAGE_ASPECT_DEPTH_BIT bit
   * [[VUID-vkCmdClearDepthStencilImage-baseMipLevel-01474]]
     The slink:VkImageSubresourceRange::pname:baseMipLevel members of the
     elements of the pname:pRanges array must: each be less than the


### PR DESCRIPTION
The original VUs said "must: each only include X". That makes the two VUs contradictory for depth+stencil format.

New VUs should allow `DEPTH` (for depth, or depth+stencil format). `STENCIL` (for stencil,  or depth+stencil format), or `DEPTH | STENCIL` (for depth+stencil format).