### PR TITLE
Make template descriptorSetLayout noauto

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -2511,7 +2511,7 @@ typedef void <name>CAMetalLayer</name>;
             <member><type>uint32_t</type>                 <name>descriptorUpdateEntryCount</name><comment>Number of descriptor update entries to use for the update template</comment></member>
             <member len="descriptorUpdateEntryCount">const <type>VkDescriptorUpdateTemplateEntry</type>* <name>pDescriptorUpdateEntries</name><comment>Descriptor update entries for the template</comment></member>
             <member><type>VkDescriptorUpdateTemplateType</type> <name>templateType</name></member>
-            <member optional="true"><type>VkDescriptorSetLayout</type> <name>descriptorSetLayout</name></member>
+            <member noautovalidity="true"><type>VkDescriptorSetLayout</type> <name>descriptorSetLayout</name></member>
             <member noautovalidity="true"><type>VkPipelineBindPoint</type> <name>pipelineBindPoint</name></member>
             <member noautovalidity="true"><type>VkPipelineLayout</type><name>pipelineLayout</name><comment>If used for push descriptors, this is the only allowed layout</comment></member>
             <member noautovalidity="true"><type>uint32_t</type> <name>set</name></member>


### PR DESCRIPTION
to be consistent with the `pipelineLayout` member in the same struct.