### PR TITLE
Vulkan-MemoryModel issue 7: Clarify that scoped modification order only relates atomic writes

### DIFF
--- a/appendices/memorymodel.txt
+++ b/appendices/memorymodel.txt
@@ -172,6 +172,7 @@ if all of the following are true:
   * They use the same reference.
   * A is in the instance of B's memory scope.
   * B is in the instance of A's memory scope.
+  * A and B are not the same operation (irreflexive).
 
 Two atomic operations A and B are _mutually-ordered_ if and only if they are
 potentially-mutually-ordered and any of the following are true:
@@ -188,7 +189,7 @@ other as if they were non-atomic operations.
 [[memory-model-scoped-modification-order]]
 == Scoped Modification Order
 
-For a given atomic operation A, all atomic operations that are
+For a given atomic write A, all atomic writes that are
 mutually-ordered with A occur in an order known as A's _scoped modification
 order_.
 A's scoped modification order relates no other operations.


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/Vulkan-MemoryModel/issues/7

Bonus: Clarify that mutually-ordered is irreflexive. Irreflexivity of some other relations follows naturally from this.
