### PR TITLE
Fix parameters section in vkGetPhysicalDeviceXcbPresentationSupportKHR page

### DIFF
--- a/chapters/VK_KHR_xcb_surface/platformQuerySupport_xcb.txt
+++ b/chapters/VK_KHR_xcb_surface/platformQuerySupport_xcb.txt
@@ -18,7 +18,7 @@ include::{generated}/api/protos/vkGetPhysicalDeviceXcbPresentationSupportKHR.txt
   * pname:queueFamilyIndex is the queue family index.
   * pname:connection is a pointer to an code:xcb_connection_t to the X
     server.
-    pname:visual_id is an X11 visual (code:xcb_visualid_t).
+  * pname:visual_id is an X11 visual (code:xcb_visualid_t).
 
 This platform-specific function can: be called prior to creating a surface.
 


### PR DESCRIPTION
`visual_id` documentation isn't in a separate item.