### PR TITLE
Remove redundant command buffer SIMULTANEOUS_USE language

### DIFF
--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -1585,24 +1585,19 @@ command buffer becomes <<commandbuffers-lifecycle, invalid>>.
     pname:level of ename:VK_COMMAND_BUFFER_LEVEL_SECONDARY
   * [[VUID-vkCmdExecuteCommands-pCommandBuffers-00089]]
     Each element of pname:pCommandBuffers must: be in the
-    <<commandbuffers-lifecycle, pending or executable state>>.
-  * [[VUID-vkCmdExecuteCommands-pCommandBuffers-00090]]
-    If any element of pname:pCommandBuffers was not recorded with the
-    ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT flag, and it was
-    recorded into any other primary command buffer, that primary command
-    buffer must: not be in the <<commandbuffers-lifecycle, pending state>>
+    <<commandbuffers-lifecycle, pending or executable state>>
   * [[VUID-vkCmdExecuteCommands-pCommandBuffers-00091]]
     If any element of pname:pCommandBuffers was not recorded with the
     ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT flag, it must: not be
-    in the <<commandbuffers-lifecycle, pending state>>.
+    in the <<commandbuffers-lifecycle, pending state>>
   * [[VUID-vkCmdExecuteCommands-pCommandBuffers-00092]]
     If any element of pname:pCommandBuffers was not recorded with the
     ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT flag, it must: not
-    have already been recorded to pname:commandBuffer.
+    have already been recorded to pname:commandBuffer
   * [[VUID-vkCmdExecuteCommands-pCommandBuffers-00093]]
     If any element of pname:pCommandBuffers was not recorded with the
     ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT flag, it must: not
-    appear more than once in pname:pCommandBuffers.
+    appear more than once in pname:pCommandBuffers
   * [[VUID-vkCmdExecuteCommands-pCommandBuffers-00094]]
     Each element of pname:pCommandBuffers must: have been allocated from a
     sname:VkCommandPool that was created for the same queue family as the
@@ -1627,7 +1622,7 @@ command buffer becomes <<commandbuffers-lifecycle, invalid>>.
     pname:pBeginInfo\->pInheritanceInfo\->renderPass members of the
     flink:vkBeginCommandBuffer commands used to begin recording each element
     of pname:pCommandBuffers must: be
-    <<renderpass-compatibility,compatible>> with the current render pass.
+    <<renderpass-compatibility,compatible>> with the current render pass
   * [[VUID-vkCmdExecuteCommands-pCommandBuffers-00099]]
     If fname:vkCmdExecuteCommands is being called within a render pass
     instance, and any element of pname:pCommandBuffers was recorded with
@@ -1666,10 +1661,10 @@ command buffer becomes <<commandbuffers-lifecycle, invalid>>.
 ifdef::VK_VERSION_1_1[]
   * [[VUID-vkCmdExecuteCommands-commandBuffer-01820]]
     If pname:commandBuffer is a protected command buffer, then each element
-    of pname:pCommandBuffers must: be a protected command buffer.
+    of pname:pCommandBuffers must: be a protected command buffer
   * [[VUID-vkCmdExecuteCommands-commandBuffer-01821]]
     If pname:commandBuffer is an unprotected command buffer, then each
-    element of pname:pCommandBuffers must: be an unprotected command buffer.
+    element of pname:pCommandBuffers must: be an unprotected command buffer
 endif::VK_VERSION_1_1[]
 ifdef::VK_EXT_transform_feedback[]
   * [[VUID-vkCmdExecuteCommands-None-02286]]

--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -761,6 +761,9 @@ time.
 include::{generated}/validity/structs/VkCommandBufferInheritanceInfo.txt[]
 --
 
+[NOTE]
+.Note
+====
 If ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT was not set when
 creating a command buffer, that command buffer must: not be submitted to a
 queue whilst it is already in the <<commandbuffers-lifecycle, pending
@@ -768,6 +771,7 @@ state>>.
 If ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT is not set on a
 secondary command buffer, that command buffer must: not be used more than
 once in a given primary command buffer.
+====
 
 [NOTE]
 .Note


### PR DESCRIPTION
- remove VUID requiring primary of a secondary to be pending. I think by definition secondary is pending if primary is, and there is already secondary specific VUID.
- remove VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT language covered by VUIDs