### PR TITLE
Consolidate pipeline dynamic state VUs

### DIFF
--- a/chapters/fragops.txt
+++ b/chapters/fragops.txt
@@ -359,22 +359,8 @@ to be `0` and the exclusive scissor test is disabled.
 
 .Valid Usage
 ****
-  * [[VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-exclusiveScissorCount-02027]]
-    If the <<features-multiViewport,multiple viewports>> feature is not
-    enabled, pname:exclusiveScissorCount must: be `0` or `1`
-  * [[VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-exclusiveScissorCount-02028]]
-    pname:exclusiveScissorCount must: be less than or equal to
-    sname:VkPhysicalDeviceLimits::pname:maxViewports
-  * [[VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-exclusiveScissorCount-02029]]
-    pname:exclusiveScissorCount must: be `0` or identical to the
-    pname:viewportCount member of sname:VkPipelineViewportStateCreateInfo
-  * [[VUID-VkPipelineViewportExclusiveScissorStateCreateInfoNV-pDynamicStates-02030]]
-    If no element of the pname:pDynamicStates member of pname:pDynamicState
-    is ename:VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV and
-    pname:exclusiveScissorCount is not `0`, pname:pExclusiveScissors must:
-    be a valid pointer to an array of pname:exclusiveScissorCount
-    sname:VkRect2D structures
-
+  * If the <<features-exclusiveScissor,pname:exclusiveScissor>> feature is
+    not enabled, pname:exclusiveScissorCount must: be `0`
 ****
 include::{generated}/validity/structs/VkPipelineViewportExclusiveScissorStateCreateInfoNV.txt[]
 --

--- a/chapters/pipelines.txt
+++ b/chapters/pipelines.txt
@@ -873,20 +873,127 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
     the pname:attachmentCount member of pname:pColorBlendState must: be
     equal to the pname:colorAttachmentCount used to create pname:subpass
   * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00747]]
-    If no element of the pname:pDynamicStates member of pname:pDynamicState
-    is ename:VK_DYNAMIC_STATE_VIEWPORT, the pname:pViewports member of
-    pname:pViewportState must: be a valid pointer to an array of
-    pname:pViewportState\->viewportCount valid sname:VkViewport structures
+    If pname:pViewportState is not ignored, and no element of
+    pname:pDynamicState\->pDynamicStates is ename:VK_DYNAMIC_STATE_VIEWPORT,
+    then pname:pViewportState\->pViewports must: be a valid pointer to an
+    array of pname:pViewportState\->viewportCount valid slink:VkViewport
+    structures
   * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00748]]
-    If no element of the pname:pDynamicStates member of pname:pDynamicState
-    is ename:VK_DYNAMIC_STATE_SCISSOR, the pname:pScissors member of
-    pname:pViewportState must: be a valid pointer to an array of
-    pname:pViewportState\->scissorCount sname:VkRect2D structures
+    If pname:pViewportState is not ignored, and no element of
+    pname:pDynamicState\->pDynamicStates is ename:VK_DYNAMIC_STATE_SCISSOR,
+    then pname:pViewportState\->pScissors must: be a valid pointer to an
+    array of pname:pViewportState\->scissorCount slink:VkRect2D structures
   * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749]]
