### PR TITLE
Refer to attachments instead of attachment references

### DIFF
--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -2602,8 +2602,8 @@ If the arrays are of different lengths, attachment references not present in
 the smaller array are treated as ename:VK_ATTACHMENT_UNUSED.
 
 Two render passes are compatible if their corresponding color, input,
-resolve, and depth/stencil attachment references are compatible and if they
-are otherwise identical except for:
+resolve, and depth/stencil attachments are compatible and if they are
+otherwise identical except for:
 
   * Initial and final image layout in attachment descriptions
   * Load and store operations in attachment descriptions


### PR DESCRIPTION
Should the description refer to attachments rather than attachment references? I suspect that two RenderPasses are not compatible if their attachments are different but references inside Subpasses still happen to be the same.