### PR TITLE
[RFC] Add VK_EXT_acquire_wl_display

### DIFF
--- a/appendices/VK_EXT_acquire_wl_display.txt
+++ b/appendices/VK_EXT_acquire_wl_display.txt
@@ -1,0 +1,41 @@
+include::meta/VK_EXT_acquire_wl_display.txt[]
+
+*Last Modified Date*::
+    2019-10-17
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Drew DeVault, Status Holdings, Ltd.
+
+This extension allows an application to take exclusive control of a display
+currently associated with a Wayland compositor.
+When control is acquired, the display will be unassociated from the Wayland
+compositor until the application releases the display or the specified display
+connection is closed.
+Essentially, the Wayland compositor will behave as if the monitor has been
+unplugged until the application releases it.
+
+=== New Enum Constants
+
+None.
+
+=== New Enums
+
+None.
+
+=== New Structures
+
+  * slink:VkWaylandLeaseConnectorEXT
+
+=== New Functions
+
+  * flink:vkAcquireWaylandDisplayEXT
+
+=== Issues
+
+None.
+
+=== Version History
+
+ * Revision 1, 2019-10-17 (Drew DeVault)
+   - Initial draft

--- a/chapters/VK_EXT_acquire_wl_display/acquire_wl_display.txt
+++ b/chapters/VK_EXT_acquire_wl_display/acquire_wl_display.txt
@@ -1,0 +1,51 @@
+[open,refpage='vkAcquireWaylandDisplayEXT',desc='Acquire access to a VkDisplayKHR using Wayland',type='protos']
+--
+
+To acquire permission to directly access a display in Vulkan from a Wayland
+compositor, call:
+
+include::{generated}/api/protos/vkAcquireWaylandDisplayEXT.txt[]
+
+  * pname:physicalDevice is the handle to the physical device the display is on.
+  * pname:display A code:wl_display associated with the Wayland compositor that
+	the application wishes to acquire the display(s) from.
+  * pname:manager A zwp_drm_lease_manager_v1 connected to the Wayland compositor
+	that associated with the connectors.
+  * pname:pConnectorCount The number of valid pointers in the pname:pConnectors
+	array.
+  * pname:pConnectors Array of slink:VkWaylandLeaseConnectorEXT to be acquired.
+
+All permissions necessary to control the display are granted to the Vulkan
+instance associated with pname:physicalDevice until the display is released, the
+Wayland connection specified by pname:display is terminated, or the compositor
+revokes the lease.
+If the Wayland server declines to grant the lease or the granted lease does not
+include the requested connectors, the call must: return the error code
+ename:VK_ERROR_INITIALIZATION_FAILED.
+If the Wayland server later revokes the lease, requests using the
+acquired slink:VkDisplayKHR resources must: fail with
+ename:VK_ERROR_SURFACE_LOST_KHR.
+
+include::{generated}/validity/protos/vkAcquireWaylandDisplayEXT.txt[]
+--
+
+[open,refpage='VkWaylandLeaseConnectorEXT',desc='Resource for relating Wayland connectors to VkDisplayKHRs',type='structs']
+--
+
+The sname:VkWaylandLeaseConnectorEXT structure is defined as:
+
+include::{generated}/api/structs/VkWaylandLeaseConnectorEXT.txt[]
+
+  * pname:pConnector A Wayland zwp_drm_lease_connector_v1 to include in the
+	lease.
+  * pname:pDisplay The corresponding slink:VkDisplayKHR handle will be
+    returned here.
+
+The implementation will make a best-effort attempt to match each
+slink:VkDisplayKHR acquired from the Wayland compositor to the appropriate
+pname:pConnectorIn. If no match is found or the result would be ambiguous, the
+lease is terminated, and flink:vkAcquireWaylandDisplayEXT must: return
+ename:VK_ERROR_INITIALIZATION_FAILED.
+
+include::{generated}/validity/structs/VkWaylandLeaseConnectorEXT.txt[]
+--

--- a/chapters/VK_EXT_direct_mode_display/acquire_release_displays.txt
+++ b/chapters/VK_EXT_direct_mode_display/acquire_release_displays.txt
@@ -10,6 +10,10 @@ ifdef::VK_EXT_acquire_xlib_display[]
 include::../VK_EXT_acquire_xlib_display/acquire_xlib_display.txt[]
 endif::VK_EXT_acquire_xlib_display[]
 
+ifdef::VK_EXT_acquire_wl_display[]
+include::../VK_EXT_acquire_wl_display/acquire_wl_display.txt[]
+endif::VK_EXT_acquire_wl_display[]
+
 [open,refpage='vkReleaseDisplayEXT',desc='Release access to an acquired VkDisplayKHR',type='protos']
 --
 

