### PR TITLE
Simplify Default Non-Dispatchable Handle Def

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -165,11 +165,7 @@ server.
 
         <type category="define" name="VK_DEFINE_NON_DISPATCHABLE_HANDLE">
 #if !defined(VK_DEFINE_NON_DISPATCHABLE_HANDLE)
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) &amp;&amp; !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object##_T *object;
-#else
-        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef uint64_t object;
-#endif
+        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object { uint64_t opaqueHandle; } object;
 #endif</type>
 
         <type category="define">


### PR DESCRIPTION
Making the ND handles a struct containing a 64-bit value should make the 64-bit ISA preprocessor branch/pointer defintion unnecessary and also allow the strong typedef to exist on 32-bit platforms.

Related: https://stackoverflow.com/questions/51743500/why-do-non-dispatchable-handles-use-a-ptr-on-64bit-platofrms

The root `#if !defined(VK_DEFINE_NON_DISPATCHABLE_HANDLE)` is kept so as to conform to the spec:

>The `vulkan_core.h` header allows the `VK_DEFINE_NON_DISPATCHABLE_HANDLE` definition to be overridden by the application. If `VK_DEFINE_NON_DISPATCHABLE_HANDLE` is already defined when `vulkan_core.h` is compiled, the default definition is skipped. This allows the application to define a binary-compatible custom handle which may provide more type-safety or other features needed by the application. Applications must not define handles in a way that is not binary compatible - where binary compatibility is platform dependent.