### PR TITLE
Prevent primary with both ONE_TIME and SIMULTANEOUS_USE

### DIFF
--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -589,12 +589,12 @@ include::{generated}/api/protos/vkBeginCommandBuffer.txt[]
 ****
   * [[VUID-vkBeginCommandBuffer-commandBuffer-00049]]
     pname:commandBuffer must: not be in the <<commandbuffers-lifecycle,
-    recording or pending state>>.
+    recording or pending state>>
   * [[VUID-vkBeginCommandBuffer-commandBuffer-00050]]
     If pname:commandBuffer was allocated from a slink:VkCommandPool which
     did not have the ename:VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
     flag set, pname:commandBuffer must: be in the
-    <<commandbuffers-lifecycle, initial state>>.
+    <<commandbuffers-lifecycle, initial state>>
   * [[VUID-vkBeginCommandBuffer-commandBuffer-00051]]
     If pname:commandBuffer is a secondary command buffer, the
     pname:pInheritanceInfo member of pname:pBeginInfo must: be a valid
@@ -606,6 +606,10 @@ include::{generated}/api/protos/vkBeginCommandBuffer.txt[]
     feature is not enabled, the pname:queryFlags member of the
     pname:pInheritanceInfo member pname:pBeginInfo must: not contain
     ename:VK_QUERY_CONTROL_PRECISE_BIT
+  * If pname:commandBuffer is a primary command buffer, then
+    pname:pBeginInfo\->flags must: not set both the
+    ename:VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT and the
+    ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT flags
 ****
 
 include::{generated}/validity/protos/vkBeginCommandBuffer.txt[]


### PR DESCRIPTION
Having primary command buffer with both `VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT` and `VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT` does not make sense. Cannot submit multiple times to make use of simultaneous flag.

For secondaries `SIMULTANEOUS` controls whether they can be recorded multiple times, so the situation is different.