### PR TITLE
Clarify the memory mapping note about invalidation

### DIFF
--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -2772,9 +2772,10 @@ the last time it was invalidated.
 [NOTE]
 .Note
 ====
-Mapping non-coherent memory does not implicitly invalidate the mapped
-memory, and device writes that have not been invalidated must: be made
-visible before the host reads or overwrites them.
+Mapping non-coherent memory does not implicitly invalidate that memory.
+Device writes to non-coherent memory need to be made visible to the host
+before any further host access to avoid a data race, irrespective of when
+that memory was mapped to the host.
 ====
 
 include::{generated}/validity/protos/vkInvalidateMappedMemoryRanges.txt[]

--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -2773,9 +2773,6 @@ the last time it was invalidated.
 .Note
 ====
 Mapping non-coherent memory does not implicitly invalidate that memory.
-Device writes to non-coherent memory need to be made visible to the host
-before any further host access to avoid a data race, irrespective of when
-that memory was mapped to the host.
 ====
 
 include::{generated}/validity/protos/vkInvalidateMappedMemoryRanges.txt[]


### PR DESCRIPTION
Made clear that the note is not normative and only points out an instance of a data race that is not satisfied implicitly as some may expect.

Closes #889 