### PR TITLE
Fix VK_KHR_imageless_framebuffer missing types

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -9702,6 +9702,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_KHR_imageless_framebuffer&quot;"      name="VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME"/>
                 <type name="VkPhysicalDeviceImagelessFramebufferFeaturesKHR"/>
                 <type name="VkFramebufferAttachmentsCreateInfoKHR"/>
+                <type name="VkFramebufferAttachmentImageInfoKHR"/>
                 <type name="VkRenderPassAttachmentBeginInfoKHR"/>
                 <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES_KHR"/>
                 <enum offset="1" extends="VkStructureType" name="VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENTS_CREATE_INFO_KHR"/>


### PR DESCRIPTION
`VK_KHR_imageless_framebuffer` specifies
`VkFramebufferAttachmentsCreateInfoKHR` which depends on the
`VkFramebufferAttachmentImageInfoKHR` type. However it fails to specify
`VkFramebufferAttachmentImageInfoKHR` in the list of types from the
`<extension>` definition block.

Bug #1076 (VK_KHR_imageless_framebuffer missing type declarations)