--- a/include/vulkan/vk_platform.h
+++ b/include/vulkan/vk_platform.h
@@ -85,6 +85,12 @@ extern "C"
     #endif
 #endif // !defined(VK_NO_STDINT_H)
 
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    // Forward declared for VK_EXT_acquire_wl_display
+    struct zwp_drm_lease_manager_v1;
+    struct zwp_drm_lease_connector_v1;
+#endif // VK_USE_PLATFORM_WAYLAND_KHR
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/scripts/genvk.py
+++ b/scripts/genvk.py
@@ -259,7 +259,9 @@ def makeGenOpts(args):
         [ 'vulkan_ios.h',         [ 'VK_MVK_ios_surface'          ], commonSuppressExtensions ],
         [ 'vulkan_macos.h',       [ 'VK_MVK_macos_surface'        ], commonSuppressExtensions ],
         [ 'vulkan_vi.h',          [ 'VK_NN_vi_surface'            ], commonSuppressExtensions ],
-        [ 'vulkan_wayland.h',     [ 'VK_KHR_wayland_surface'      ], commonSuppressExtensions ],
+        [ 'vulkan_wayland.h',     [ 'VK_KHR_wayland_surface',
+                                    'VK_EXT_acquire_wl_display'
+                                                                  ], commonSuppressExtensions ],
         [ 'vulkan_win32.h',       [ 'VK_.*_win32(|_.*)', 'VK_EXT_full_screen_exclusive' ],
                                                                      commonSuppressExtensions +
                                                                      [ 'VK_KHR_external_semaphore',

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -127,6 +127,8 @@ server.
         <type requires="X11/extensions/Xrandr.h" name="RROutput"/>
         <type requires="wayland-client.h" name="wl_display"/>
         <type requires="wayland-client.h" name="wl_surface"/>
+        <type name="zwp_drm_lease_manager_v1"/>
+        <type name="zwp_drm_lease_connector_v1"/>
         <type requires="windows.h" name="HINSTANCE"/>
         <type requires="windows.h" name="HWND"/>
         <type requires="windows.h" name="HMONITOR"/>
@@ -4205,6 +4207,10 @@ typedef void <name>CAMetalLayer</name>;
             <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>deviceCoherentMemory</name></member>
         </type>
+		<type category="struct" name="VkWaylandLeaseConnectorEXT">
+			<member>struct <type>zwp_drm_lease_connector_v1</type>* <name>pConnector</name></member>
+			<member><type>VkDisplayKHR</type> <name>pDisplay</name></member>
+		</type>
     </types>
 
     <comment>Vulkan enumerant (token) definitions</comment>
@@ -7846,6 +7852,14 @@ typedef void <name>CAMetalLayer</name>;
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>uint32_t</type> <name>lineStippleFactor</name></param>
             <param><type>uint16_t</type> <name>lineStipplePattern</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkAcquireWaylandDisplayEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>struct <type>wl_display</type>* <name>display</name></param>
+            <param>struct <type>zwp_drm_lease_manager_v1</type>* <name>manager</name></param>
+            <param><type>uint32_t</type> <name>pConnectorCount</name></param>
+            <param len="connectorCount"><type>VkWaylandLeaseConnectorEXT</type>* <name>pConnectors</name></param>
         </command>
     </commands>
 
@@ -11581,10 +11595,11 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_EXT_extension_285&quot;"              name="VK_EXT_extension_285"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_286" number="286" type="instance" author="EXT" contact="Drew DeVault sir@cmpwn.com" supported="disabled">
+        <extension name="VK_EXT_acquire_wl_display" number="286" type="instance" requires="VK_EXT_direct_mode_display" author="EXT" contact="Drew DeVault @ddevault" platform="wayland" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_286_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_286&quot;"              name="VK_EXT_extension_286"/>
+                <enum value="1"                                             name="VK_EXT_ACQUIRE_WL_DISPLAY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_acquire_wl_display&quot;"         name="VK_EXT_ACQUIRE_WL_DISPLAY_EXTENSION_NAME"/>
+                <command name="vkAcquireWaylandDisplayEXT"/>
             </require>
         </extension>
         <extension name="VK_NVX_extension_287" number="287" author="NVX" contact="Liam Middlebrook @liam-middlebrook" supported="disabled">


### PR DESCRIPTION
This is my first time putting together a VK extension, so be prepared to find some mistakes herein. I appreciate your patience.

This extension fulfills a similar purpose to VK_EXT_acquire_xlib_display, but for Wayland. It relies on a Wayland extension which is currently under discussion on wayland-devel. The thread there provides more information about the specifics:

https://lists.freedesktop.org/archives/wayland-devel/2019-July/040707.html

I want to avoid creating a Vk extension which depends on an unstable Wayland protocol, as the structure names reflect their unstable nature and I would prefer not to immortalize the unstable version in this extension. Therefore, once consensus is reached on the Wayland protocol, we're thinking about fast-tracking it to stable. At that point, I'll update this patch accordingly.

I've also implemented this extension for Mesa and radv:

https://gitlab.freedesktop.org/mesa/mesa/merge_requests/1509

As well as for Sway and wlroots (Wayland compositor) with these patches:

https://github.com/swaywm/wlroots/pull/1730

https://github.com/swaywm/sway/pull/4289

And I have an xrgears tree as well which takes advantage of this to show a VR scene using these extensions:

https://git.sr.ht/~sircmpwn/xrgears