### PR TITLE
Tweak parents of VkDisplayKHR and VkDisplayModeKHR.

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -383,8 +383,8 @@ typedef void <name>CAMetalLayer</name>;
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkPerformanceConfigurationINTEL</name>)</type>
 
             <comment>WSI extensions</comment>
-        <type category="handle"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDisplayKHR</name>)</type>
-        <type category="handle" parent="VkPhysicalDevice,VkDisplayKHR"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDisplayModeKHR</name>)</type>
+        <type category="handle" parent="VkPhysicalDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDisplayKHR</name>)</type>
+        <type category="handle" parent="VkDisplayKHR"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDisplayModeKHR</name>)</type>
         <type category="handle" parent="VkInstance"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkSurfaceKHR</name>)</type>
         <type category="handle" parent="VkSurfaceKHR"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkSwapchainKHR</name>)</type>
         <type category="handle" parent="VkInstance"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDebugReportCallbackEXT</name>)</type>


### PR DESCRIPTION
When looking at the registry, I see that `VkDisplayKHR` has no parent. This handle is acquired by functions with a `VkPhysicalDevice` dispatchable object. Shouldn't the parent then be `VkPhysicalDevice`?

If that's the case, then by extension it makes sense to remove `VkPhysicalDevice` from the  `VkDisplayModeKHR` parent so that it only has `VkDisplayKHR`.