### PR TITLE
 Make markup inside link look like a link in CSS 

### DIFF
--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -2871,8 +2871,8 @@ include::../api/structs/VkDescriptorBufferInfo.txt[]
 ====
 When setting pname:range to ename:VK_WHOLE_SIZE, the effective range must:
 not be larger than the maximum range for the descriptor type
-(<<features-limits-maxUniformBufferRange, maxUniformBufferRange>> or
-<<features-limits-maxStorageBufferRange, maxStorageBufferRange>>).
+(<<features-limits-maxUniformBufferRange, pname:maxUniformBufferRange>> or
+<<features-limits-maxStorageBufferRange, pname:maxStorageBufferRange>>).
 This means that ename:VK_WHOLE_SIZE is not typically useful in the common
 case where uniform buffer descriptors are suballocated from a buffer that is
 much larger than pname:maxUniformBufferRange.

--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -3704,8 +3704,8 @@ include::../api/structs/VkImageViewASTCDecodeModeEXT.txt[]
     ename:VK_FORMAT_E5B9G9R9_UFLOAT_PACK32
   * [[VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02231]]
     If the <<features-features-astc-decodeModeSharedExponent,
-    decodeModeSharedExponent>> feature is not enabled, pname:decodeMode
-    must: not be ename:VK_FORMAT_E5B9G9R9_UFLOAT_PACK32
+    pname:decodeModeSharedExponent>> feature is not enabled,
+    pname:decodeMode must: not be ename:VK_FORMAT_E5B9G9R9_UFLOAT_PACK32
   * [[VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02232]]
     If pname:decodeMode is ename:VK_FORMAT_R8G8B8A8_UNORM the image view
     must: not include blocks using any of the ASTC HDR modes

--- a/config/khronos.css
+++ b/config/khronos.css
@@ -213,6 +213,7 @@ strong, b { font-weight: bold; line-height: inherit; }
 small { font-size: 60%; line-height: inherit; }
 
 code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #264357; }
+a code { color: inherit; }
 
 /* Lists */
 ul, ol, dl { font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; list-style-position: outside; font-family: Noto, sans-serif; }


### PR DESCRIPTION
Currently the `code` tags (which `pname` and other markup is translated to) override the color of a link if the are part of one. In effect that makes the links look unclickable (especially if there is no non-markup text in the link too).

So I make the markup tag inside a link inherit link's color, instead using its own. The markup text should still be distinguished by its monospace font...