### PR TITLE
Memory model: Remove (unnecessary) scoped modification order case from location-ordered definition

### DIFF
--- a/appendices/memorymodel.txt
+++ b/appendices/memorymodel.txt
@@ -719,8 +719,6 @@ the following is true:
   * A~X~ == A~Y~ and R~X~ == R~Y~ and X->Y
   ** NOTE: this case means no availability/visibility ops required when it's
      the same (agent,reference).
-  * X and Y are mutually-ordered atomics, and X is before Y in X's scoped
-    modification order
 
   * X is a read, both X and Y are non-private, and X->Y
   * X is a read, and X (transitively) system-synchronizes with Y


### PR DESCRIPTION
See https://github.com/KhronosGroup/Vulkan-MemoryModel/pull/17 for the corresponding alloy change.

Scoped modification order only relates writes (not reads), so this special case for atomics was incomplete and  necessary.
