### PR TITLE
Correct and complete protected queue creation VUs

### DIFF
--- a/chapters/devsandqueues.txt
+++ b/chapters/devsandqueues.txt
@@ -1029,7 +1029,7 @@ ename:VK_ERROR_TOO_MANY_OBJECTS.
     All <<extendingvulkan-extensions-extensiondependencies, required
     extensions>> for each extension in the
     slink:VkDeviceCreateInfo::pname:ppEnabledExtensionNames list must: also
-    be present in that list.
+    be present in that list
 ****
 
 include::{generated}/validity/protos/vkCreateDevice.txt[]
@@ -1070,17 +1070,24 @@ include::{generated}/api/structs/VkDeviceCreateInfo.txt[]
 
 .Valid Usage
 ****
-ifndef::VK_VERSION_1_1[]
-  * [[VUID-VkDeviceCreateInfo-queueFamilyIndex-00372]]
-    The pname:queueFamilyIndex member of each element of
+  * The (pname:queueFamilyIndex, pname:flags) pair of each element of
     pname:pQueueCreateInfos must: be unique within pname:pQueueCreateInfos
-endif::VK_VERSION_1_1[]
+  * Sum of pname:queueCount members for a specific pname:queueFamilyIndex in
+    the pname:pQueueCreateInfos array must: be less than or equal to the
+    pname:queueCount member of the
+    pname:pQueueFamilyProperties[pname:queueFamilyIndex],
+    as returned by flink:vkGetPhysicalDeviceQueueFamilyProperties
 ifdef::VK_VERSION_1_1[]
-  * [[VUID-VkDeviceCreateInfo-queueFamilyIndex-02802]]
-    The pname:queueFamilyIndex member of each element of
-    pname:pQueueCreateInfos must: be unique within pname:pQueueCreateInfos,
-    except that two members can share the same pname:queueFamilyIndex if one
-    is a protected-capable queue and one is not a protected-capable queue
+  * If <<features-protectedMemory,pname:protectedMemory>> feature is not
+    being enabled, then each pname:pQueueCreateInfos element must: not
+    include ename:VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT in its pname:flags
+    member
+  * Any pname:pQueueCreateInfos element, whose pname:queueFamilyIndex does
+    not report ename:VK_QUEUE_PROTECTED_BIT in the pname:queueFlags member
+    of pname:pQueueFamilyProperties[pname:queueFamilyIndex] (as returned by
+    flink:vkGetPhysicalDeviceQueueFamilyProperties), must: not have
+    ename:VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT included in its pname:flags
+    member
 endif::VK_VERSION_1_1[]
 ifdef::VK_VERSION_1_1,VK_KHR_get_physical_device_properties2[]
   * [[VUID-VkDeviceCreateInfo-pNext-00373]]
@@ -1239,7 +1246,7 @@ In particular, the device index of that physical device is zero.
   * [[VUID-VkDeviceGroupDeviceCreateInfo-physicalDeviceCount-00377]]
     If pname:physicalDeviceCount is not `0`, the pname:physicalDevice
     parameter of flink:vkCreateDevice must: be an element of
-    pname:pPhysicalDevices.
+    pname:pPhysicalDevices
 ****
 
 include::{generated}/validity/structs/VkDeviceGroupDeviceCreateInfo.txt[]
@@ -1577,11 +1584,6 @@ endif::VK_VERSION_1_1[]
     pname:queueFamilyIndex must: be less than
     pname:pQueueFamilyPropertyCount returned by
     fname:vkGetPhysicalDeviceQueueFamilyProperties
-  * [[VUID-VkDeviceQueueCreateInfo-queueCount-00382]]
-    pname:queueCount must: be less than or equal to the pname:queueCount
-    member of the sname:VkQueueFamilyProperties structure, as returned by
-    fname:vkGetPhysicalDeviceQueueFamilyProperties in the
-    pname:pQueueFamilyProperties[queueFamilyIndex]
   * [[VUID-VkDeviceQueueCreateInfo-pQueuePriorities-00383]]
     Each element of pname:pQueuePriorities must: be between `0.0` and `1.0`
     inclusive
@@ -1727,17 +1729,15 @@ endif::VK_VERSION_1_1[]
 
 .Valid Usage
 ****
-  * [[VUID-vkGetDeviceQueue-queueFamilyIndex-00384]]
-    pname:queueFamilyIndex must: be one of the queue family indices
-    specified when pname:device was created, via the
-    sname:VkDeviceQueueCreateInfo structure
+  * pname:queueFamilyIndex must: be one of the queue family indices
+    specified with a pname:flags member of `0`, when pname:device was
+    created, via the slink:VkDeviceQueueCreateInfo structure
   * [[VUID-vkGetDeviceQueue-queueIndex-00385]]
-    pname:queueIndex must: be less than the number of queues created for the
-    specified queue family index when pname:device was created, via the
-    pname:queueCount member of the sname:VkDeviceQueueCreateInfo structure
-  * [[VUID-vkGetDeviceQueue-flags-01841]]
-    slink:VkDeviceQueueCreateInfo::pname:flags must: have been set to zero
-    when pname:device was created
+    pname:queueIndex must: be less than pname:queueCount member of the
+    slink:VkDeviceQueueCreateInfo structure with
+    sname:VkDeviceQueueCreateInfo::pname:queueFamilyIndex equal to
+    pname:queueFamilyIndex, and sname:VkDeviceQueueCreateInfo::pname:flags
+    equal to `0`, when pname:device was created
 ****
 
 include::{generated}/validity/protos/vkGetDeviceQueue.txt[]
@@ -1788,16 +1788,16 @@ pname:pQueue will return dlink:VK_NULL_HANDLE.
 
 .Valid Usage
 ****
-  * [[VUID-VkDeviceQueueInfo2-queueFamilyIndex-01842]]
-    pname:queueFamilyIndex must: be one of the queue family indices
-    specified when pname:device was created, via the
-    sname:VkDeviceQueueCreateInfo structure
+  * pname:queueFamilyIndex must: be one of the queue family indices
+    specified with a sname:VkDeviceQueueCreateInfo::pname:flags member equal
+    to pname:flags, when pname:device was created, via the
+    slink:VkDeviceQueueCreateInfo structure
   * [[VUID-VkDeviceQueueInfo2-queueIndex-01843]]
-    pname:queueIndex must: be less than the number of queues created for the
-    specified queue family index and tlink:VkDeviceQueueCreateFlags member
-    pname:flags equal to this pname:flags value when pname:device was
-    created, via the pname:queueCount member of the
-    sname:VkDeviceQueueCreateInfo structure
+    pname:queueIndex must: be less than pname:queueCount member of the
+    slink:VkDeviceQueueCreateInfo structure with
+    sname:VkDeviceQueueCreateInfo::pname:queueFamilyIndex equal to
+    pname:queueFamilyIndex, and sname:VkDeviceQueueCreateInfo::pname:flags
+    equal to pname:flags, when pname:device was created
 ****
 
 include::{generated}/validity/structs/VkDeviceQueueInfo2.txt[]


### PR DESCRIPTION
1) Let the non-unique family queues in the device creation list share the queue count limit
2) Prevent creation of `PROTECTED` queue from a family that does not support `PROTECTED`
3) Fix preprocessor inside a VU breaking json script + reduce `ifdef`ery by wording in 1.0 compatible manner
4) Prevent creation of `PROTECTED` queue from when `protectedMemory` feature is not being enabled
5) Allow `vkGetDeviceQueue` to fetch any queue that had `flags` set to `0`, and remove ambiguity if this function is valid if `pQueueCreateInfos` contained both protected and non-protected version of the same queue family