### PR TITLE
Clarify shaderStorageImageExtendedFormats feature

### DIFF
--- a/chapters/features.txt
+++ b/chapters/features.txt
@@ -548,14 +548,53 @@ supported properties of individual formats as normal.
     code:ImageGatherExtended capability.
   * [[features-shaderStorageImageExtendedFormats]]
     pname:shaderStorageImageExtendedFormats specifies whether all the
-    extended storage image formats are available in shader code.
-    If this feature is enabled then the
-    ename:VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT feature must: be supported in
-    pname:optimalTilingFeatures for all of the extended formats.
-    To query for additional properties, or if the feature is not enabled,
-    flink:vkGetPhysicalDeviceFormatProperties and
-    flink:vkGetPhysicalDeviceImageFormatProperties can: be used to check for
-    supported properties of individual formats as normal.
+    "`storage image extended formats`" below are supported; if this feature
+    is supported, then the ename:VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT must:
+    be supported in pname:optimalTilingFeatures for the following formats:
++
+  ** ename:VK_FORMAT_R16G16_SFLOAT
+  ** ename:VK_FORMAT_B10G11R11_UFLOAT_PACK32
+  ** ename:VK_FORMAT_R16_SFLOAT
+  ** ename:VK_FORMAT_R16G16B16A16_UNORM
+  ** ename:VK_FORMAT_A2B10G10R10_UNORM_PACK32
+  ** ename:VK_FORMAT_R16G16_UNORM
+  ** ename:VK_FORMAT_R8G8_UNORM
+  ** ename:VK_FORMAT_R16_UNORM
+  ** ename:VK_FORMAT_R8_UNORM
+  ** ename:VK_FORMAT_R16G16B16A16_SNORM
+  ** ename:VK_FORMAT_R16G16_SNORM
+  ** ename:VK_FORMAT_R8G8_SNORM
+  ** ename:VK_FORMAT_R16_SNORM
+  ** ename:VK_FORMAT_R8_SNORM
+  ** ename:VK_FORMAT_R16G16_SINT
+  ** ename:VK_FORMAT_R8G8_SINT
+  ** ename:VK_FORMAT_R16_SINT
+  ** ename:VK_FORMAT_R8_SINT
+  ** ename:VK_FORMAT_A2B10G10R10_UINT_PACK32
+  ** ename:VK_FORMAT_R16G16_UINT
+  ** ename:VK_FORMAT_R8G8_UINT
+  ** ename:VK_FORMAT_R16_UINT
+  ** ename:VK_FORMAT_R8_UINT
++
+[NOTE]
+.Note
+====
+pname:shaderStorageImageExtendedFormats feature only adds a guarantee of
+format support, which is specified for the whole physical device.
+Therefore enabling or disabling the feature via flink:vkCreateDevice has no
+practical effect.
+
+To query for additional properties, or if the feature is not supported,
+flink:vkGetPhysicalDeviceFormatProperties and
+flink:vkGetPhysicalDeviceImageFormatProperties can: be used to check for
+supported properties of individual formats, as usual rules allow.
+
+ename:VK_FORMAT_R32G32_UINT, ename:VK_FORMAT_R32G32_SINT, and
+ename:VK_FORMAT_R32G32_SFLOAT from code:StorageImageExtendedFormats SPIR-V
+capability, are already covered by core Vulkan
+<<formats-mandatory-features-32bit,mandatory format support>>.
+====
+
   * [[features-shaderStorageImageMultisample]]
     pname:shaderStorageImageMultisample specifies whether multisampled
     storage images are supported.

--- a/chapters/formats.txt
+++ b/chapters/formats.txt
@@ -2634,6 +2634,8 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
 ^|{sym2} | This feature must: be supported on at least some
 of the named formats, with more information in the table
 where the symbol appears
+^|{sym3} | This feature must: be supported with some caveats or
+preconditions, with more information in the table where the symbol appears
 |====
 
 .Feature bits in pname:optimalTilingFeatures
@@ -2717,34 +2719,38 @@ s| Format
 2+>| ename:VK_FORMAT_FEATURE_BLIT_SRC_BIT                      .3+^.^| {downarrow}
 1+>| ename:VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT                 .2+^.^| {downarrow}
 s| Format
