### PR TITLE
Rename Pastel driver ID to SwiftShader

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -5077,7 +5077,7 @@ typedef void <name>CAMetalLayer</name>;
         <enum value="7"       name="VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR"   comment="Imagination Technologies"/>
         <enum value="8"       name="VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"      comment="Qualcomm Technologies, Inc."/>
         <enum value="9"       name="VK_DRIVER_ID_ARM_PROPRIETARY_KHR"           comment="Arm Limited"/>
-        <enum value="10"      name="VK_DRIVER_ID_GOOGLE_PASTEL_KHR"             comment="Google LLC"/>
+        <enum value="10"      name="VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR"        comment="Google LLC"/>
         <enum value="11"      name="VK_DRIVER_ID_GGP_PROPRIETARY_KHR"           comment="Google LLC"/>
     </enums>
     <enums name="VkConditionalRenderingFlagBitsEXT" type="bitmask">


### PR DESCRIPTION
Pastel was the project name for SwiftShader's initial Vulkan
implementation, but won't live on as a product name.

Note that at this point SwiftShader's VK_KHR_driver_properties
implementation has not landed yet:
https://swiftshader-review.googlesource.com/c/SwiftShader/+/22690
So there's no risk of the old enum name being used already and this
renaming causing any issues.

Bug: https://issuetracker.google.com/issues/116336664
Bug: b/130019658