### PR TITLE
Reserve Codeplay vendor ID

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -5646,7 +5646,8 @@ typedef void <name>CAMetalLayer</name>;
         <enum value="0x10001" name="VK_VENDOR_ID_VIV"   comment="Vivante vendor ID"/>
         <enum value="0x10002" name="VK_VENDOR_ID_VSI"   comment="VeriSilicon vendor ID"/>
         <enum value="0x10003" name="VK_VENDOR_ID_KAZAN" comment="Kazan Software Renderer"/>
-            <unused start="0x10004" comment="This is the next unused available Khronos vendor ID"/>
+        <enum value="0x10004" name="VK_VENDOR_ID_CODEPLAY" comment="Codeplay Software Ltd. vendor ID"/>
+            <unused start="0x10005" comment="This is the next unused available Khronos vendor ID"/>
     </enums>
     <enums name="VkDriverId" type="enum">
         <comment>Driver IDs are now represented as enums instead of the old


### PR DESCRIPTION
Codeplay Software Ltd is a ISV, and as such doesn't have a PCIe ID to use for the `VkPhysicalDeviceProperties::vendorID` in our [ComputeAorta](https://codeplay.com/products/computesuite/computeaorta) product.

Reserve the next free ID from `VkVendorId` in vk.xml