### PR TITLE
memory.txt: Clarify memory properties

### DIFF
--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -1888,6 +1888,11 @@ times into a given Vulkan instance.
 In all cases, each import operation must: create a distinct
 sname:VkDeviceMemory object.
 
+If the import is successful, the implementation must: ensure that any successful
+subsequent call to fname:vkMapMemory results in a host visible pointer that is
+consistent with memory properties corresponding to pname:memoryTypeIndex of the
+slink:VkMemoryAllocateInfo structure.
+
 .Valid Usage
 ****
   * [[VUID-VkImportMemoryFdInfoKHR-handleType-00667]]


### PR DESCRIPTION
This may be a bit obvious, but we want to make sure the imported
memory, if it is mapped, as the same memory properties of the
corresponding memory index.

Again, let me know if this is too obvious given VkMemoryFdPropertiesKHR.