### PR TITLE
Fix pNext features not accessible via VkPhysicalDeviceFeatures2

### DIFF
--- a/chapters/devsandqueues.txt
+++ b/chapters/devsandqueues.txt
@@ -966,6 +966,10 @@ ifdef::VK_VERSION_1_1,VK_KHR_get_physical_device_properties2[]
   * [[VUID-VkDeviceCreateInfo-pNext-00373]]
     If the pname:pNext chain includes a slink:VkPhysicalDeviceFeatures2
     structure, then pname:pEnabledFeatures must: be `NULL`
+  * If the pname:pNext chain includes a slink:VkPhysicalDeviceFeatures2
+    structure, then pname:pNext chain must: not include any
+    stext:Vk*Features* instances earlier in chain before the
+    slink:VkPhysicalDeviceFeatures2
 endif::VK_VERSION_1_1,VK_KHR_get_physical_device_properties2[]
 ifdef::VK_AMD_negative_viewport_height[]
 ifdef::VK_VERSION_1_1[]


### PR DESCRIPTION
Require all pNext features to be accesible via VkPhysicalDeviceFeatures2::pNext.

Would it be a reasonable restriction?

BTW: For some reason `VkPhysicalDeviceFeatures2` struct does not have generated `pNext` VU...
probably because of its dual use in `vkGet*Features` and `vkCreateDevice`... 