-    If the wide lines feature is not enabled, and no element of the
-    pname:pDynamicStates member of pname:pDynamicState is
-    ename:VK_DYNAMIC_STATE_LINE_WIDTH, the pname:lineWidth member of
-    pname:pRasterizationState must: be `1.0`
+    If no element of pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_LINE_WIDTH, and the
+    <<features-wideLines,wide lines>> feature is not enabled, then
+    pname:pRasterizationState\->lineWidth must: be `1.0`
+  * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00754]]
+    If no element of pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_DEPTH_BIAS, and the <<features-depthBiasClamp,
+    depth bias clamping>> feature is not enabled, and
+    pname:pRasterizationState\->depthBiasEnable is ename:VK_TRUE, then
+    pname:pRasterizationState\->depthBiasClamp must: be `0.0`
+ifndef::VK_EXT_depth_range_unrestricted[]
+  * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00755]]
+    If pname:pDepthStencilState is not ignored, and
+    no element of pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_DEPTH_BOUNDS, and
+    pname:pDepthStencilState\->depthBoundsTestEnable is
+    ename:VK_TRUE, then pname:pDepthStencilState\->minDepthBounds and
+    pname:pDepthStencilState\->maxDepthBounds must: both be between `0.0`
+    and `1.0`, inclusive
+endif::VK_EXT_depth_range_unrestricted[]
+ifdef::VK_EXT_depth_range_unrestricted[]
+  * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-02510]]
+    If pname:pDepthStencilState is not ignored, and
+    `<<VK_EXT_depth_range_unrestricted>>` extension is not enabled, and
+    no element of pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_DEPTH_BOUNDS, and
+    pname:pDepthStencilState\->depthBoundsTestEnable is
+    ename:VK_TRUE, then pname:pDepthStencilState\->minDepthBounds and
+    pname:pDepthStencilState\->maxDepthBounds must: both be between `0.0`
+    and `1.0`, inclusive
+endif::VK_EXT_depth_range_unrestricted[]
+ifdef::VK_NV_clip_space_w_scaling[]
+  * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-01715]]
+    If pname:pViewportState is not ignored, and no element of
+    pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV, and the
+    pname:viewportWScalingEnable member of a
+    slink:VkPipelineViewportWScalingStateCreateInfoNV structure (included in
+    the pname:pNext chain of pname:pViewportState) is ename:VK_TRUE, then
+    the
+    slink:VkPipelineViewportWScalingStateCreateInfoNV::pname:pViewportWScalings
+    must: be a pointer to an array of
+    slink:VkPipelineViewportWScalingStateCreateInfoNV::pname:viewportCount
+    slink:VkViewportWScalingNV structures
+endif::VK_NV_clip_space_w_scaling[]
+ifdef::VK_EXT_discard_rectangles[]
+  * If no element of pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT, then the
+    pname:pDiscardRectangles member of a
+    slink:VkPipelineDiscardRectangleStateCreateInfoEXT structure (included
+    in the pname:pNext chain) must: be a pointer to an array of
+    slink:VkPipelineDiscardRectangleStateCreateInfoEXT::pname:discardRectangleCount
+    slink:VkRect2D structures
+endif::VK_EXT_discard_rectangles[]
+ifdef::VK_EXT_sample_locations[]
+  * If pname:pMultisampleState is not ignored, and no element of
+    pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT, and the
+    pname:sampleLocationsEnable member of a
+    slink:VkPipelineSampleLocationsStateCreateInfoEXT structure (included in
+    the pname:pNext chain of pname:pMultisampleState) is ename:VK_TRUE, then
+    the
+    slink:VkPipelineSampleLocationsStateCreateInfoEXT::pname:sampleLocationsInfo
+    must: be a valid slink:VkSampleLocationsInfoEXT structure
+endif::VK_EXT_sample_locations[]
+ifdef::VK_NV_scissor_exclusive[]
+  * If pname:pViewportState is not ignored, and no element of
+    pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV, and
+    pname:exclusiveScissorCount member of
+    slink:VkPipelineViewportExclusiveScissorStateCreateInfoNV (included in
+    the pname:pNext chain of pname:pViewportState) is not `0`, then
+    slink:VkPipelineViewportExclusiveScissorStateCreateInfoNV::pname:pExclusiveScissors
+    must: be a valid pointer to an array of
+    slink:VkPipelineViewportExclusiveScissorStateCreateInfoNV::pname:exclusiveScissorCount
+    slink:VkRect2D structures
+endif::VK_NV_scissor_exclusive[]
+ifdef::VK_NV_shading_rate_image[]
+  * If pname:pViewportState is not ignored, and no element of
+    pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV, and the
+    pname:shadingRateImageEnable member of
+    slink:VkPipelineViewportShadingRateImageStateCreateInfoNV (included in
+    the pname:pNext chain of pname:pViewportState) is ename:VK_TRUE, then
+    slink:VkPipelineViewportShadingRateImageStateCreateInfoNV::pname:pShadingRatePalettes
+    must: be a valid pointer to an array of
+    slink:VkPipelineViewportShadingRateImageStateCreateInfoNV::pname:viewportCount
+    valid sname:VkShadingRatePaletteNV structures
+  * If pname:pViewportState is not ignored, and no element of
+    pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_VIEWPORT_COARSE_SAMPLE_ORDER_NV, and the
+    pname:customSampleOrderCount member of
+    slink:VkPipelineViewportCoarseSampleOrderStateCreateInfoNV (included in
+    the pname:pNext chain of pname:pViewportState) is not `0`, then
+    slink:VkPipelineViewportCoarseSampleOrderStateCreateInfoNV::pname:pCustomSampleOrders
+    must: be a valid pointer to an array of
+    slink:VkPipelineViewportCoarseSampleOrderStateCreateInfoNV::pname:customSampleOrderCount
+    valid sname:VkCoarseSampleOrderCustomNV structures
+endif::VK_NV_shading_rate_image[]
+ifdef::VK_EXT_line_rasterization[]
+  * [[VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767]]
+    If no element of pname:pDynamicState\->pDynamicStates is
+    ename:VK_DYNAMIC_STATE_LINE_STIPPLE_EXT, and the
+    pname:stippledLineEnable member of
+    slink:VkPipelineRasterizationLineStateCreateInfoEXT (included in
+    the pname:pNext chain of pname:pRasterizationState) is ename:VK_TRUE,
+    then the
+    slink:VkPipelineRasterizationLineStateCreateInfoEXT::pname:lineStippleFactor
+    must: be in the [eq]#[1,256]# range
+endif::VK_EXT_line_rasterization[]
   * [[VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-00750]]
     If the pname:rasterizerDiscardEnable member of pname:pRasterizationState
     is ename:VK_FALSE, pname:pViewportState must: be a valid pointer to a
