### PR TITLE
Clarify the ACCESS_MEMORY bit flags

### DIFF
--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -789,24 +789,12 @@ endif::VK_KHR_depth_stencil_resolve[]
     operation.
     Accesses of this type are not performed through a resource, but directly
     on memory.
-  * ename:VK_ACCESS_MEMORY_READ_BIT specifies read access via non-specific
-    entities.
-    These entities include the Vulkan device and host, but may: also include
-    entities external to the Vulkan device or otherwise not part of the core
-    Vulkan pipeline.
-    When included in a destination access mask, makes all available writes
-    visible to all future read accesses on entities known to the Vulkan
-    device.
-  * ename:VK_ACCESS_MEMORY_WRITE_BIT specifies write access via non-specific
-    entities.
-    These entities include the Vulkan device and host, but may: also include
-    entities external to the Vulkan device or otherwise not part of the core
-    Vulkan pipeline.
-    When included in a source access mask, all writes that are performed by
-    entities known to the Vulkan device are made available.
-    When included in a destination access mask, makes all available writes
-    visible to all future write accesses on entities known to the Vulkan
-    device.
+  * ename:VK_ACCESS_MEMORY_READ_BIT is equivalent to the logical OR of
+    every other etype:READ access flag bit that is supported in the
+    pipeline stage it is used with.
+  * ename:VK_ACCESS_MEMORY_WRITE_BIT is equivalent to the logical OR of
+    every other etype:WRITE access flag bit that is supported in the
+    pipeline stage it is used with.
 ifdef::VK_EXT_conditional_rendering[]
   * ename:VK_ACCESS_CONDITIONAL_RENDERING_READ_BIT_EXT specifies read access
     to a predicate as part of conditional rendering.

--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -789,12 +789,12 @@ endif::VK_KHR_depth_stencil_resolve[]
     operation.
     Accesses of this type are not performed through a resource, but directly
     on memory.
-  * ename:VK_ACCESS_MEMORY_READ_BIT is equivalent to the logical OR of
-    every other etype:READ access flag bit that is supported in the
-    pipeline stage it is used with.
-  * ename:VK_ACCESS_MEMORY_WRITE_BIT is equivalent to the logical OR of
-    every other etype:WRITE access flag bit that is supported in the
-    pipeline stage it is used with.
+  * ename:VK_ACCESS_MEMORY_READ_BIT specifies all read accesses.
+    It is always valid in any access mask, and is treated as equivalent to setting
+    all etext:READ access flags that are valid where it is used.
+  * ename:VK_ACCESS_MEMORY_WRITE_BIT specifies all write accesses.
+    It is always valid in any access mask, and is treated as equivalent to setting
+    all etext:WRITE access flags that are valid where it is used.
 ifdef::VK_EXT_conditional_rendering[]
   * ename:VK_ACCESS_CONDITIONAL_RENDERING_READ_BIT_EXT specifies read access
     to a predicate as part of conditional rendering.
@@ -894,8 +894,8 @@ endif::VK_NV_ray_tracing[]
 |ename:VK_ACCESS_TRANSFER_WRITE_BIT                           | ename:VK_PIPELINE_STAGE_TRANSFER_BIT
 |ename:VK_ACCESS_HOST_READ_BIT                                | ename:VK_PIPELINE_STAGE_HOST_BIT
 |ename:VK_ACCESS_HOST_WRITE_BIT                               | ename:VK_PIPELINE_STAGE_HOST_BIT
-|ename:VK_ACCESS_MEMORY_READ_BIT                              | N/A
-|ename:VK_ACCESS_MEMORY_WRITE_BIT                             | N/A
+|ename:VK_ACCESS_MEMORY_READ_BIT                              | Any
+|ename:VK_ACCESS_MEMORY_WRITE_BIT                             | Any
 ifdef::VK_EXT_blend_operation_advanced[]
 |ename:VK_ACCESS_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT    | ename:VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
 endif::VK_EXT_blend_operation_advanced[]


### PR DESCRIPTION
This change makes clear that VK_ACCESS_MEMORY_READ_BIT and VK_ACCESS_MEMORY_WRITE_BIT are meant to be equivalent to setting all applicable READ/WRITE access flags.

Closes #1007 