### PR TITLE
remove extra 'a'

### DIFF
--- a/chapters/VK_NV_ray_tracing/raytracing.txt
+++ b/chapters/VK_NV_ray_tracing/raytracing.txt
@@ -134,13 +134,13 @@ include::{chapters}/commonvalidity/draw_dispatch_nonindirect_common.txt[]
     pname:callableShaderBindingStride must: be a multiple of
     sname:VkPhysicalDeviceRayTracingPropertiesNV::pname:shaderGroupHandleSize
   * [[VUID-vkCmdTraceRaysNV-missShaderBindingStride-02466]]
-    pname:missShaderBindingStride must: be a less than or equal to
+    pname:missShaderBindingStride must: be less than or equal to
     sname:VkPhysicalDeviceRayTracingPropertiesNV::pname:maxShaderGroupStride
   * [[VUID-vkCmdTraceRaysNV-hitShaderBindingStride-02467]]
-    pname:hitShaderBindingStride must: be a less than or equal to
+    pname:hitShaderBindingStride must: be less than or equal to
     sname:VkPhysicalDeviceRayTracingPropertiesNV::pname:maxShaderGroupStride
   * [[VUID-vkCmdTraceRaysNV-callableShaderBindingStride-02468]]
-    pname:callableShaderBindingStride must: be a less than or equal to
+    pname:callableShaderBindingStride must: be less than or equal to
     sname:VkPhysicalDeviceRayTracingPropertiesNV::pname:maxShaderGroupStride
   * [[VUID-vkCmdTraceRaysNV-width-02469]]
     pname:width must: be less than or equal to


### PR DESCRIPTION
Fixes a typo in 3 locations.