### PR TITLE
Fix typo in VkPhysicalDeviceShadingRateImagePropertiesNV structextends

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -3393,7 +3393,7 @@ server.
             <member><type>VkBool32</type>                            <name>shadingRateImage</name></member>
             <member><type>VkBool32</type>                            <name>shadingRateCoarseSampleOrder</name></member>
         </type>
-        <type category="struct" name="VkPhysicalDeviceShadingRateImagePropertiesNV" structextends="VkPhysicalDeviceProperties" returnedonly="true">
+        <type category="struct" name="VkPhysicalDeviceShadingRateImagePropertiesNV" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkExtent2D</type>                          <name>shadingRateTexelSize</name></member>


### PR DESCRIPTION
`VkPhysicalDeviceProperties` does not have a `pNext` member.