### PR TITLE
Fix wrong subpass in VkRenderPassCreateInfo VU

### DIFF
--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -273,7 +273,8 @@ endif::VK_VERSION_1_1,VK_KHR_multiview[]
     ename:VK_SUBPASS_EXTERNAL, all stage flags included in the
     pname:dstStageMask member of that dependency must: be a pipeline stage
     supported by the <<synchronization-pipeline-stages-types, pipeline>>
-    identified by the pname:pipelineBindPoint member of the source subpass
+    identified by the pname:pipelineBindPoint member of the destination
+    subpass
   * [[VUID-VkRenderPassCreateInfo-srcSubpass-02517]]
     The pname:srcSubpass member of each element of pname:pDependencies must:
     be less than pname:subpassCount
@@ -1682,13 +1683,14 @@ respectively.
     ename:VK_SUBPASS_EXTERNAL, all stage flags included in the
     pname:srcStageMask member of that dependency must: be a pipeline stage
     supported by the <<synchronization-pipeline-stages-types, pipeline>>
-    identified by the pname:pipelineBindPoint member of the source subpass.
+    identified by the pname:pipelineBindPoint member of the source subpass
   * [[VUID-VkRenderPassCreateInfo2KHR-pDependencies-03055]]
     For any element of pname:pDependencies, if the pname:dstSubpass is not
     ename:VK_SUBPASS_EXTERNAL, all stage flags included in the
     pname:dstStageMask member of that dependency must: be a pipeline stage
     supported by the <<synchronization-pipeline-stages-types, pipeline>>
-    identified by the pname:pipelineBindPoint member of the source subpass.
+    identified by the pname:pipelineBindPoint member of the destination
+    subpass
   * [[VUID-VkRenderPassCreateInfo2KHR-pCorrelatedViewMasks-03056]]
     The set of bits included in any element of pname:pCorrelatedViewMasks
     must: not overlap with the set of bits included in any other element of


### PR DESCRIPTION
Fix copy-paste error referencing wrong subpass in `VkRenderPassCreateInfo` VU.

