### PR TITLE
Ifdef VK_AMD_mixed_attachment_samples and VK_NV_framebuffer_mixed_samples

### DIFF
--- a/chapters/fragops.txt
+++ b/chapters/fragops.txt
@@ -1284,7 +1284,12 @@ with one bit for each sample in the color attachment(s) for the subpass.
 If a bit in the color sample mask is 0, then blending and writing to the
 framebuffer are not performed for that sample.
 
+ifdef::VK_NV_framebuffer_mixed_samples[]
 When the `VK_NV_framebuffer_mixed_samples` extension is not enabled, each
+endif::VK_NV_framebuffer_mixed_samples[]
+ifndef::VK_NV_framebuffer_mixed_samples[]
+Each
+endif::VK_NV_framebuffer_mixed_samples[]
 color sample is associated with a unique rasterization sample, and the value
 of the coverage mask is assigned to the color sample mask.
 

--- a/chapters/primsrast.txt
+++ b/chapters/primsrast.txt
@@ -229,11 +229,30 @@ Surviving fragments are processed by fragment shaders.
 Fragment shaders determine associated data for fragments, and can: also
 modify or replace their assigned depth values.
 
+ifdef::VK_AMD_mixed_attachment_samples[]
+ifndef::VK_NV_framebuffer_mixed_samples[]
+When the `VK_AMD_mixed_attachment_samples` extension is not enabled, if
+endif::VK_NV_framebuffer_mixed_samples[]
+endif::VK_AMD_mixed_attachment_samples[]
+ifndef::VK_AMD_mixed_attachment_samples[]
+ifdef::VK_NV_framebuffer_mixed_samples[]
+When the `VK_NV_framebuffer_mixed_samples` extension is not enabled, if
+endif::VK_NV_framebuffer_mixed_samples[]
+endif::VK_AMD_mixed_attachment_samples[]
+ifdef::VK_AMD_mixed_attachment_samples[]
+ifdef::VK_NV_framebuffer_mixed_samples[]
 When the `VK_AMD_mixed_attachment_samples` and
-`VK_NV_framebuffer_mixed_samples` extensions are not enabled, if the subpass
-for which this pipeline is being created uses color and/or depth/stencil
-attachments, then pname:rasterizationSamples must: be the same as the sample
-count for those subpass attachments.
+`VK_NV_framebuffer_mixed_samples` extensions are not enabled, if
+endif::VK_NV_framebuffer_mixed_samples[]
+endif::VK_AMD_mixed_attachment_samples[]
+ifndef::VK_AMD_mixed_attachment_samples[]
+ifndef::VK_NV_framebuffer_mixed_samples[]
+If
+endif::VK_NV_framebuffer_mixed_samples[]
+endif::VK_AMD_mixed_attachment_samples[]
+the subpass for which this pipeline is being created uses color and/or
+depth/stencil attachments, then pname:rasterizationSamples must: be the
+same as the sample count for those subpass attachments.
 
 ifdef::VK_AMD_mixed_attachment_samples[]
 


### PR DESCRIPTION
The text shouldn't be referencing vendor extensions when they are not enabled when compiling the specification.