### PR TITLE
Update markup extension

### DIFF
--- a/appendices/VK_EXT_image_drm_format_modifier.txt
+++ b/appendices/VK_EXT_image_drm_format_modifier.txt
@@ -323,7 +323,7 @@ individual planes.
 *RESOLVED*: No.
 The application must: not provide the size.
 To enforce this, the API requires that
-slink:VkImageDrmFormatModifierExplicitCreateInfoEXT::pname:pPlaneLayouts\-><<VkSubresourceLayout,size>>
+slink:VkImageDrmFormatModifierExplicitCreateInfoEXT::pname:pPlaneLayouts->size
 must: be 0.
 
 *DISCUSSION*: Prior art, such as

--- a/chapters/VK_EXT_debug_utils.txt
+++ b/chapters/VK_EXT_debug_utils.txt
@@ -44,9 +44,9 @@ include::{generated}/api/protos/vkSetDebugUtilsObjectNameEXT.txt[]
 .Valid Usage
 ****
   * [[VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02587]]
-    pname:pNameInfo\->objectType must: not be ename:VK_OBJECT_TYPE_UNKNOWN
+    pname:pNameInfo->objectType must: not be ename:VK_OBJECT_TYPE_UNKNOWN
   * [[VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02588]]
-    pname:pNameInfo\->objectHandle must: not be dlink:VK_NULL_HANDLE
+    pname:pNameInfo->objectHandle must: not be dlink:VK_NULL_HANDLE
 ****
 
 include::{generated}/validity/protos/vkSetDebugUtilsObjectNameEXT.txt[]
@@ -676,7 +676,7 @@ registered.
 ****
   * [[VUID-vkSubmitDebugUtilsMessageEXT-objectType-02591]]
     The pname:objectType member of each element of
-    pname:pCallbackData\->pObjects must: not be ename:VK_OBJECT_TYPE_UNKNOWN
+    pname:pCallbackData->pObjects must: not be ename:VK_OBJECT_TYPE_UNKNOWN
 ****
 
 include::{generated}/validity/protos/vkSubmitDebugUtilsMessageEXT.txt[]

--- a/chapters/VK_KHR_surface/wsi.txt
+++ b/chapters/VK_KHR_surface/wsi.txt
@@ -909,7 +909,7 @@ that not all the available values were returned.
 .Valid Usage
 ****
   * [[VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceInfo-02740]]
-    pname:pSurfaceInfo\->surface must be supported by pname:physicalDevice,
+    pname:pSurfaceInfo->surface must be supported by pname:physicalDevice,
     as reported by flink:vkGetPhysicalDeviceSurfaceSupportKHR or an
     equivalent platform-specific mechanism.
 ****

--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -599,16 +599,16 @@ endif::VK_KHR_swapchain_mutable_format[]
 all other bits are unset
 endif::VK_VERSION_1_1,VK_KHR_device_group,VK_KHR_swapchain_mutable_format[]
 | pname:imageType               | ename:VK_IMAGE_TYPE_2D
-| pname:format                  | pname:pCreateInfo\->imageFormat
-| pname:extent                  | {pname:pCreateInfo\->imageExtent.width, pname:pCreateInfo\->imageExtent.height, `1`}
+| pname:format                  | pname:pCreateInfo->imageFormat
+| pname:extent                  | {pname:pCreateInfo->imageExtent.width, pname:pCreateInfo->imageExtent.height, `1`}
 | pname:mipLevels               | 1
-| pname:arrayLayers             | pname:pCreateInfo\->imageArrayLayers
+| pname:arrayLayers             | pname:pCreateInfo->imageArrayLayers
 | pname:samples                 | ename:VK_SAMPLE_COUNT_1_BIT
 | pname:tiling                  | ename:VK_IMAGE_TILING_OPTIMAL
