### PR TITLE
Fix "happens before" per glossary and style

### DIFF
--- a/appendices/glossary.txt
+++ b/appendices/glossary.txt
@@ -619,14 +619,14 @@ Handle::
     An opaque integer or pointer value used to refer to a Vulkan object.
     Each object type has a unique handle type.
 
-Happen-after::
+Happen-after, happens-after::
     A transitive, irreflexive and antisymmetric ordering relation between
     operations.
     An execution dependency with a source of *A* and a destination of *B*
     enforces that *B* happens-after *A*.
     The inverse relation of happens-before.
 
-Happen-before::
+Happen-before, happens-before::
     A transitive, irreflexive and antisymmetric ordering relation between
     operations.
     An execution dependency with a source of *A* and a destination of *B*

--- a/appendices/memorymodel.txt
+++ b/appendices/memorymodel.txt
@@ -596,7 +596,7 @@ increasing scope where element N+1 of the chain is performed in the same
 scope instance as the destination of element N and element N happens-before
 element N+1.
 An example is an availability operation with destination scope of the
-workgroup instance domain that happens before an availability operation to
+workgroup instance domain that happens-before an availability operation to
 the shader domain performed by an invocation in the same workgroup.
 An availability chain AVC that happens-after W and that includes (A,R,L) in
 the source scope makes (W,L) _available_ to the memory domains in its final
@@ -609,7 +609,7 @@ decreasing scope where element N of the chain is performed in the same scope
 instance as the source of element N+1 and element N happens-before element
 N+1.
 An example is a visibility operation with source scope of the shader domain
-that happens before a visibility operation with source scope of the
+that happens-before a visibility operation with source scope of the
 workgroup instance domain performance by an invocation in the same
 workgroup.
 A visibility chain VISC that happens-after AVC (or DOM) and for which (W,L)

--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -1050,7 +1050,7 @@ endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     Operation>> on a queue in the queue family identified by the acquire
     operation, with parameters matching the acquire operation as defined in
     the definition of such <<synchronization-queue-transfers-acquire,
-    acquire operations>>, and which happens before the acquire operation
+    acquire operations>>, and which happens-before the acquire operation
 ifdef::VK_KHR_performance_query[]
   * [[VUID-vkQueueSubmit-pCommandBuffers-03220]]
     If a command recorded into any element of pname:pCommandBuffers was a

--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -624,11 +624,13 @@ endif::VK_NV_mesh_shader[]
 
 ifdef::VK_EXT_fragment_density_map[]
 For graphics pipeline commands executing in a render pass with a fragment
-density map attachment, the pipeline stage where the fragment density map
-read happens has no particular order relative to the other stages except
-that it happens before ename:VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT.
+density map attachment, the following pipeline stage where the fragment
+density map read happens has no particular order relative to the other
+stages, except that it is logically earlier than
+ename:VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT:
 
   * ename:VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT
+  * ename:VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT
 endif::VK_EXT_fragment_density_map[]
 
 For the compute pipeline, the following stages occur in this order:


### PR DESCRIPTION
- add happens-before to glossary for better search
- convert "happens before" to happens-before
- fix one case of "happens before" where it probably means
  "logically earlier stage"