-| ename:VK_FORMAT_R8_UNORM                   | {sym1} | {sym1} | {sym1} |   |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R8_SNORM                   | {sym1} | {sym1} | {sym1} |   |   |   |   |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R8_USCALED                 |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8_SSCALED                 |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8_UINT                    | {sym1} | {sym1} |   |   |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R8_SINT                    | {sym1} | {sym1} |   |   |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R8_SRGB                    |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8_UNORM                 | {sym1} | {sym1} | {sym1} |   |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R8G8_SNORM                 | {sym1} | {sym1} | {sym1} |   |   |   |   |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R8G8_USCALED               |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8_SSCALED               |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8_UINT                  | {sym1} | {sym1} |   |   |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R8G8_SINT                  | {sym1} | {sym1} |   |   |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R8G8_SRGB                  |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8B8_UNORM               |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8B8_SNORM               |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8B8_USCALED             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8B8_SSCALED             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8B8_UINT                |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8B8_SINT                |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R8G8B8_SRGB                |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_B8G8R8_UNORM               |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_B8G8R8_SNORM               |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_B8G8R8_USCALED             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_B8G8R8_SSCALED             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_B8G8R8_UINT                |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_B8G8R8_SINT                |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_B8G8R8_SRGB                |   |   |   |   |   |   |   |   |   |   |   |   |
+| ename:VK_FORMAT_R8_UNORM                   | {sym1} | {sym1} | {sym1} | {sym3} |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |   |
+| ename:VK_FORMAT_R8_SNORM                   | {sym1} | {sym1} | {sym1} | {sym3} |   |        |        |        |   | {sym1} | {sym1} |   |
+| ename:VK_FORMAT_R8_USCALED                 |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8_SSCALED                 |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8_UINT                    | {sym1} | {sym1} |        | {sym3} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} |   |
+| ename:VK_FORMAT_R8_SINT                    | {sym1} | {sym1} |        | {sym3} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} |   |
+| ename:VK_FORMAT_R8_SRGB                    |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8_UNORM                 | {sym1} | {sym1} | {sym1} | {sym3} |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |   |
+| ename:VK_FORMAT_R8G8_SNORM                 | {sym1} | {sym1} | {sym1} | {sym3} |   |        |        |        |   | {sym1} | {sym1} |   |
+| ename:VK_FORMAT_R8G8_USCALED               |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8_SSCALED               |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8_UINT                  | {sym1} | {sym1} |        | {sym3} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} |   |
+| ename:VK_FORMAT_R8G8_SINT                  | {sym1} | {sym1} |        | {sym3} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} |   |
+| ename:VK_FORMAT_R8G8_SRGB                  |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8B8_UNORM               |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8B8_SNORM               |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8B8_USCALED             |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8B8_SSCALED             |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8B8_UINT                |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8B8_SINT                |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R8G8B8_SRGB                |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_B8G8R8_UNORM               |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_B8G8R8_SNORM               |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_B8G8R8_USCALED             |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_B8G8R8_SSCALED             |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_B8G8R8_UINT                |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_B8G8R8_SINT                |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_B8G8R8_SRGB                |        |        |        |        |   |        |        |        |   |        |        |   |
+14+| Format features marked with {sym3} must: be supported for
+pname:optimalTilingFeatures if the sname:VkPhysicalDevice supports the
+<<features-shaderStorageImageExtendedFormats,
+pname:shaderStorageImageExtendedFormats>> feature.
 |====
 
 <<<
@@ -2810,24 +2816,28 @@ s| Format
 2+>| ename:VK_FORMAT_FEATURE_BLIT_SRC_BIT                      .3+^.^| {downarrow}
 1+>| ename:VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT                 .2+^.^| {downarrow}
 s| Format
-| ename:VK_FORMAT_A2R10G10B10_UNORM_PACK32   |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_A2R10G10B10_SNORM_PACK32   |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_A2R10G10B10_USCALED_PACK32 |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_A2R10G10B10_SSCALED_PACK32 |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_A2R10G10B10_UINT_PACK32    |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_A2R10G10B10_SINT_PACK32    |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_A2B10G10R10_UNORM_PACK32   | {sym1} | {sym1} | {sym1} |   |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_A2B10G10R10_SNORM_PACK32   |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_A2B10G10R10_USCALED_PACK32 |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_A2B10G10R10_SSCALED_PACK32 |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_A2B10G10R10_UINT_PACK32    | {sym1} | {sym1} |   |   |   | {sym1} | {sym1} |   |   |   | {sym1} |   |
-| ename:VK_FORMAT_A2B10G10R10_SINT_PACK32    |   |   |   |   |   |   |   |   |   |   |   |   |
+| ename:VK_FORMAT_A2R10G10B10_UNORM_PACK32   |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_A2R10G10B10_SNORM_PACK32   |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_A2R10G10B10_USCALED_PACK32 |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_A2R10G10B10_SSCALED_PACK32 |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_A2R10G10B10_UINT_PACK32    |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_A2R10G10B10_SINT_PACK32    |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_A2B10G10R10_UNORM_PACK32   | {sym1} | {sym1} | {sym1} | {sym3} |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |   |
+| ename:VK_FORMAT_A2B10G10R10_SNORM_PACK32   |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_A2B10G10R10_USCALED_PACK32 |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_A2B10G10R10_SSCALED_PACK32 |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_A2B10G10R10_UINT_PACK32    | {sym1} | {sym1} |        | {sym3} |   | {sym1} | {sym1} |        |   |        | {sym1} |   |
+| ename:VK_FORMAT_A2B10G10R10_SINT_PACK32    |        |        |        |        |   |        |        |        |   |        |        |   |
 ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
