### PR TITLE
Remove redundant render pass VUs

### DIFF
--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1215,12 +1215,6 @@ layouts as follows:
 
 .Valid Usage
 ****
-  * [[VUID-VkSubpassDependency-srcSubpass-00858]]
-    If pname:srcSubpass is not ename:VK_SUBPASS_EXTERNAL, pname:srcStageMask
-    must: not include ename:VK_PIPELINE_STAGE_HOST_BIT
-  * [[VUID-VkSubpassDependency-dstSubpass-00859]]
-    If pname:dstSubpass is not ename:VK_SUBPASS_EXTERNAL, pname:dstStageMask
-    must: not include ename:VK_PIPELINE_STAGE_HOST_BIT
   * [[VUID-VkSubpassDependency-srcStageMask-00860]]
     If the <<features-geometryShader,geometry shaders>> feature is not
     enabled, pname:srcStageMask must: not contain
@@ -1246,11 +1240,6 @@ layouts as follows:
   * [[VUID-VkSubpassDependency-srcSubpass-00865]]
     pname:srcSubpass and pname:dstSubpass must: not both be equal to
     ename:VK_SUBPASS_EXTERNAL
-  * [[VUID-VkSubpassDependency-srcSubpass-01989]]
-    If pname:srcSubpass is equal to pname:dstSubpass, pname:srcStageMask and
-    pname:dstStageMask must: not set any bits that are neither
-    ename:VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, nor one of the
-    <<synchronization-pipeline-stages-types,graphics pipeline stages>>
   * [[VUID-VkSubpassDependency-srcSubpass-00867]]
     If pname:srcSubpass is equal to pname:dstSubpass and not all of the
     stages in pname:srcStageMask and pname:dstStageMask are
@@ -2087,12 +2076,6 @@ corresponding subpass dependency.
 
 .Valid Usage
 ****
-  * [[VUID-VkSubpassDependency2KHR-srcSubpass-03078]]
-    If pname:srcSubpass is not ename:VK_SUBPASS_EXTERNAL, pname:srcStageMask
-    must: not include ename:VK_PIPELINE_STAGE_HOST_BIT
-  * [[VUID-VkSubpassDependency2KHR-dstSubpass-03079]]
-    If pname:dstSubpass is not ename:VK_SUBPASS_EXTERNAL, pname:dstStageMask
-    must: not include ename:VK_PIPELINE_STAGE_HOST_BIT
   * [[VUID-VkSubpassDependency2KHR-srcStageMask-03080]]
     If the <<features-geometryShader,geometry shaders>> feature is not
     enabled, pname:srcStageMask must: not contain
@@ -2118,11 +2101,6 @@ corresponding subpass dependency.
   * [[VUID-VkSubpassDependency2KHR-srcSubpass-03085]]
     pname:srcSubpass and pname:dstSubpass must: not both be equal to
     ename:VK_SUBPASS_EXTERNAL
-  * [[VUID-VkSubpassDependency2KHR-srcSubpass-02244]]
-    If pname:srcSubpass is equal to pname:dstSubpass, pname:srcStageMask and
-    pname:dstStageMask must: not set any bits that are neither
-    ename:VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, nor one of the
-    <<synchronization-pipeline-stages-types,graphics pipeline stages>>
   * [[VUID-VkSubpassDependency2KHR-srcSubpass-03087]]
     If pname:srcSubpass is equal to pname:dstSubpass and not all of the
     stages in pname:srcStageMask and pname:dstStageMask are


### PR DESCRIPTION
These VUs seem redundant to [VUID-VkRenderPassCreateInfo-pDependencies-00837](https://www.khronos.org/registry/vulkan/specs/1.1/html/vkspec.html#VUID-VkRenderPassCreateInfo-pDependencies-00837) and its siblings.

There was perhaps some attempt at being more generic. But any pipeline bind point is unlikely to support `VK_PIPELINE_STAGE_HOST_BIT` anyway. And not sure why any future self-dependencies could not theoretically be non-graphic. 