### PR TITLE
Generate a quick ref HTML page.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ chunked: $(HTMLDIR)/vkspec.html $(SPECSRC) $(COMMONDOCS)
 	$(QUIET)$(ROSWELL) $(ROSWELLOPTS) $(CHUNKER) \
 	    $(HTMLDIR)/vkspec.html -o $(HTMLDIR)
 
-html: $(HTMLDIR)/vkspec.html $(SPECSRC) $(COMMONDOCS)
+html: $(HTMLDIR)/vkspec.html $(HTMLDIR)/quick_ref.html $(SPECSRC) $(COMMONDOCS)
 
 $(HTMLDIR)/vkspec.html: KATEXDIR = ../katex
 $(HTMLDIR)/vkspec.html: $(SPECSRC) $(COMMONDOCS) katexinst
@@ -381,6 +381,9 @@ $(OUTDIR)/apispec.html: ADOCMISCOPTS =
 $(OUTDIR)/apispec.html: $(SPECVERSION) man/apispec.txt $(MANCOPYRIGHT) $(SVGFILES) $(GENDEPENDS) katexinst
 	$(QUIET)$(MKDIR) $(OUTDIR)
 	$(QUIET)$(ASCIIDOC) -b html5 -a html_spec_relative='html/vkspec.html' $(ADOCOPTS) $(ADOCHTMLOPTS) -o $@ man/apispec.txt
+
+$(HTMLDIR)/quick_ref.html: $(VKXML) $(GENVK)
+	$(PYTHON) $(GENVK) $(GENVKOPTS) -o out/html quick_ref.html
 
 # Targets generated from the XML and registry processing scripts
 #   $(SCRIPTS)/vkapi.py - Python encoding of the registry

--- a/scripts/genvk.py
+++ b/scripts/genvk.py
@@ -21,6 +21,7 @@ from cgenerator import CGeneratorOptions, COutputGenerator
 from docgenerator import DocGeneratorOptions, DocOutputGenerator
 from extensionmetadocgenerator import ExtensionMetaDocGeneratorOptions, ExtensionMetaDocOutputGenerator
 from pygenerator import PyOutputGenerator
+from quick_ref_generator import QuickRefOutputGenerator
 from validitygenerator import ValidityOutputGenerator
 from hostsyncgenerator import HostSynchronizationOutputGenerator
 from vkconventions import VulkanConventions
@@ -166,6 +167,22 @@ def makeGenOpts(args):
             versions          = featuresPat,
             emitversions      = featuresPat,
             defaultExtensions = None,
