### PR TITLE
Compatible pathlib for py2 and py3 in script/generator.py

### DIFF
--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -21,7 +21,10 @@ import os
 import re
 import pdb
 import sys
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 
 def write( *args, **kwargs ):
     file = kwargs.pop('file',sys.stdout)


### PR DESCRIPTION
pathlib name is not compatible in python2 and python3, it's named pathlib2 in python2.

Fixes #1011