### PR TITLE
Ignore disabled Bits in validity

### DIFF
--- a/scripts/validitygenerator.py
+++ b/scripts/validitygenerator.py
@@ -658,7 +658,7 @@ class ValidityOutputGenerator(OutputGenerator):
         elif typecategory == 'bitmask':
             bitsname = paramtype.replace('Flags', 'FlagBits')
             bitselem = self.registry.tree.find("enums[@name='" + bitsname + "']")
-            if bitselem is None or len(bitselem.findall('enum')) == 0:
+            if bitselem is None or len(bitselem.findall('enum[@required="true"]')) == 0:
                 # Empty bit mask: presumably just a placeholder (or only in
                 # an extension not enabled for this build)
                 entry = ValidityEntry(

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -1364,7 +1364,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkRenderPassCreateInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*            <name>pNext</name></member>
-            <member optional="true" noautovalidity="true"><type>VkRenderPassCreateFlags</type>    <name>flags</name></member>
+            <member optional="true"><type>VkRenderPassCreateFlags</type> <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>   <name>attachmentCount</name></member>
             <member len="attachmentCount">const <type>VkAttachmentDescription</type>* <name>pAttachments</name></member>
             <member><type>uint32_t</type>               <name>subpassCount</name></member>
@@ -3314,7 +3314,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkRenderPassCreateInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                                              <name>pNext</name></member>
-            <member optional="true" noautovalidity="true"><type>VkRenderPassCreateFlags</type> <name>flags</name></member>
+            <member optional="true"><type>VkRenderPassCreateFlags</type>                  <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>                                 <name>attachmentCount</name></member>
             <member len="attachmentCount">const <type>VkAttachmentDescription2KHR</type>* <name>pAttachments</name></member>
             <member><type>uint32_t</type>                                                 <name>subpassCount</name></member>


### PR DESCRIPTION
Effectively adds:

> `flags` **must** be `0`

to `VkRenderPassCreateInfo`, `VkRenderPassCreateInfo2KHR`, and `VkShaderModuleCreateInfo` (which are disabled, but defined in upcoming extensions).
And to others based on the extensions and vulkan version chosen to build,