@@ -905,29 +1012,6 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
     is ename:VK_FALSE, and pname:subpass uses color attachments,
     pname:pColorBlendState must: be a valid pointer to a valid
     sname:VkPipelineColorBlendStateCreateInfo structure
-  * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00754]]
-    If the depth bias clamping feature is not enabled, no element of the
-    pname:pDynamicStates member of pname:pDynamicState is
-    ename:VK_DYNAMIC_STATE_DEPTH_BIAS, and the pname:depthBiasEnable member
-    of pname:pRasterizationState is ename:VK_TRUE, the pname:depthBiasClamp
-    member of pname:pRasterizationState must: be `0.0`
-ifndef::VK_EXT_depth_range_unrestricted[]
-  * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00755]]
-    If no element of the pname:pDynamicStates member of pname:pDynamicState
-    is ename:VK_DYNAMIC_STATE_DEPTH_BOUNDS, and the
-    pname:depthBoundsTestEnable member of pname:pDepthStencilState is
-    ename:VK_TRUE, the pname:minDepthBounds and pname:maxDepthBounds members
-    of pname:pDepthStencilState must: be between `0.0` and `1.0`, inclusive
-endif::VK_EXT_depth_range_unrestricted[]
-ifdef::VK_EXT_depth_range_unrestricted[]
-  * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-02510]]
-    If the `<<VK_EXT_depth_range_unrestricted>>` extension is not enabled
-    and no element of the pname:pDynamicStates member of pname:pDynamicState
-    is ename:VK_DYNAMIC_STATE_DEPTH_BOUNDS, and the
-    pname:depthBoundsTestEnable member of pname:pDepthStencilState is
-    ename:VK_TRUE, the pname:minDepthBounds and pname:maxDepthBounds members
-    of pname:pDepthStencilState must: be between `0.0` and `1.0`, inclusive
-endif::VK_EXT_depth_range_unrestricted[]
 ifdef::VK_EXT_sample_locations[]
   * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-01521]]
     If no element of the pname:pDynamicStates member of pname:pDynamicState
@@ -1050,19 +1134,6 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
     The number of resources in pname:layout accessible to each shader stage
     that is used by the pipeline must: be less than or equal to
     sname:VkPhysicalDeviceLimits::pname:maxPerStageResources
-ifdef::VK_NV_clip_space_w_scaling[]
-  * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-01715]]
-    If no element of the pname:pDynamicStates member of pname:pDynamicState
-    is ename:VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV, and the
-    pname:viewportWScalingEnable member of a
-    slink:VkPipelineViewportWScalingStateCreateInfoNV structure, included in
-    the pname:pNext chain of pname:pViewportState, is ename:VK_TRUE, the
-    pname:pViewportWScalings member of the
-    slink:VkPipelineViewportWScalingStateCreateInfoNV must: be a pointer to
-    an array of
-    slink:VkPipelineViewportWScalingStateCreateInfoNV::pname:viewportCount
-    valid slink:VkViewportWScalingNV structures
-endif::VK_NV_clip_space_w_scaling[]
   * [[VUID-VkGraphicsPipelineCreateInfo-pStages-02097]]
     If pname:pStages includes a vertex shader stage, pname:pVertexInputState
     must: be a valid pointer to a valid
