### PR TITLE
Add anchor handles to chapters and VUIDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,9 @@ GENDEPENDS     = $(APIDEPEND) $(VALIDITYDEPEND) $(HOSTSYNCDEPEND) $(METADEPEND)
 # All non-format-specific dependencies
 COMMONDOCS     = $(SPECFILES) $(GENDEPENDS)
 
+# Script to add href to anchors
+GENANCHORLINKS = $(SCRIPTS)/genanchorlinks.py
+
 # Install katex in $(OUTDIR)/katex for reference by all HTML targets
 # README.md is a proxy for all the katex files that need to be installed
 katexinst: KATEXDIR = katex
@@ -250,6 +253,7 @@ html: $(HTMLDIR)/vkspec.html $(SPECSRC) $(COMMONDOCS)
 $(HTMLDIR)/vkspec.html: KATEXDIR = ../katex
 $(HTMLDIR)/vkspec.html: $(SPECSRC) $(COMMONDOCS) katexinst
 	$(QUIET)$(ASCIIDOC) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) -o $@ $(SPECSRC)
+	$(QUIET)$(PYTHON) $(GENANCHORLINKS) $@ $@
 
 diff_html: $(HTMLDIR)/diff.html $(SPECSRC) $(COMMONDOCS)
 

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,8 @@ ADOCHTMLEXTS = -r $(CURDIR)/config/katex_replace.rb
 # 'stylesdir' containing our custom CSS.
 KATEXDIR     = katex
 ADOCHTMLOPTS = $(ADOCHTMLEXTS) -a katexpath=$(KATEXDIR) \
-	       -a stylesheet=khronos.css -a stylesdir=$(CURDIR)/config
+	       -a stylesheet=khronos.css -a stylesdir=$(CURDIR)/config \
+	       -a sectanchors
 
 ADOCPDFEXTS  = -r asciidoctor-pdf -r asciidoctor-mathematical -r $(CURDIR)/config/asciidoctor-mathematical-ext.rb
 ADOCPDFOPTS  = $(ADOCPDFEXTS) -a mathematical-format=svg \

--- a/config/chunkindex/chunked.css
+++ b/config/chunkindex/chunked.css
@@ -7,6 +7,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+/*
 a.headerlink { display: none; text-decoration: none; }
 
 h2:hover a.headerlink { display: inline; }
@@ -14,6 +15,7 @@ h3:hover a.headerlink { display: inline; }
 h4:hover a.headerlink { display: inline; }
 h5:hover a.headerlink { display: inline; }
 h6:hover a.headerlink { display: inline; }
+*/
 
 div.searchbox {
   background-color: white;

--- a/config/chunkindex/chunked.js
+++ b/config/chunkindex/chunked.js
@@ -144,18 +144,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     toc.scrollTop -= 96;
   }
 
-  // add anchor links
-  ["h2","h3","h4","h5","h6"].forEach(function(hX) {
-    var headers = document.getElementsByTagName(hX);
-
-    for(var i=0; i < headers.length; i++) {
-      var header = headers[i];
-      if(header.id.length > 0) {
-        header.innerHTML += ' <a class="headerlink" href="#' + header.id + '\">\u00B6</a>';
-      }
-    }
-  });
-
+  // add anchor links to code blocks
   var blocks = document.getElementsByClassName("listingblock")
 
   for(var i=0; i < blocks.length; i++) {

--- a/config/khronos.css
+++ b/config/khronos.css
@@ -715,3 +715,10 @@ p.tableblock.header { color: #6d6e71; }
 
 /* From https://github.com/KhronosGroup/Vulkan-Docs/pull/901 */
 a code { color: inherit; }
+
+/* Make VUID anchor handles*/
+li > p > a[id^="VUID-"] { visibility: hidden; position: absolute; z-index: 1001; width: 2.2ex; margin-left: -2.2ex; display: block; text-decoration: none !important; text-align: center; font-weight: normal; }
+li > p > a[id^="VUID-"]:before { content: "\00A7"; font-size: 1em; display: block; padding-top: 0em; background: #fff }
+li > p:hover > a[id^="VUID-"], li > p > a[id^="VUID-"]:hover { visibility: visible; }
+li > p > a[id^="VUID-"].link { color: black; text-decoration: none; } /* TODO: not quite sure what these two do */
+li > p > a[id^="VUID-"].link:hover { color: black; }

--- a/scripts/genanchorlinks.py
+++ b/scripts/genanchorlinks.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2020 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script that adds href to <a> anchors
+
+import os,sys,re
+
+def genAnchorLinks(in_file, out_file):
+	try:
+		with open(in_file, 'r', encoding='utf8') as f: data = f.read()
+	except FileNotFoundError:
+		print('Error: File %s does not exist.' % in_file)
+		sys.exit(2)
+
+	data = re.sub( r'(<a )(id="(VUID\-[\w\-:]+)")(>)', '\g<1>\g<2> href="#\g<3>"\g<4>', data)
+	with open(out_file, 'w', encoding='utf8') as f: data = f.write(data)
+
+if __name__ == '__main__':
+	if len(sys.argv) != 3:
+		print('Error: genanchorlinks.py requires two arguments.')
+		print('Usage: genanchorlinks.py infile.html outfile.html')
+		sys.exit(1)
+	genAnchorLinks(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
- add anchor handles to chapters
   - chunked already had them sneaked in with the build script, so replace with the asciidoctor feature. Difference is it is on the left of the chapter header instead. Also the symbol is different (but that can be changed in the CSS).
- add similar anchor handles to each VU

It is pretty standard on modern websites (such as here on GitHub when viewing md file). Helps people to link to stuff without having to fish inside the html source for the anchor ids. Additionally makes the VUID of VU more visible (hovering over link usually shows the URL, as well as clicking it should apply it to the address bar).

preview: http://vulkan.hys.cz/orig/pr1157/vkspec.html
hover mouse over a chapter header, or over a VU statement to see a clickable link symbol.