-| pname:usage                   | pname:pCreateInfo\->imageUsage
-| pname:sharingMode             | pname:pCreateInfo\->imageSharingMode
-| pname:queueFamilyIndexCount   | pname:pCreateInfo\->queueFamilyIndexCount
-| pname:pQueueFamilyIndices     | pname:pCreateInfo\->pQueueFamilyIndices
+| pname:usage                   | pname:pCreateInfo->imageUsage
+| pname:sharingMode             | pname:pCreateInfo->imageSharingMode
+| pname:queueFamilyIndexCount   | pname:pCreateInfo->queueFamilyIndexCount
+| pname:pQueueFamilyIndices     | pname:pCreateInfo->pQueueFamilyIndices
 | pname:initialLayout           | ename:VK_IMAGE_LAYOUT_UNDEFINED
 |====
 

--- a/chapters/VK_NV_external_memory_capabilities/external_image_format.txt
+++ b/chapters/VK_NV_external_memory_capabilities/external_image_format.txt
@@ -25,7 +25,7 @@ include::{generated}/api/protos/vkGetPhysicalDeviceExternalImageFormatProperties
     are returned.
 
 If pname:externalHandleType is 0,
-pname:pExternalImageFormatProperties\->imageFormatProperties will return the
+pname:pExternalImageFormatProperties->imageFormatProperties will return the
 same values as a call to flink:vkGetPhysicalDeviceImageFormatProperties, and
 the other members of pname:pExternalImageFormatProperties will all be 0.
 Otherwise, they are filled in as described for

--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -175,7 +175,7 @@ include::{generated}/api/protos/vkCreateCommandPool.txt[]
 .Valid Usage
 ****
   * [[VUID-vkCreateCommandPool-queueFamilyIndex-01937]]
-    pname:pCreateInfo\->queueFamilyIndex must: be the index of a queue
+    pname:pCreateInfo->queueFamilyIndex must: be the index of a queue
     family available in the logical device pname:device.
 ****
 
@@ -624,7 +624,7 @@ include::{generated}/api/protos/vkBeginCommandBuffer.txt[]
     ename:VK_QUERY_CONTROL_PRECISE_BIT
   * [[VUID-vkBeginCommandBuffer-commandBuffer-02840]]
     If pname:commandBuffer is a primary command buffer, then
-    pname:pBeginInfo\->flags must: not set both the
+    pname:pBeginInfo->flags must: not set both the
     ename:VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT and the
     ename:VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT flags
 ****
@@ -1050,7 +1050,7 @@ endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     pname:pSubmits must: have been allocated from a sname:VkCommandPool that
     was created for the same queue family pname:queue belongs to
   * [[VUID-vkQueueSubmit-pSubmits-02207]]
-    If any element of pname:pSubmits\->pCommandBuffers includes a
+    If any element of pname:pSubmits->pCommandBuffers includes a
     <<synchronization-queue-transfers-acquire, Queue Family Transfer Acquire
     Operation>>, there must: exist a previously submitted
     <<synchronization-queue-transfers-release, Queue Family Transfer Release
@@ -1630,7 +1630,7 @@ command buffer becomes <<commandbuffers-lifecycle, invalid>>.
   * [[VUID-vkCmdExecuteCommands-pInheritanceInfo-00098]]
     If fname:vkCmdExecuteCommands is being called within a render pass
     instance, the render passes specified in the
-    pname:pBeginInfo\->pInheritanceInfo\->renderPass members of the
+    pname:pBeginInfo->pInheritanceInfo->renderPass members of the
     flink:vkBeginCommandBuffer commands used to begin recording each element
     of pname:pCommandBuffers must: be
     <<renderpass-compatibility,compatible>> with the current render pass

--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -2199,7 +2199,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
 If a call to fname:vkAllocateDescriptorSets would cause the total number of
 descriptor sets allocated from the pool to exceed the value of
 slink:VkDescriptorPoolCreateInfo::pname:maxSets used to create
-pname:pAllocateInfo\->descriptorPool, then the allocation may: fail due to
+pname:pAllocateInfo->descriptorPool, then the allocation may: fail due to
 lack of space in the descriptor pool.
 Similarly, the allocation may: fail due to lack of space if the call to
 fname:vkAllocateDescriptorSets would cause the number of any given