+            addExtensions     = addExtensionsPat,
+            removeExtensions  = removeExtensionsPat,
+            emitExtensions    = emitExtensionsPat)
+        ]
+
+    genOpts['quick_ref.html'] = [
+          QuickRefOutputGenerator,
+          DocGeneratorOptions(
+            conventions       = conventions,
+            filename          = "quick_ref.html",
+            directory         = directory,
+            apiname           = 'vulkan',
+            profile           = None,
+            versions          = featuresPat,
+            emitversions      = featuresPat,
+            defaultExtensions = defaultExtensions,
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat)

--- a/scripts/quick_ref_generator.py
+++ b/scripts/quick_ref_generator.py
@@ -1,0 +1,435 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2019 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import sys
+from generator import (GeneratorOptions, OutputGenerator, noneStr,
+                       regSortFeatures, write)
+
+# QuickRefOutputGenerator - subclass of OutputGenerator.
+# Generates C-language API interfaces.
+#
+# ---- methods ----
+# QuickRefOutputGenerator(errFile, warnFile, diagFile) - args as for
+#   OutputGenerator. Defines additional internal state.
+# ---- methods overriding base class ----
+# beginFile(genOpts)
+# endFile()
+# beginFeature(interface, emit)
+# endFeature()
+# genType(typeinfo,name)
+# genStruct(typeinfo,name)
+# genGroup(groupinfo,name)
+# genEnum(enuminfo, name)
+# genCmd(cmdinfo)
+class QuickRefOutputGenerator(OutputGenerator):
+    """Generate specified API interfaces in a specific style, such as a C header"""
+    # This is an ordered list of sections in the header file.
+    TYPE_SECTIONS = ['include', 'define', 'basetype', 'handle', 'enum',
+                     'group', 'bitmask', 'funcpointer', 'struct']
+    ALL_SECTIONS = TYPE_SECTIONS + ['commandPointer', 'command']
+
+    REF_LINK = "https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/"
+
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
+        self.sections = {section: {} for section in self.ALL_SECTIONS}
+
+    def beginFile(self, genOpts):
+        OutputGenerator.beginFile(self, genOpts)
+
+    def endFile(self):
+        write('<!doctype html5>\n<html>\n<head>\n<meta charset="utf-8">\n', file=self.outFile)
+        write('<title>Vulkan Quick Reference</title>', file=self.outFile)
+        write('<style>* { box-sizing: border-box; }\ndiv { columns: 32em; }\n', file=self.outFile)
+        write('ul {margin: 0; padding: 0;}\n', file=self.outFile)
+        write('li {list-style-type: none; -webkit-column-break-inside: avoid; overflow: auto;}\n', file=self.outFile)
+        write('.struct-name { color: green; }\n.function-name { color: blue; }\n', file=self.outFile)
+        write('a { text-decoration: none; background-color: #eee; padding: 2px; margin: 2px; border-radius: 5px;}\n', file=self.outFile)
+        write('ul#cmd-ptr-and-instance, ul#dispatch, ul#blend-facts, ul#extend, ul#vtex-input, ul#wsi, ul#vtex-post, ul#resource-create, ul#render-pass { background-color: #deffea }\n', file=self.outFile)
+        write('ul#mem-alloc, ul#queries { background-color: #e4fbff; }\n', file=self.outFile)
+        write('ul#struct-and-elem, ul#raster, ul#copy-cmds, ul#res-desc, ul#dev-and-queue, ul#pipelines { background-color: #f8fdce}\n', file=self.outFile)
+        write('ul#cmd-buffers, ul#sparse, ul#draw-cmds, ul#samplers {background-color: #decbde;}\n', file=self.outFile)
+        write('ul#sync-and-cache, ul#feat-lim-formats, ul#frag-ops, ul#clr-cmds, ul#shaders {background-color: #ffd08a;}\n', file=self.outFile)
+        write('</style>', file=self.outFile)
+        write('</head><body>', file=self.outFile)
+
+        self.struct_and_cmd = []
+        self.struct_and_cmd.extend(self.sections['struct'].keys())
+        self.struct_and_cmd.extend(self.sections['command'].keys())
+        self.struct_and_cmd.sort()
+
+        # Each of these remove their displayed items from struct_and_cmd
+        self.writeCommandFunctionPointersAndInstances()
+        self.writeDeviceAndQueues()
+        self.writeCommandBuffers()
+        self.writeSyncAndCacheControl()
+        self.writeRenderPass()
+        self.writeShaders()
+        self.writePipelines()
+        self.writeMemoryAlloc()
+        self.writeResourceCreation()
+        self.writeSamplers()
+        self.writeResourceDescriptors()
+        self.writeQueries()
+        self.writeClearCommands()
+        self.writeDrawCommands()
+        self.writeCopyCommands()
+        self.writeFixedFuncVertexPostProcessing()
+        self.writeVertexInputDesc()
+        self.writeFragmentOperations()
+        self.writeRasterization()
+        self.writeBlendFactors()
+        self.writeDispatchCommands()
+        self.writeSparseResources()
+        self.writeWindowSystem()
+        self.writeExtended()
+        self.writeFeaturesLimitsAndFormats()
+
+        self.writeRemaining()
+
+        self.writeStructsAndEnums()
+
+        write('</body></html>', file=self.outFile)
+        OutputGenerator.endFile(self)
+
+    def writeRender(self, title, id, keys, delete=True):
+        write('<h1>' + title + '</h1>', file=self.outFile)
+        write('<div><ul id="' + id + '">', file=self.outFile)
+
+        for key in keys:
+            if delete:
+                self.struct_and_cmd.remove(key)
+
+            code = ''
+            if key in self.sections['struct']:
+                code = self.sections['struct'][key]
+            else:
+                code = self.sections['command'][key]
+            write('<li><pre><code>' + code + '</code></pre></li>', file=self.outFile)
+
+        write('</ul></div>', file=self.outFile)
+
+
+    def writeRemaining(self):
+        self.writeRender('Remaining', 'remaining', self.struct_and_cmd, False)
+
+    def writeFeaturesLimitsAndFormats(self):
+        keys = [key for key in self.struct_and_cmd if 'Features' in key or
+                'Format' in key or
+                'External' in key]
+        self.writeRender('Features, Limits, and Formats', 'feat-lim-formats', keys)
+
+    def writeExtended(self):
+        keys = [key for key in self.struct_and_cmd if 'Enumerate' in key or
+                'LayerProp' in key or
+                'External' in key or
+                'ExtensionProperties' in key]
+        self.writeRender('Extended Functionality', 'extend', keys)
+
+    def writeWindowSystem(self):
+        keys = [key for key in self.struct_and_cmd if 'Surface' in key or
+                'Display' in key or
+                'Present' in key or
+                'Swapchain' in key or
+                'AcquireNext' in key or
+                'RectLayer' in key]
+        self.writeRender('Window System Integration (WSI)', 'wsi', keys)
+
+    def writeSparseResources(self):
+        keys = [key for key in self.struct_and_cmd if 'Sparse' in key or
+                'SetDepthBias' in key]
+        self.writeRender('Sparse Resources', 'sparse', keys)
+
+    def writeDispatchCommands(self):
+        keys = [key for key in self.struct_and_cmd if 'Dispatch' in key]
+        self.writeRender('Dispatching Commands', 'dispatch', keys)
+
+    def writeBlendFactors(self):
+        keys = [key for key in self.struct_and_cmd if 'SetBlendConst' in key]
+        self.writeRender('Framebuffer: Blend Factors', 'blend-facts', keys)
+
+    def writeRasterization(self):
+        keys = [key for key in self.struct_and_cmd if 'SetLineWidth' in key or
+                'SetDepthBias' in key]
+        self.writeRender('Rasterization', 'raster', keys)
+
+    def writeFragmentOperations(self):
+        keys = [key for key in self.struct_and_cmd if 'Scissor' in key or
+                'SetDepthBounds' in key or
+                'SetStencil' in key]
+        self.writeRender('Fragment Operations', 'frag-ops', keys)
+
+    def writeVertexInputDesc(self):
+        keys = [key for key in self.struct_and_cmd if 'BindVertexBuffers' in key]
+        self.writeRender('Vertex Input Description', 'vtex-input', keys)
+
+    def writeFixedFuncVertexPostProcessing(self):
+        keys = [key for key in self.struct_and_cmd if 'SetViewport' in key]
+        self.writeRender('Fixed-Function Vertex Postprocessing', 'vtex-post', keys)
+
+    def writeCopyCommands(self):
+        keys = [key for key in self.struct_and_cmd if 'Copy' in key or
+                'Blit' in key or
+                'Blit' in key or
+                'Resolve' in key]
+        self.writeRender('Copy Commands', 'copy-cmds', keys)
+
+    def writeDrawCommands(self):
+        keys = [key for key in self.struct_and_cmd if 'Draw' in key or
+                'BindIndex' in key]
+        self.writeRender('Draw Commands', 'draw-cmds', keys)
+
+    def writeClearCommands(self):
+        keys = [key for key in self.struct_and_cmd if 'Clear' in key or
+                'FillBuffer' in key or
+                'UpdateBuffer' in key]
+        self.writeRender('Clear Commands', 'clr-cmds', keys)
+
+    def writeQueries(self):
+        keys = [key for key in self.struct_and_cmd if 'Query' in key or
+                'WriteTimestamp' in key]
+        self.writeRender('Queries', 'queries', keys)
+
+    def writeResourceDescriptors(self):
+        keys = [key for key in self.struct_and_cmd if 'Descriptor' in key or
+                'PushConstant' in key]
+        self.writeRender('Resource Descriptors', 'res-desc', keys)
+
+    def writeSamplers(self):
+        keys = [key for key in self.struct_and_cmd if 'Sampler' in key]
+        self.writeRender('Samplers', 'samplers', keys)
+
+    def writeResourceCreation(self):
+        keys = [key for key in self.struct_and_cmd if 'Buffer' in key or
+                'Image' in key or
+                'Subresource' in key or
+                'ComponentMapping' in key]
+        keys = [key for key in keys if 'UpdateBuffer' not in key and
+                'FillBuffer' not in key and
+                'Clear' not in key and
+                'Format' not in key and
+                'BindIndexBuffer' not in key and
+                'AcquireNext' not in key and
+                'Blit' not in key and
+                'Resolve' not in key and
+                'Copy' not in key and
+                'BindVertexBuffers' not in key and
+                'Sparse' not in key and
+                'Swapchain' not in key]
+        self.writeRender('Resource Creation', 'resource-create', keys)
+
+    def writeMemoryAlloc(self):
+        keys = [key for key in self.struct_and_cmd if 'Memory' in key]
+        keys = [key for key in keys if 'Sparse' not in key]
+        self.writeRender('Memory Allocation', 'mem-alloc', keys)
+
+    def writePipelines(self):
+        keys = [key for key in self.struct_and_cmd if 'Pipeline' in key or
+                'VertexInputAttribute' in key or
+                'StencilOpState' in key or
+                'VertexInputBinding' in key]
+        self.writeRender('Pipelines', 'pipelines', keys)
+
+    def writeShaders(self):
+        keys = [key for key in self.struct_and_cmd if 'ShaderModule' in key]
+        self.writeRender('Shaders', 'shaders', keys)
+
+    def writeRenderPass(self):
+        keys = [key for key in self.struct_and_cmd if 'RenderPass' in key or
+                'Attachment' in key or
+                'Subpass' in key or
+                'Framebuffer' in key or
+                'RenderArea' in key]
+        keys = [key for key in keys if 'ClearAttachment' not in key]
+        self.writeRender('Render Pass', 'render-pass', keys)
+
+    def writeSyncAndCacheControl(self):
+        keys = [key for key in self.struct_and_cmd if 'Fence' in key or
+                'Semaphore' in key or
+                'Event' in key or
+                'Barrier' in key or
+                'WaitIdle' in key]
+        self.writeRender('Synchronization and Cache Control', 'sync-and-cache', keys)
+
+    def writeCommandBuffers(self):
+        keys = [key for key in self.struct_and_cmd if 'CommandPool' in key or
+            'CommandBuffer' in key or
+            'VkSubmitInfo' in key or
+            'Execute' in key]
+        self.writeRender('Command Buffers', 'cmd-buffers', keys)
+
+    def writeDeviceAndQueues(self):
+        keys = [key for key in self.struct_and_cmd if 'Device' in key or
+            'Queue' in key]
+        keys = [key for key in keys if 'Bind' not in key and
+                    'CommandBuffer' not in key and
+                    'RenderPass' not in key and
+                    'Present' not in key and
+                    'PhysicalDeviceFeatures' not in key and
+                    'PhysicalDeviceFormat' not in key and
+                    'PhysicalDeviceImageFormat' not in key and
+                    'PhysicalDeviceExternal' not in key and
+                    'PhysicalDeviceMemory' not in key and
+                    'PhysicalDeviceSparse' not in key and
+                    'PhysicalDeviceDisplay' not in key and
+                    'PhysicalDeviceSurface' not in key and
+                    'Win32' not in key and
+                    'Xcb' not in key and
+                    'Wayland' not in key and
+                    'Xlib' not in key and
+                    'WaitIdle' not in key]
+        self.writeRender('Devices and Queues', 'dev-and-queue', keys)
+
+    def writeCommandFunctionPointersAndInstances(self):
+        keys = [key for key in self.struct_and_cmd if 'Instance' in key or
+            'DeviceProc' in key or
+            'Application' in key]
+        keys = [key for key in keys if 'EnumerateInstanceLayer' not in key and
+            'EnumerateInstanceExtension' not in key]
+        self.writeRender('Command Function Pointers and Instances', 'cmd-ptr-and-instance', keys)
+
+    def writeStructsAndEnums(self):
+        write('<h1>Structures and Enumerations</h1><div>', file=self.outFile)
+        write('<ul id="struct-and-elem">', file=self.outFile)
+
+        keys = []
+        keys.extend(self.sections['struct'].keys())
+        keys.extend(self.sections['group'].keys())
+        keys.sort()
+
+        for key in keys:
+            code = ''
+            if key in self.sections['struct']:
+                code = self.sections['struct'][key]
+            else:
+                code = self.sections['group'][key]
+            write('<li><pre><code>' + code + '</code></pre></li>', file=self.outFile)
+
+        write('</ul></div>', file=self.outFile)
+
+    # Append a definition to the specified section
+    def appendSection(self, section, key, text):
+        self.sections[section][key] = text
+
+    # Type generation
+    def genType(self, typeinfo, name, alias):
+        OutputGenerator.genType(self, typeinfo, name, alias)
+        typeElem = typeinfo.elem
+
+        category = typeElem.get('category')
+        if category in ('struct', 'union'):
+            self.genStruct(typeinfo, name, alias)
+
+    # Struct (e.g. C "struct" type) generation.
+    def genStruct(self, typeinfo, typeName, alias):
+        OutputGenerator.genStruct(self, typeinfo, typeName, alias)
+
+        typeElem = typeinfo.elem
+        body = 'typedef <a href="' + self.REF_LINK + typeName + '.html">' + typeElem.get('category')
+        body += ' <span class="struct-name">' + typeName + '</span></a> {\n'
+
+        for member in typeElem.findall('.//member'):
+            body += self.makeCParamDecl(member, 1)
+            body += '\n'
+
+        body += '} ' + typeName + ';\n'
+
+        self.appendSection('struct', typeName, body)
+
+    # Group (e.g. C "enum" type) generation.
+    def genGroup(self, groupinfo, groupName, alias = None):
+        OutputGenerator.genGroup(self, groupinfo, groupName, alias)
+        groupElem = groupinfo.elem
+
+        body = 'enum <a href="' + self.REF_LINK + groupName + '.html">' + groupName + "</a>\n"
+
+        enumerants = [elem.get('name') for elem in groupElem.findall('enum')]
+        enumerants.sort()
+        for name in enumerants:
+            body += "  " + name + "\n"
+
+        self.appendSection('group', groupName, body)
+
+    # Enumerant generation
+    def genEnum(self, enuminfo, name, alias):
+        OutputGenerator.genEnum(self, enuminfo, name, alias)
+        body = '#define ' + name.ljust(33)
+        self.appendSection('define', name, body)
+
+    # Command generation
+    def genCmd(self, cmdinfo, name, alias):
+        OutputGenerator.genCmd(self, cmdinfo, name, alias)
+
+        cmd = cmdinfo.elem
+        proto = cmd.find('proto')
+        params = cmd.findall('param')
+        # Begin accumulating prototype and typedef strings
+        pdecl = self.genOpts.apicall
+
+        # Insert the function return type/name.
+        # For prototypes, add APIENTRY macro before the name
+        # For typedefs, add (APIENTRY *<name>) around the name and
+        #   use the PFN_cmdnameproc naming convention.
+        # Done by walking the tree for <proto> element by element.
+        # etree has elem.text followed by (elem[i], elem[i].tail)
+        #   for each child element and any following text
+        # Leading text
+        pdecl += noneStr(proto.text)
+
+        # For each child element, if it's a <name> wrap in appropriate
+        # declaration. Otherwise append its contents and tail contents.
+        for elem in proto:
+            text = noneStr(elem.text)
+            tail = noneStr(elem.tail)
+            if elem.tag == 'name':
+                pdecl += '<a href="' + self.REF_LINK + text + '.html"><span class="function-name">' + self.makeProtoName(text, tail) + '</span></a>'
+            else:
+                pdecl += text + tail
+
+        # Now add the parameter declaration list, which is identical
+        # for prototypes and typedefs. Concatenate all the text from
+        # a <param> node without the tags. No tree walking required
+        # since all tags are ignored.
+        # Uses: self.indentFuncProto
+        # self.indentFuncPointer
+        # self.alignFuncParam
+        n = len(params)
+        # Indented parameters
+        if n > 0:
+            indentdecl = '(\n'
+            indentdecl += ',\n'.join(self.makeCParamDecl(p, self.genOpts.alignFuncParam)
+                                     for p in params)
+            indentdecl += ');'
+        else:
+            indentdecl = '(void);'
+        # Non-indented parameters
+        paramdecl = '('
+        if n > 0:
+            paramnames = (''.join(t for t in p.itertext())
+                          for p in params)
+            paramdecl += ', '.join(paramnames)
+        else:
+            paramdecl += 'void'
+        paramdecl += ");"
+
+        decl = pdecl + indentdecl
+
+        self.appendSection('command', name, decl + '\n')


### PR DESCRIPTION
This Cl adds a generator to create a quick_ref.html page which links to
the indvidual spec pages. The structure of the generated page is similar
to the vulkan quick reference document.