### PR TITLE
Remove redundant vkCmdExecuteCommands VU

### DIFF
--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -1577,9 +1577,6 @@ command buffer becomes <<commandbuffers-lifecycle, invalid>>.
 
 .Valid Usage
 ****
-  * [[VUID-vkCmdExecuteCommands-commandBuffer-00087]]
-    pname:commandBuffer must: have been allocated with a pname:level of
-    ename:VK_COMMAND_BUFFER_LEVEL_PRIMARY
   * [[VUID-vkCmdExecuteCommands-pCommandBuffers-00088]]
     Each element of pname:pCommandBuffers must: have been allocated with a
     pname:level of ename:VK_COMMAND_BUFFER_LEVEL_SECONDARY


### PR DESCRIPTION
already covered by implicit VUID-vkCmdExecuteCommands-bufferlevel