### PR TITLE
Remove readme.txt reference

### DIFF
--- a/xml/README.adoc
+++ b/xml/README.adoc
@@ -52,7 +52,6 @@ processing XML.
     <<targets,Makefile Targets>> below).
   * vk.xml - XML API description.
   * genvk.py - Python script to generate vulkan_core.h and other targets.
-  * readme.txt - Source for detailed description of the XML schema.
   * registry.rnc - RelaxNG compact schema for validating XML against the
     schema.
   * reg.py - Python tools to read XML file and convert it into C headers.


### PR DESCRIPTION
I think this is referring to `../registry.txt`, and that's covered in the root README.