### PR TITLE
Make genvk.py work in Python2

### DIFF
--- a/xml/genvk.py
+++ b/xml/genvk.py
@@ -30,12 +30,13 @@ startTime = None
 
 def startTimer(timeit):
     global startTime
-    startTime = time.process_time()
+    if timeit:
+        startTime = time.process_time()
 
 def endTimer(timeit, msg):
     global startTime
-    endTime = time.process_time()
-    if (timeit):
+    if timeit:
+        endTime = time.process_time()
         write(msg, endTime - startTime, file=sys.stderr)
         startTime = None
 


### PR DESCRIPTION
In Python2, the script would not be able to use the `time` argument, but would otherwise work as expected.

Needed for ANGLE.