### PR TITLE
Hide outdated VU in face of timeline semaphores

### DIFF
--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -997,11 +997,13 @@ See <<devsandqueues-lost-device,Lost Device>>.
     by any element of the pname:pWaitSemaphores member of any element of
     pname:pSubmits executes on pname:queue, there must: be no other queues
     waiting on the same semaphore.
+ifndef::VK_KHR_timeline_semaphore[]
   * [[VUID-vkQueueSubmit-pWaitSemaphores-00069]]
     All elements of the pname:pWaitSemaphores member of all elements of
     pname:pSubmits must: be semaphores that are signaled, or have
     <<synchronization-semaphores-signaling, semaphore signal operations>>
     previously submitted for execution.
+endif::VK_KHR_timeline_semaphore[]
 ifdef::VK_KHR_timeline_semaphore[]
   * [[VUID-vkQueueSubmit-pWaitSemaphores-03238]]
     All elements of the pname:pWaitSemaphores member of all elements of


### PR DESCRIPTION
The following VU added by VK_KHR_timeline_semaphore is accurate, and covers the same invalid cases as this does, but factoring in timeline semaphores.