-| ename:VK_FORMAT_R10X6_UNORM_PACK16         |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R10X6G10X6_UNORM_2PACK16   |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R12X4_UNORM_PACK16         |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R12X4G12X4_UNORM_2PACK16   |   |   |   |   |   |   |   |   |   |   |   |   |
+| ename:VK_FORMAT_R10X6_UNORM_PACK16         |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R10X6G10X6_UNORM_2PACK16   |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R12X4_UNORM_PACK16         |        |        |        |        |   |        |        |        |   |        |        |   |
+| ename:VK_FORMAT_R12X4G12X4_UNORM_2PACK16   |        |        |        |        |   |        |        |        |   |        |        |   |
 endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+14+| Format features marked with {sym3} must: be supported for
+pname:optimalTilingFeatures if the sname:VkPhysicalDevice supports the
+<<features-shaderStorageImageExtendedFormats,
+pname:shaderStorageImageExtendedFormats>> feature.
 |====
 
 <<<
@@ -2850,34 +2860,38 @@ endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
 2+>| ename:VK_FORMAT_FEATURE_BLIT_SRC_BIT                      .3+^.^| {downarrow}
 1+>| ename:VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT                 .2+^.^| {downarrow}
 s| Format
-| ename:VK_FORMAT_R16_UNORM                  |   |   |   |   |   |   |   |   |   | {sym1} |   |   |
-| ename:VK_FORMAT_R16_SNORM                  |   |   |   |   |   |   |   |   |   | {sym1} |   |   |
-| ename:VK_FORMAT_R16_USCALED                |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16_SSCALED                |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16_UINT                   | {sym1} | {sym1} |   |   |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R16_SINT                   | {sym1} | {sym1} |   |   |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R16_SFLOAT                 | {sym1} | {sym1} | {sym1} |   |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R16G16_UNORM               |   |   |   |   |   |   |   |   |   | {sym1} |   |   |
-| ename:VK_FORMAT_R16G16_SNORM               |   |   |   |   |   |   |   |   |   | {sym1} |   |   |
-| ename:VK_FORMAT_R16G16_USCALED             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16_SSCALED             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16_UINT                | {sym1} | {sym1} |   |   |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R16G16_SINT                | {sym1} | {sym1} |   |   |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R16G16_SFLOAT              | {sym1} | {sym1} | {sym1} |   |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |   |
-| ename:VK_FORMAT_R16G16B16_UNORM            |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16B16_SNORM            |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16B16_USCALED          |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16B16_SSCALED          |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16B16_UINT             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16B16_SINT             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16B16_SFLOAT           |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16B16A16_UNORM         |   |   |   |   |   |   |   |   |   | {sym1} |   |   |
-| ename:VK_FORMAT_R16G16B16A16_SNORM         |   |   |   |   |   |   |   |   |   | {sym1} |   |   |
-| ename:VK_FORMAT_R16G16B16A16_USCALED       |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16B16A16_SSCALED       |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R16G16B16A16_UINT          | {sym1} | {sym1} |   | {sym1} |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} | {sym1} |
-| ename:VK_FORMAT_R16G16B16A16_SINT          | {sym1} | {sym1} |   | {sym1} |   | {sym1} | {sym1} |   |   | {sym1} | {sym1} | {sym1} |
+| ename:VK_FORMAT_R16_UNORM                  |        |        |        | {sym3} |   |        |        |        |   | {sym1} |        |        |
+| ename:VK_FORMAT_R16_SNORM                  |        |        |        | {sym3} |   |        |        |        |   | {sym1} |        |        |
+| ename:VK_FORMAT_R16_USCALED                |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16_SSCALED                |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16_UINT                   | {sym1} | {sym1} |        | {sym3} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} |        |
+| ename:VK_FORMAT_R16_SINT                   | {sym1} | {sym1} |        | {sym3} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} |        |
+| ename:VK_FORMAT_R16_SFLOAT                 | {sym1} | {sym1} | {sym1} | {sym3} |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |        |
+| ename:VK_FORMAT_R16G16_UNORM               |        |        |        | {sym3} |   |        |        |        |   | {sym1} |        |        |
+| ename:VK_FORMAT_R16G16_SNORM               |        |        |        | {sym3} |   |        |        |        |   | {sym1} |        |        |
+| ename:VK_FORMAT_R16G16_USCALED             |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16_SSCALED             |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16_UINT                | {sym1} | {sym1} |        | {sym3} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} |        |
+| ename:VK_FORMAT_R16G16_SINT                | {sym1} | {sym1} |        | {sym3} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} |        |
+| ename:VK_FORMAT_R16G16_SFLOAT              | {sym1} | {sym1} | {sym1} | {sym3} |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} |        |
+| ename:VK_FORMAT_R16G16B16_UNORM            |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16B16_SNORM            |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16B16_USCALED          |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16B16_SSCALED          |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16B16_UINT             |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16B16_SINT             |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16B16_SFLOAT           |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16B16A16_UNORM         |        |        |        | {sym3} |   |        |        |        |   | {sym1} |        |        |
+| ename:VK_FORMAT_R16G16B16A16_SNORM         |        |        |        | {sym3} |   |        |        |        |   | {sym1} |        |        |
+| ename:VK_FORMAT_R16G16B16A16_USCALED       |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16B16A16_SSCALED       |        |        |        |        |   |        |        |        |   |        |        |        |
+| ename:VK_FORMAT_R16G16B16A16_UINT          | {sym1} | {sym1} |        | {sym1} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} | {sym1} |
+| ename:VK_FORMAT_R16G16B16A16_SINT          | {sym1} | {sym1} |        | {sym1} |   | {sym1} | {sym1} |        |   | {sym1} | {sym1} | {sym1} |
 | ename:VK_FORMAT_R16G16B16A16_SFLOAT        | {sym1} | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} | {sym1} |   | {sym1} | {sym1} | {sym1} |
