### PR TITLE
Add issue for name changes in buffer_device_address

### DIFF
--- a/appendices/VK_EXT_buffer_device_address.txt
+++ b/appendices/VK_EXT_buffer_device_address.txt
@@ -66,7 +66,9 @@ None
 
 === Issues
 
-None
+1) Where is VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT and VkPhysicalDeviceBufferAddressFeaturesEXT?
+
+*RESOLVED*: They were renamed as VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT and VkPhysicalDeviceBufferDeviceAddressFeaturesEXT accordingly for consistency.
 
 === Version History
 


### PR DESCRIPTION
Some structure names are changed in VK_EXT_buffer_device_address for consistency and this PR adds an issue to log it.