@@ -1115,14 +1186,6 @@ ifdef::VK_EXT_line_rasterization[]
     rasterization is enabled, then the pname:alphaToCoverageEnable,
     pname:alphaToOneEnable, and pname:sampleShadingEnable members of
     pname:pMultisampleState must: all be ename:VK_FALSE
-  * [[VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767]]
-    If the pname:stippledLineEnable member of
-    slink:VkPipelineRasterizationLineStateCreateInfoEXT is ename:VK_TRUE and
-    no element of the pname:pDynamicStates member of pname:pDynamicState is
-    ename:VK_DYNAMIC_STATE_LINE_STIPPLE_EXT, then the
-    pname:lineStippleFactor member of
-    slink:VkPipelineRasterizationLineStateCreateInfoEXT must: be in the
-    range [eq]#[1,256]#
 endif::VK_EXT_line_rasterization[]
 ****
 

--- a/chapters/primsrast.txt
+++ b/chapters/primsrast.txt
@@ -812,21 +812,8 @@ to be ename:VK_FALSE, and the shading rate image and palettes are not used.
 
 .Valid Usage
 ****
-  * [[VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-viewportCount-02054]]
-    If the <<features-multiViewport,multiple viewports>> feature is not
-    enabled, pname:viewportCount must: be `0` or `1`
-  * [[VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-viewportCount-02055]]
-    pname:viewportCount must: be less than or equal to
-    sname:VkPhysicalDeviceLimits::pname:maxViewports
-  * [[VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-shadingRateImageEnable-02056]]
-    If pname:shadingRateImageEnable is ename:VK_TRUE, pname:viewportCount
-    must: be equal to the pname:viewportCount member of
-    sname:VkPipelineViewportStateCreateInfo
-  * [[VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-pDynamicStates-02057]]
-    If no element of the pname:pDynamicStates member of pname:pDynamicState
-    is ename:VK_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV,
-    pname:pShadingRatePalettes must: be a valid pointer to an array of
-    pname:viewportCount sname:VkShadingRatePaletteNV structures
+  * If the <<features-shadingRateImage,shadingRateImage>> feature is not
+    enabled, pname:shadingRateImageEnable must: be ename:VK_FALSE
 ****
 include::{generated}/validity/structs/VkPipelineViewportShadingRateImageStateCreateInfoNV.txt[]
 --
@@ -1134,14 +1121,18 @@ specified by flink:vkCmdSetCoarseSampleOrderNV.
 
 .Valid Usage
 ****
+  * If the <<features-shadingRateCoarseSampleOrder,
+    shadingRateCoarseSampleOrder>> feature is not enabled,
+    pname:sampleOrderType must:
+    be ename:VK_COARSE_SAMPLE_ORDER_TYPE_DEFAULT_NV
   * [[VUID-VkPipelineViewportCoarseSampleOrderStateCreateInfoNV-sampleOrderType-02072]]
     If pname:sampleOrderType is not
     ename:VK_COARSE_SAMPLE_ORDER_TYPE_CUSTOM_NV,
     pname:customSamplerOrderCount must: be `0`
   * [[VUID-VkPipelineViewportCoarseSampleOrderStateCreateInfoNV-pCustomSampleOrders-02234]]
-    The array pname:pCustomSampleOrders must: not contain two structures
-    with matching values for both the pname:shadingRate and
-    pname:sampleCount members.
+    If the pname:pCustomSampleOrders array is not ignored, it must: not
+    contain two structures with matching values for both the
+    pname:shadingRate and pname:sampleCount members
 ****
 include::{generated}/validity/structs/VkPipelineViewportCoarseSampleOrderStateCreateInfoNV.txt[]
 --

--- a/chapters/vertexpostproc.txt
+++ b/chapters/vertexpostproc.txt
@@ -862,6 +862,19 @@ ifdef::VK_NV_clip_space_w_scaling[]
     of the slink:VkPipelineViewportWScalingStateCreateInfoNV structure must:
     be equal to pname:viewportCount
 endif::VK_NV_clip_space_w_scaling[]