@@ -4069,7 +4069,7 @@ endif::VK_EXT_buffer_device_address[]
   * pname:pInfo is a pointer to a slink:VkBufferDeviceAddressInfo structure
     specifying the buffer to retrieve an address for.
 
-The 64-bit return value is an address of the start of pname:pInfo\->buffer.
+The 64-bit return value is an address of the start of pname:pInfo->buffer.
 The address range starting at this value and whose size is the size of the
 buffer can: be used in a shader to access the memory bound to that buffer,
 using the
@@ -4184,7 +4184,7 @@ endif::VK_KHR_buffer_device_address[]
     specifying the buffer to retrieve an address for.
 
 The 64-bit return value is an opaque capture address of the start of
-pname:pInfo\->buffer.
+pname:pInfo->buffer.
 
 If the buffer was created with a non-zero value of
 slink:VkBufferOpaqueCaptureAddressCreateInfo::pname:opaqueCaptureAddress the

--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -1031,21 +1031,21 @@ endif::VK_AMD_memory_overallocation_behavior[]
 .Valid Usage
 ****
   * [[VUID-vkAllocateMemory-pAllocateInfo-01713]]
-    pname:pAllocateInfo\->allocationSize must: be less than or equal to
+    pname:pAllocateInfo->allocationSize must: be less than or equal to
     slink:VkPhysicalDeviceMemoryProperties::pname:memoryHeaps[memindex].size
     where `memindex` =
     slink:VkPhysicalDeviceMemoryProperties::pname:memoryTypes[pAllocateInfo\->memoryTypeIndex].heapIndex
     as returned by flink:vkGetPhysicalDeviceMemoryProperties for the
     slink:VkPhysicalDevice that pname:device was created from.
   * [[VUID-vkAllocateMemory-pAllocateInfo-01714]]
-    pname:pAllocateInfo\->memoryTypeIndex must: be less than
+    pname:pAllocateInfo->memoryTypeIndex must: be less than
     slink:VkPhysicalDeviceMemoryProperties::pname:memoryTypeCount as
     returned by flink:vkGetPhysicalDeviceMemoryProperties for the
     slink:VkPhysicalDevice that pname:device was created from.
 ifdef::VK_AMD_device_coherent_memory[]
   * [[VUID-vkAllocateMemory-deviceCoherentMemory-02790]]
     If the <<features-deviceCoherentMemory,pname:deviceCoherentMemory>>
-    feature is not enabled, pname:pAllocateInfo\->memoryTypeIndex must: not
+    feature is not enabled, pname:pAllocateInfo->memoryTypeIndex must: not
     identify a memory type supporting
     ename:VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD
 endif::VK_AMD_device_coherent_memory[]
@@ -3489,7 +3489,7 @@ endif::VK_KHR_buffer_device_address[]
     memory object to retrieve an address for.
 
 The 64-bit return value is an opaque address representing the start of
-pname:pInfo\->memory.
+pname:pInfo->memory.
 
 If the memory object was allocated with a non-zero value of
 slink:VkMemoryOpaqueCaptureAddressAllocateInfo::pname:opaqueCaptureAddress,

--- a/chapters/pipelines.txt
+++ b/chapters/pipelines.txt
@@ -876,12 +876,12 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
     If no element of the pname:pDynamicStates member of pname:pDynamicState
     is ename:VK_DYNAMIC_STATE_VIEWPORT, the pname:pViewports member of
     pname:pViewportState must: be a valid pointer to an array of
-    pname:pViewportState\->viewportCount valid sname:VkViewport structures
+    pname:pViewportState->viewportCount valid sname:VkViewport structures
   * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00748]]
     If no element of the pname:pDynamicStates member of pname:pDynamicState
     is ename:VK_DYNAMIC_STATE_SCISSOR, the pname:pScissors member of
     pname:pViewportState must: be a valid pointer to an array of
