### PR TITLE
Fix vkGetPhysicalDeviceToolPropertiesEXT

### DIFF
--- a/chapters/debugging.txt
+++ b/chapters/debugging.txt
@@ -133,6 +133,10 @@ pname:pToolProperties.
 If pname:pToolCount is less than the number of currently active tools, at
 most pname:pToolCount structures will be written.
 
+The count and properties of active tools may: change in response to events
+outside the scope of the specification. An application should: assume these
+properties might change at any given time.
+
 include::{generated}/validity/protos/vkGetPhysicalDeviceToolPropertiesEXT.txt[]
 --
 

--- a/chapters/debugging.txt
+++ b/chapters/debugging.txt
@@ -122,15 +122,16 @@ include::{generated}/api/protos/vkGetPhysicalDeviceToolPropertiesEXT.txt[]
   * pname:pToolCount is a pointer to an integer describing the number of
     tools active on pname:physicalDevice.
   * pname:pToolProperties is either `NULL` or a pointer to an array of
-    slink:VkPhysicalDeviceToolPropertiesEXT instances.
+    slink:VkPhysicalDeviceToolPropertiesEXT structures.
 
-If pname:pToolProperties is `NULL`, the implementation will return the
-number of tools currently active on pname:physicalDevice in
-pname:pToolCount.
-
-If pname:pToolProperties is not `NULL`, its elements are populate with
-information about active tools, up to the number stored in pname:pToolCount;
-the number of elements actually returned is returned in pname:pToolCount.
+If pname:pToolProperties is `NULL`, then the number of tools currently
+active on pname:physicalDevice is returned in pname:pToolCount.
+Otherwise, pname:pToolCount must: point to a variable set by the user to the
+number of elements in the pname:pToolProperties array, and on return the
+variable is overwritten with the number of structures actually written to
+pname:pToolProperties.
+If pname:pToolCount is less than the number of currently active tools, at
+most pname:pToolCount structures will be written.
 
 include::{generated}/validity/protos/vkGetPhysicalDeviceToolPropertiesEXT.txt[]
 --

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -8031,7 +8031,7 @@ typedef void <name>CAMetalLayer</name>;
         <command successcodes="VK_SUCCESS,VK_INCOMPLETE">
             <proto><type>VkResult</type> <name>vkGetPhysicalDeviceToolPropertiesEXT</name></proto>
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
-            <param><type>uint32_t</type>* <name>pToolCount</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pToolCount</name></param>
             <param optional="true" len="pToolCount"><type>VkPhysicalDeviceToolPropertiesEXT</type>* <name>pToolProperties</name></param>
         </command>
     </commands>


### PR DESCRIPTION
- Fix returned array implicit VUs
![diff](https://user-images.githubusercontent.com/3791331/71632308-229b7880-2c0e-11ea-9cce-f7c0524f8549.png)
- Rewrite text to be more consistent (based on `vkGetPhysicalDeviceQueueFamilyProperties`)
- Explicitly state variability (aka "lifetime") of retrieved results. (I assume active tools list can change; e.g. tools being switched on and off outside the Vulkan scope.)