+ifdef::VK_NV_scissor_exclusive[]
+  * If the the pname:pNext chain includes a
+    slink:VkPipelineViewportExclusiveScissorStateCreateInfoNV structure, the
+    slink:VkPipelineViewportExclusiveScissorStateCreateInfoNV::pname:exclusiveScissorCount
+    must: be `0` or equal to pname:scissorCount
+endif::VK_NV_scissor_exclusive[]
+ifdef::VK_NV_shading_rate_image[]
+  * If the the pname:pNext chain includes a
+    slink:VkPipelineViewportShadingRateImageStateCreateInfoNV structure, and
+    its pname:shadingRateImageEnable member is ename:VK_TRUE, then the
+    slink:VkPipelineViewportShadingRateImageStateCreateInfoNV::pname:viewportCount
+    must: equal to pname:viewportCount
+endif::VK_NV_shading_rate_image[]
 ****
 
 include::{generated}/validity/structs/VkPipelineViewportStateCreateInfo.txt[]

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -2916,9 +2916,9 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineSampleLocationsStateCreateInfoEXT" structextends="VkPipelineMultisampleStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
-            <member><type>VkBool32</type>                         <name>sampleLocationsEnable</name></member>
-            <member><type>VkSampleLocationsInfoEXT</type>         <name>sampleLocationsInfo</name></member>
+            <member>const <type>void</type>*                                    <name>pNext</name></member>
+            <member><type>VkBool32</type>                                       <name>sampleLocationsEnable</name></member>
+            <member noautovalidity="true"><type>VkSampleLocationsInfoEXT</type> <name>sampleLocationsInfo</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSampleLocationsPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3600,9 +3600,9 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineViewportExclusiveScissorStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                    <name>pNext</name></member>
-            <member optional="true"><type>uint32_t</type>                                       <name>exclusiveScissorCount</name></member>
-            <member len="exclusiveScissorCount" optional="true">const <type>VkRect2D</type>*    <name>pExclusiveScissors</name></member>
+            <member>const <type>void</type>*                                                       <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>                                          <name>exclusiveScissorCount</name></member>
+            <member len="exclusiveScissorCount" noautovalidity="true">const <type>VkRect2D</type>* <name>pExclusiveScissors</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCornerSampledImageFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
@@ -3636,10 +3636,10 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineViewportShadingRateImageStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                            <name>pNext</name></member>
-            <member><type>VkBool32</type>                                                               <name>shadingRateImageEnable</name></member>
-            <member optional="true"><type>uint32_t</type>                                                               <name>viewportCount</name></member>
-            <member len="viewportCount" optional="true">const <type>VkShadingRatePaletteNV</type>*      <name>pShadingRatePalettes</name></member>
+            <member>const <type>void</type>*                                                             <name>pNext</name></member>
+            <member><type>VkBool32</type>                                                                <name>shadingRateImageEnable</name></member>
+            <member optional="true"><type>uint32_t</type>                                                <name>viewportCount</name></member>
+            <member len="viewportCount" noautovalidity="true">const <type>VkShadingRatePaletteNV</type>* <name>pShadingRatePalettes</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShadingRateImageFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
@@ -3667,10 +3667,10 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineViewportCoarseSampleOrderStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                            <name>pNext</name></member>
-            <member><type>VkCoarseSampleOrderTypeNV</type>                                              <name>sampleOrderType</name></member>
-            <member optional="true"><type>uint32_t</type>                                               <name>customSampleOrderCount</name></member>
-            <member len="customSampleOrderCount">const <type>VkCoarseSampleOrderCustomNV</type>*        <name>pCustomSampleOrders</name></member>
+            <member>const <type>void</type>*                                                                           <name>pNext</name></member>
+            <member><type>VkCoarseSampleOrderTypeNV</type>                                                             <name>sampleOrderType</name></member>
+            <member optional="true"><type>uint32_t</type>                                                              <name>customSampleOrderCount</name></member>
+            <member len="customSampleOrderCount" noautovalidity="true">const <type>VkCoarseSampleOrderCustomNV</type>* <name>pCustomSampleOrders</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMeshShaderFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>


### PR DESCRIPTION
- unify the language
- fix #1180 
- add some VUs that feel missing
- remove VUs that are redundant or at wrong place

Some problems remain. Not sure how to deal with `VkRect2D` dynamic states and their non-0 and non-overflow requirements. There's also bunch of `VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT` validity problems remaining that I did not want to get into.