### PR TITLE
Prefer slink in autovalidity

### DIFF
--- a/scripts/conventions.py
+++ b/scripts/conventions.py
@@ -114,7 +114,7 @@ class ConventionsBase:
 
         May override.
         """
-        return 'sname:'
+        return 'slink:'
 
     @property
     def external_macro(self):


### PR DESCRIPTION
to be consistent with the preference for `elink:` and `tlink:`

Example diff:
![diff](https://user-images.githubusercontent.com/3791331/69077270-89d1e480-0a35-11ea-849d-5b41ff2b705a.PNG)
