### PR TITLE
Fix minImageCount VU wrt the shared present modes

### DIFF
--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -268,17 +268,26 @@ endif::VK_KHR_shared_presentable_image[]
   * [[VUID-VkSwapchainCreateInfoKHR-surface-01270]]
     pname:surface must: be a surface that is supported by the device as
     determined using flink:vkGetPhysicalDeviceSurfaceSupportKHR
+ifndef::VK_KHR_shared_presentable_image[]
   * [[VUID-VkSwapchainCreateInfoKHR-minImageCount-01271]]
     pname:minImageCount must: be greater than or equal to the value returned
     in the pname:minImageCount member of the sname:VkSurfaceCapabilitiesKHR
     structure returned by flink:vkGetPhysicalDeviceSurfaceCapabilitiesKHR
     for the surface
+endif::VK_KHR_shared_presentable_image[]
   * [[VUID-VkSwapchainCreateInfoKHR-minImageCount-01272]]
     pname:minImageCount must: be less than or equal to the value returned in
     the pname:maxImageCount member of the sname:VkSurfaceCapabilitiesKHR
     structure returned by fname:vkGetPhysicalDeviceSurfaceCapabilitiesKHR
     for the surface if the returned pname:maxImageCount is not zero
 ifdef::VK_KHR_shared_presentable_image[]
+  * If pname:presentMode is not
+    ename:VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR nor
+    ename:VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR, then
+    pname:minImageCount must: be greater than or equal to the value returned
+    in the pname:minImageCount member of the sname:VkSurfaceCapabilitiesKHR
+    structure returned by flink:vkGetPhysicalDeviceSurfaceCapabilitiesKHR
+    for the surface
   * [[VUID-VkSwapchainCreateInfoKHR-minImageCount-01383]]
     pname:minImageCount must: be `1` if pname:presentMode is either
     ename:VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR or


### PR DESCRIPTION
Most of the drivers seem to report `minImageCount==2`, which would make the swapchain uncreatable due to the another VU requiring the count to be 1 for shared present modes.