-    pname:pViewportState\->scissorCount sname:VkRect2D structures
+    pname:pViewportState->scissorCount sname:VkRect2D structures
   * [[VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749]]
     If the wide lines feature is not enabled, and no element of the
     pname:pDynamicStates member of pname:pDynamicState is

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -887,7 +887,7 @@ pass.
 
 pname:subpass and pname:inputAttachmentIndex index into the render pass as:
 
-pname:pCreateInfo\->pSubpasses[subpass].pInputAttachments[inputAttachmentIndex]
+pname:pCreateInfo->pSubpasses[subpass].pInputAttachments[inputAttachmentIndex]
 
 include::{generated}/api/structs/VkInputAttachmentAspectReference.txt[]
 
@@ -2653,9 +2653,9 @@ include::{generated}/api/protos/vkCreateFramebuffer.txt[]
 .Valid Usage
 ****
   * [[VUID-vkCreateFramebuffer-pCreateInfo-02777]]
-    If pname:pCreateInfo\->flags does not include
+    If pname:pCreateInfo->flags does not include
     ename:VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT, and pname:attachmentCount is
-    not `0`, each element of pname:pCreateInfo\->pAttachments must: have
+    not `0`, each element of pname:pCreateInfo->pAttachments must: have
     been created on pname:device
 ****
 

--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -130,7 +130,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_external_memory[]
     member must: only contain bits that are also in
     slink:VkExternalBufferProperties::pname:externalMemoryProperties.compatibleHandleTypes,
     as returned by flink:vkGetPhysicalDeviceExternalBufferProperties with
-    pname:pExternalBufferInfo\->handleType equal to any one of the handle
+    pname:pExternalBufferInfo->handleType equal to any one of the handle
     types specified in
     slink:VkExternalMemoryBufferCreateInfo::pname:handleTypes
 endif::VK_VERSION_1_1,VK_KHR_external_memory[]

--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -1520,7 +1520,7 @@ or transfer ownership back to Vulkan by using the file descriptor to import
 a fence payload.
 ====
 
-If pname:pGetFdInfo\->handleType is
+If pname:pGetFdInfo->handleType is
 ename:VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT and the fence is signaled at
 the time fname:vkGetFenceFdKHR is called, pname:pFd may: return the value
 `-1` instead of a valid file descriptor.

--- a/config/spec-macros/extension.rb
+++ b/config/spec-macros/extension.rb
@@ -27,35 +27,35 @@ class NormativeInlineMacroBase < SpecInlineMacroBase
     end
 
     def process parent, target, attributes
-        '<strong class="purple">' + text + '</strong>'
+        create_inline parent, :quoted, '<strong class="purple">' + text + '</strong>'
     end
 end
 
 class LinkInlineMacroBase < SpecInlineMacroBase
     def process parent, target, attributes
       if parent.document.attributes['cross-file-links']
-        return Inline.new(parent, :anchor, target, :type => :link, :target => (target + '.html')).convert
+        return Inline.new(parent, :anchor, target, :type => :link, :target => (target + '.html'))
       else
-        return Inline.new(parent, :anchor, target, :type => :xref, :target => ('#' + target), :attributes => {'fragment' => target, 'refid' => target}).convert
+        return Inline.new(parent, :anchor, target, :type => :xref, :target => ('#' + target), :attributes => {'fragment' => target, 'refid' => target})
       end
     end
 end
 
 class CodeInlineMacroBase < SpecInlineMacroBase
     def process parent, target, attributes
-        '<code>' + target + '</code>'
+        create_inline parent, :quoted, '<code>' + target.gsub('&#8594;', '-&gt;') + '</code>'
     end
 end
 
 class StrongInlineMacroBase < SpecInlineMacroBase
     def process parent, target, attributes
-        '<code>' + target + '</code>'
+        create_inline parent, :quoted, '<code>' + target.gsub('&#8594;', '-&gt;') + '</code>'
     end
 end
 
 class ParamInlineMacroBase < SpecInlineMacroBase
     def process parent, target, attributes
