### PR TITLE
Make note redundant vkMapMemory restriction

### DIFF
--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -2679,8 +2679,13 @@ include::{generated}/api/protos/vkMapMemory.txt[]
 
 After a successful call to fname:vkMapMemory the memory object pname:memory
 is considered to be currently _host mapped_.
+
+[NOTE]
+.Note
+====
 It is an application error to call fname:vkMapMemory on a memory object that
-is already host mapped.
+is already _host mapped_.
+====
 
 [NOTE]
 .Note


### PR DESCRIPTION
restriction already in [`VUID-vkMapMemory-memory-00678`](https://www.khronos.org/registry/vulkan/specs/1.1/html/vkspec.html#VUID-vkMapMemory-memory-00678)

closes #1142