### PR TITLE
Remove redundant SIMULTANEOUS_USE note

### DIFF
--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -769,18 +769,6 @@ include::{generated}/validity/structs/VkCommandBufferInheritanceInfo.txt[]
 [NOTE]
 .Note
 ====
-If ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT was not set when
-creating a command buffer, that command buffer must: not be submitted to a
-queue whilst it is already in the <<commandbuffers-lifecycle, pending
-state>>.
-If ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT is not set on a
-secondary command buffer, that command buffer must: not be used more than
-once in a given primary command buffer.
-====
-
-[NOTE]
-.Note
-====
 On some implementations, not using the
 ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT bit enables command
 buffers to be patched in-place if needed, rather than creating a copy of the


### PR DESCRIPTION
follow-up from #1153

Remove note that only reiterates for the third time what `VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT` does.

On the bit introduction there already is:

> `VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BI`T specifies that a command buffer **can** be resubmitted to a queue while it is in the _pending_ state, and recorded into multiple primary command buffers.

As well as it is covered by VUs.