### PR TITLE
Restructure WSI Query chapter 

### DIFF
--- a/chapters/VK_KHR_surface/wsi.txt
+++ b/chapters/VK_KHR_surface/wsi.txt
@@ -1043,19 +1043,10 @@ the following color spaces:
 | AdobeRGB       | 0.640, 0.330 | 0.210, 0.710  | 0.150, 0.060 | 0.3127, 0.3290 (D65) | AdobeRGB
 |====
 
-The transfer functions are described in the "Transfer Functions" chapter of
-the <<data-format,Khronos Data Format Specification>>.
+The transfer functions are described in the "`Transfer Functions`" chapter
+of the <<data-format,Khronos Data Format Specification>>.
 
-// @@@ The ref page is ended earlier than in the original markup due to
-// asciidoctor issues described in internal MR 2201.
-endif::VK_EXT_swapchain_colorspace[]
-
---
-
-ifdef::VK_EXT_swapchain_colorspace[]
-
-
-==== Display-P3 OETF
+Except Display-P3 OETF, which is:
 
 [latexmath]
 +++++++++++++++++++
@@ -1079,8 +1070,7 @@ For most uses, the sRGB OETF is equivalent.
 
 endif::VK_EXT_swapchain_colorspace[]
 
-// @@@ originally, the VkColorSpaceKHR ref page ended here
-// --
+--
 
 
 === Surface Presentation Mode Support

--- a/chapters/VK_KHR_surface/wsi.txt
+++ b/chapters/VK_KHR_surface/wsi.txt
@@ -284,6 +284,9 @@ supported by the surface on that physical device, even if the capabilities
 taken individually are supported as part of some other parameter
 combinations.
 
+
+=== Surface Capabilities
+
 [open,refpage='vkGetPhysicalDeviceSurfaceCapabilitiesKHR',desc='Query surface capabilities',type='protos']
 --
 
@@ -591,9 +594,10 @@ ifdef::VK_KHR_surface_protected_capabilities[]
 [open,refpage='VkSurfaceProtectedCapabilitiesKHR',desc='Structure describing capability of a surface to be protected',type='structs']
 --
 
-An application queries if a protected VkSurface is displayable on a specific
-windowing system using sname:VkSurfaceProtectedCapabilitiesKHR, which can:
-be passed in pname:pNext parameter of sname:VkSurfaceCapabilities2KHR.
+An application queries if a protected slink:VkSurface is displayable on a
+specific windowing system using sname:VkSurfaceProtectedCapabilitiesKHR,
+which can: be passed in pname:pNext parameter of
+sname:VkSurfaceCapabilities2KHR.
 
 The sname:VkSurfaceProtectedCapabilitiesKHR structure is defined as:
 
@@ -785,6 +789,9 @@ tname:VkCompositeAlphaFlagsKHR is a bitmask type for setting a mask of zero
 or more elink:VkCompositeAlphaFlagBitsKHR.
 --
 
+
+=== Surface Format Support
+
 [open,refpage='vkGetPhysicalDeviceSurfaceFormatsKHR',desc='Query color formats supported by surface',type='protos']
 --
 
@@ -816,7 +823,18 @@ If pname:pSurfaceFormatCount is smaller than the number of format pairs
 supported for the given pname:surface, ename:VK_INCOMPLETE will be returned
 instead of ename:VK_SUCCESS to indicate that not all the available values
 were returned.
+
 The number of format pairs supported must: be greater than or equal to 1.
+pname:pSurfaceFormats must: not contain an entry whose value for
+pname:format is ename:VK_FORMAT_UNDEFINED.
+
+If pname:pSurfaceFormats includes an entry whose value for pname:colorSpace
+is ename:VK_COLOR_SPACE_SRGB_NONLINEAR_KHR and whose value for pname:format
+is a UNORM (or SRGB) format and the corresponding SRGB (or UNORM) format is
+a color renderable format for ename:VK_IMAGE_TILING_OPTIMAL, then
+pname:pSurfaceFormats must: also contain an entry with the same value for
+pname:colorSpace and pname:format equal to the corresponding SRGB (or UNORM)
+format.
 
 .Valid Usage
 ****
@@ -865,6 +883,10 @@ include::{generated}/api/protos/vkGetPhysicalDeviceSurfaceFormats2KHR.txt[]
   * pname:pSurfaceFormats is either `NULL` or a pointer to an array of
     slink:VkSurfaceFormat2KHR structures.
 
