### PR TITLE
Fix links in PDF build

### DIFF
--- a/config/optimize-pdf
+++ b/config/optimize-pdf
@@ -72,6 +72,7 @@ ERRFILE=ERRS.optimize
 "$GS" -q -dNOPAUSE -dBATCH -dSAFER -dNOOUTERSAVE \
   -sDEVICE=pdfwrite \
   -dPDFSETTINGS=/prepress \
+  -dPrinted=false \
   -dCannotEmbedFontPolicy=/Warning \
   -dDownsampleColorImages=$DOWNSAMPLE_IMAGES \
   -dColorImageResolution=$IMAGE_DPI \


### PR DESCRIPTION
fixes #877 

Not quite sure what the flag is supposed to be doing. Based on https://bugs.ghostscript.com/show_bug.cgi?id=699830.

Alternatively downgrade ghostscript to <= 9.23.