-        '<code>' + target + '</code>'
+         create_inline parent, :quoted, '<code>' + target.gsub('&#8594;', '-&gt;') + '</code>'
     end
 end
 
@@ -132,12 +132,12 @@ class FlinkInlineMacro < LinkInlineMacroBase
     match /flink:(\w+)/
 end
 
-class FnameInlineMacro < StrongInlineMacroBase
+class FnameInlineMacro < CodeInlineMacroBase
     named :fname
     match /fname:(\w+)/
 end
 
-class FtextInlineMacro < StrongInlineMacroBase
+class FtextInlineMacro < CodeInlineMacroBase
     named :ftext
     match /ftext:([\w\*]+)/
 end
@@ -176,12 +176,12 @@ end
 
 class PnameInlineMacro < ParamInlineMacroBase
     named :pname
-    match /pname:(\w+((\.|\-&gt;)\w+)*)/
+    match /pname:(\w+((\.|&#8594;)\w+)*)/
 end
 
 class PtextInlineMacro < ParamInlineMacroBase
     named :ptext
-    match /ptext:([\w\*]+((\.|\-&gt;)[\w\*]+)*)/
+    match /ptext:([\w\*]+((\.|&#8594;)[\w\*]+)*)/
 end
 
 class DnameInlineMacro < CodeInlineMacroBase
@@ -234,7 +234,7 @@ class UndefinedInlineMacro < SpecInlineMacroBase
     match /undefined:/
 
     def process parent, target, attributes
-        'undefined'
+        create_inline parent, :quoted, 'undefined'
     end
 end
 

--- a/style/extensions.txt
+++ b/style/extensions.txt
@@ -903,12 +903,12 @@ In this case, the type's etext:Vk prefix is replaced with the enum prefix
 etext:VK_OBJECT_TYPE_, and the rest of the handle name is converted as
 described in that section.
 
-[source,asciidoc]
-.Conversion of Handle to VkObjectType Examples:
-----
- VkSurfaceKHR                  -> VK_OBJECT_TYPE_SURFACE_KHR
- VkDescriptorUpdateTemplateKHR -> VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR
-----
+[literal, subs="+replacements"]
+.Conversion of Handle to sname:VkObjectType Examples:
+....
+VkSurfaceKHR                  -> VK_OBJECT_TYPE_SURFACE_KHR
+VkDescriptorUpdateTemplateKHR -> VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR
+....
 
 [NOTE]
 .Note

--- a/style/markup.txt
+++ b/style/markup.txt
@@ -563,15 +563,25 @@ This is often done when referring to a particular parameter or member in a
 part of the document other than the description of the corresponding
 function or structure.
 When a nested member within the compound name is referred to, use normal C
-markup, escaped as shown in the following examples:
+markup:
 
 [source,asciidoc]
 .Example Markup
 ----
 flink:vkCmdBindIndexBuffer::pname:indexType
 sname:VkExternalImageFormatProperties::pname:externalMemoryProperties.externalMemoryFeatures
-pname:pAllocateInfo\->memoryTypeIndex
+pname:pAllocateInfo->memoryTypeIndex
 ----
+
+[NOTE]
+.Note
+====
+In the macros, "```\->```" results correctly in a C arrow. But in any other
+context (including a "```````" delimited inline literal) it would be subject
+to standard asciidoctor
+https://asciidoctor.org/docs/user-manual/#replacements[text replacements],
+which results in a unicode arrow: ->.
+====
 
 
 [[markup-macros-api-name]]

--- a/styleguide.txt
+++ b/styleguide.txt
@@ -158,6 +158,8 @@ include::style/vuid.txt[]
 
 = Revision History
 
+* 2020-02-22 - Document that it is no longer needed to escape C arrows in
+  macros.
 * 2019-12-15 - Add a markup section on <<markup-macros-prime-symbols, Prime
   Symbols>> (internal issue 1110).
 * 2019-11-27 - Expand the <<writing-pNext-chain, Describing Extension


### PR DESCRIPTION
- resolves new asciidoctor warnings
- obviates the need to escape ->