### PR TITLE
Clarify command buffer state

### DIFF
--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -63,8 +63,8 @@ Each command buffer is always in one of the following states:
 Initial::
     When a command buffer is <<vkAllocateCommandBuffers, allocated>>, it is
     in the _initial state_.
-    Some commands are able to _reset_ a command buffer, or a set of command
-    buffers, back to this state from any of the executable, recording or
+    Some commands are able to _reset_ a command buffer (or a set of command
+    buffers) back to this state from any of the executable, recording or
     invalid state.
     Command buffers in the initial state can: only be moved to the recording
     state, or freed.
@@ -86,9 +86,10 @@ Pending::
     Whilst in the pending state, applications must: not attempt to modify
     the command buffer in any way - as the device may: be processing the
     commands recorded to it.
-    Once execution of a command buffer completes, the command buffer reverts
-    back to either the _executable state_, or the _invalid state_ if it was
-    recorded with ename:VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT.
+    Once execution of a command buffer completes, the command buffer either
+    reverts back to the _executable state_, or if it was recorded with
+    ename:VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, it moves to the
+    _invalid state_.
     A <<synchronization, synchronization>> command should: be used to detect
     when this occurs.
 Invalid::
@@ -106,25 +107,33 @@ on what state a command buffer must: be in, which are detailed in the valid
 usage constraints for that command.
 
 Resetting a command buffer is an operation that discards any previously
-recorded commands and puts a command buffer in the initial state.
+recorded commands and puts a command buffer in the _initial state_.
 Resetting occurs as a result of flink:vkResetCommandBuffer or
 flink:vkResetCommandPool, or as part of flink:vkBeginCommandBuffer (which
-additionally puts the command buffer in the recording state).
+additionally puts the command buffer in the _recording state_).
 
 <<commandbuffers-secondary, Secondary command buffers>> can: be recorded to
 a primary command buffer via flink:vkCmdExecuteCommands.
 This partially ties the lifecycle of the two command buffers together - if
 the primary is submitted to a queue, both the primary and any secondaries
-recorded to it move to the pending state.
-Once execution of the primary completes, so does any secondary recorded
-within it, and once all executions of each command buffer complete, they
-move to the executable state.
-If a secondary moves to any other state whilst it is recorded to another
-command buffer, the primary moves to the invalid state.
-A primary moving to any other state does not affect the state of the
-secondary.
-Resetting or freeing a primary command buffer removes the linkage to any
-secondary command buffers that were recorded to it.
+recorded to it move to the _pending state_.
+Once execution of the primary completes, so it does for any secondary
+recorded within it.
+After all executions of each command buffer complete, they each move to
+their appropriate completion state (either to the _execution state_ or the
+_invalid state_, as specified above).
+
+If a secondary moves to the _invalid state_ or the _initial state_, then all
+primary buffers it is recorded in move to the _invalid state_.
+A primary moving to any other state does not affect the state of a
+secondary recorded in it.
+
+[NOTE]
+.Note
+====
+Resetting or freeing a primary command buffer removes the lifecycle linkage
+to all secondary command buffers that were recorded into it.
+====
 
 
 [[commandbuffers-pools]]
@@ -951,8 +960,8 @@ Once execution of all submissions of a command buffer complete, it moves
 from the <<commandbuffers-lifecycle, pending state>>, back to the
 <<commandbuffers-lifecycle, executable state>>.
 If a command buffer was recorded with the
-ename:VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT flag, it instead moves
-back to the <<commandbuffers-lifecycle, invalid state>>.
+ename:VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT flag, it instead moves to
+the <<commandbuffers-lifecycle, invalid state>>.
 
 If fname:vkQueueSubmit fails, it may: return
 ename:VK_ERROR_OUT_OF_HOST_MEMORY or ename:VK_ERROR_OUT_OF_DEVICE_MEMORY.


### PR DESCRIPTION
- do not use "reverts back" with invalid state
- clear out ambiguities in primary-secondary lifecycle linkage
  - include the case when completion moves to the invalid state
  - clarify that moving secondary between the pending and
     execution state does not invalidate any other primary it
     may be recorded in