+flink:vkGetPhysicalDeviceSurfaceFormats2KHR behaves similarly to
+flink:vkGetPhysicalDeviceSurfaceFormatsKHR, with the ability to be extended
+via pname:pNext chains.
+
 If pname:pSurfaceFormats is `NULL`, then the number of format tuples
 supported for the given pname:surface is returned in
 pname:pSurfaceFormatCount.
@@ -879,7 +901,6 @@ If pname:pSurfaceFormatCount is smaller than the number of format tuples
 supported for the surface parameters described in pname:pSurfaceInfo,
 ename:VK_INCOMPLETE will be returned instead of ename:VK_SUCCESS to indicate
 that not all the available values were returned.
-The number of format tuples supported must: be greater than or equal to 1.
 
 .Valid Usage
 ****
@@ -976,6 +997,18 @@ endif::VK_AMD_display_native_hdr[]
 [NOTE]
 .Note
 ====
+In the initial release of the `VK_KHR_surface` and `<<VK_KHR_swapchain>>`
+extensions, the token ename:VK_COLORSPACE_SRGB_NONLINEAR_KHR was used.
+Starting in the 2016-05-13 updates to the extension branches, matching
+release 1.0.13 of the core API specification,
+ename:VK_COLOR_SPACE_SRGB_NONLINEAR_KHR is used instead for consistency with
+Vulkan naming rules.
+The older enum is still available for backwards compatibility.
+====
+
+[NOTE]
+.Note
+====
 In older versions of this extension
 ename:VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT was misnamed
 ename:VK_COLOR_SPACE_DCI_P3_LINEAR_EXT.
@@ -1021,7 +1054,8 @@ endif::VK_EXT_swapchain_colorspace[]
 
 ifdef::VK_EXT_swapchain_colorspace[]
 
-=== Display-P3 OETF
+
+==== Display-P3 OETF
 
 [latexmath]
 +++++++++++++++++++
@@ -1043,40 +1077,13 @@ encoded value (as stored in the image in memory).
 For most uses, the sRGB OETF is equivalent.
 ====
 
-
-An implementation supporting this extension indicates support for these
-color spaces via slink:VkSurfaceFormatKHR structures returned from
-flink:vkGetPhysicalDeviceSurfaceFormatsKHR.
-
-Specifying the supported surface color space when calling
-flink:vkCreateSwapchainKHR will create a swapchain using that color space.
-
 endif::VK_EXT_swapchain_colorspace[]
-
-If pname:pSurfaceFormats includes an entry whose value for pname:colorSpace
-is ename:VK_COLOR_SPACE_SRGB_NONLINEAR_KHR and whose value for pname:format
-is a UNORM (or SRGB) format and the corresponding SRGB (or UNORM) format is
-a color renderable format for ename:VK_IMAGE_TILING_OPTIMAL, then
-pname:pSurfaceFormats must: also contain an entry with the same value for
-pname:colorSpace and pname:format equal to the corresponding SRGB (or UNORM)
-format.
-pname:pSurfaceFormats must: not contain an entry whose value for
-pname:format is ename:VK_FORMAT_UNDEFINED.
-
-[NOTE]
-.Note
-====
-In the initial release of the `VK_KHR_surface` and `<<VK_KHR_swapchain>>`
-extensions, the token ename:VK_COLORSPACE_SRGB_NONLINEAR_KHR was used.
-Starting in the 2016-05-13 updates to the extension branches, matching
-release 1.0.13 of the core API specification,
-ename:VK_COLOR_SPACE_SRGB_NONLINEAR_KHR is used instead for consistency with
-Vulkan naming rules.
-The older enum is still available for backwards compatibility.
-====
 
 // @@@ originally, the VkColorSpaceKHR ref page ended here
 // --
+
+
+=== Surface Presentation Mode Support
 
 [open,refpage='vkGetPhysicalDeviceSurfacePresentModesKHR',desc='Query supported presentation modes',type='protos']
 --


### PR DESCRIPTION
- split in sections
- move orphaned paragraphs
- concentrate behavior descriptions to
vkGetPhysicalDeviceSurfaceFormatsKHR (non-2)
- remove two paragraphs restating the obvious
- remove old hack