+14+| Format features marked with {sym3} must: be supported for
+pname:optimalTilingFeatures if the sname:VkPhysicalDevice supports the
+<<features-shaderStorageImageExtendedFormats,
+pname:shaderStorageImageExtendedFormats>> feature.
 |====
 
 <<<
@@ -2934,20 +2948,24 @@ s| Format
 2+>| ename:VK_FORMAT_FEATURE_BLIT_SRC_BIT                      .3+^.^| {downarrow}
 1+>| ename:VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT                 .2+^.^| {downarrow}
 s| Format
-| ename:VK_FORMAT_R64_UINT                   |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64_SINT                   |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64_SFLOAT                 |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64G64_UINT                |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64G64_SINT                |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64G64_SFLOAT              |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64G64B64_UINT             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64G64B64_SINT             |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64G64B64_SFLOAT           |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64G64B64A64_UINT          |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64G64B64A64_SINT          |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_R64G64B64A64_SFLOAT        |   |   |   |   |   |   |   |   |   |   |   |   |
-| ename:VK_FORMAT_B10G11R11_UFLOAT_PACK32    | {sym1} | {sym1} | {sym1} |   |   |   |   |   |   |   | {sym1} |   |
-| ename:VK_FORMAT_E5B9G9R9_UFLOAT_PACK32     | {sym1} | {sym1} | {sym1} |   |   |   |   |   |   |   |   |   |
+| ename:VK_FORMAT_R64_UINT                   |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64_SINT                   |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64_SFLOAT                 |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64G64_UINT                |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64G64_SINT                |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64G64_SFLOAT              |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64G64B64_UINT             |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64G64B64_SINT             |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64G64B64_SFLOAT           |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64G64B64A64_UINT          |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64G64B64A64_SINT          |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_R64G64B64A64_SFLOAT        |        |        |        |        |   |   |   |   |   |   |        |   |
+| ename:VK_FORMAT_B10G11R11_UFLOAT_PACK32    | {sym1} | {sym1} | {sym1} | {sym3} |   |   |   |   |   |   | {sym1} |   |
+| ename:VK_FORMAT_E5B9G9R9_UFLOAT_PACK32     | {sym1} | {sym1} | {sym1} |        |   |   |   |   |   |   |        |   |
+14+| Format features marked with {sym3} must: be supported for
+pname:optimalTilingFeatures if the sname:VkPhysicalDevice supports the
+<<features-shaderStorageImageExtendedFormats,
+pname:shaderStorageImageExtendedFormats>> feature.
 |====
 
 <<<

--- a/config/attribs.txt
+++ b/config/attribs.txt
@@ -4,6 +4,7 @@
 // Special symbols - not used in [eq] spans
 :sym1: ✓
 :sym2: †
+:sym3: ‡
 :reg: ®
 :trade: ™
 


### PR DESCRIPTION
Fix suggestion for #395.

- Add the formats to Required Format tables, with precondition on the feature
- Update feature description with explicitly listed format
- Update description with note about enabling being optional
- Update description with note about discrepancy vs SPIR-V formats