### PR TITLE
Remove periods after VUs

### DIFF
--- a/chapters/VK_AMD_buffer_marker/copies.txt
+++ b/chapters/VK_AMD_buffer_marker/copies.txt
@@ -55,7 +55,7 @@ operations may: degrade command execution performance.
 ****
   * [[VUID-vkCmdWriteBufferMarkerAMD-dstOffset-01798]]
     pname:dstOffset must: be less than or equal to the size of
-    pname:dstBuffer minus `4`.
+    pname:dstBuffer minus `4`
   * [[VUID-vkCmdWriteBufferMarkerAMD-dstBuffer-01799]]
     pname:dstBuffer must: have been created with
     ename:VK_BUFFER_USAGE_TRANSFER_DST_BIT usage flag

--- a/chapters/VK_EXT_debug_marker.txt
+++ b/chapters/VK_EXT_debug_marker.txt
@@ -63,7 +63,7 @@ empty string.
     pname:object must: not be dlink:VK_NULL_HANDLE
   * [[VUID-VkDebugMarkerObjectNameInfoEXT-object-01492]]
     pname:object must: be a Vulkan object of the type associated with
-    pname:objectType as defined in <<debug-report-object-types>>.
+    pname:objectType as defined in <<debug-report-object-types>>
 ****
 
 include::{generated}/validity/structs/VkDebugMarkerObjectNameInfoEXT.txt[]
@@ -119,7 +119,7 @@ be used by that implementation.
     pname:object must: not be dlink:VK_NULL_HANDLE
   * [[VUID-VkDebugMarkerObjectTagInfoEXT-object-01495]]
     pname:object must: be a Vulkan object of the type associated with
-    pname:objectType as defined in <<debug-report-object-types>>.
+    pname:objectType as defined in <<debug-report-object-types>>
 ****
 
 include::{generated}/validity/structs/VkDebugMarkerObjectTagInfoEXT.txt[]
@@ -202,7 +202,7 @@ must: be matched and balanced.
     If pname:commandBuffer is a secondary command buffer, there must: be an
     outstanding flink:vkCmdDebugMarkerBeginEXT command recorded to
     pname:commandBuffer that has not previously been ended by a call to
-    flink:vkCmdDebugMarkerEndEXT.
+    flink:vkCmdDebugMarkerEndEXT
 ****
 
 include::{generated}/validity/protos/vkCmdDebugMarkerEndEXT.txt[]

--- a/chapters/VK_EXT_debug_report.txt
+++ b/chapters/VK_EXT_debug_report.txt
@@ -267,7 +267,7 @@ registered.
     If pname:objectType is not ename:VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT
     and pname:object is not dlink:VK_NULL_HANDLE, pname:object must: be a
     Vulkan object of the corresponding type associated with pname:objectType
-    as defined in <<debug-report-object-types>>.
+    as defined in <<debug-report-object-types>>
 ****
 
 include::{generated}/validity/protos/vkDebugReportMessageEXT.txt[]

--- a/chapters/VK_EXT_debug_utils.txt
+++ b/chapters/VK_EXT_debug_utils.txt
@@ -307,7 +307,7 @@ flink:vkCmdEndDebugUtilsLabelEXT must: be matched and balanced.
     If pname:commandBuffer is a secondary command buffer, there must: be an
     outstanding fname:vkCmdBeginDebugUtilsLabelEXT command recorded to
     pname:commandBuffer that has not previously been ended by a call to
-    fname:vkCmdEndDebugUtilsLabelEXT.
+    fname:vkCmdEndDebugUtilsLabelEXT
 ****
 
 include::{generated}/validity/protos/vkCmdEndDebugUtilsLabelEXT.txt[]

--- a/chapters/VK_EXT_display_control/swapchain_counters.txt
+++ b/chapters/VK_EXT_display_control/swapchain_counters.txt
@@ -18,7 +18,7 @@ include::{generated}/api/structs/VkSwapchainCounterCreateInfoEXT.txt[]
   * [[VUID-VkSwapchainCounterCreateInfoEXT-surfaceCounters-01244]]
     The bits in pname:surfaceCounters must: be supported by
     slink:VkSwapchainCreateInfoKHR::pname:surface, as reported by
-    flink:vkGetPhysicalDeviceSurfaceCapabilities2EXT.
+    flink:vkGetPhysicalDeviceSurfaceCapabilities2EXT
 ****
 
 include::{generated}/validity/structs/VkSwapchainCounterCreateInfoEXT.txt[]
@@ -45,7 +45,7 @@ implementation may: return ename:VK_ERROR_OUT_OF_DATE_KHR.
 ****
   * [[VUID-vkGetSwapchainCounterEXT-swapchain-01245]]
     One or more present commands on pname:swapchain must: have been
-    processed by the presentation engine.
+    processed by the presentation engine
 ****
 
 include::{generated}/validity/protos/vkGetSwapchainCounterEXT.txt[]

--- a/chapters/VK_EXT_display_surface_counter/surface_capabilities.txt
+++ b/chapters/VK_EXT_display_surface_counter/surface_capabilities.txt
@@ -44,7 +44,7 @@ The remaining members are:
   * [[VUID-VkSurfaceCapabilities2EXT-supportedSurfaceCounters-01246]]
     pname:supportedSurfaceCounters must: not include
     ename:VK_SURFACE_COUNTER_VBLANK_EXT unless the surface queried is a
-    <<wsi-display-surfaces,display surface>>.
+    <<wsi-display-surfaces,display surface>>
 ****
 
 include::{generated}/validity/structs/VkSurfaceCapabilities2EXT.txt[]

--- a/chapters/VK_GOOGLE_display_timing/PresentTimeInfo.txt
+++ b/chapters/VK_GOOGLE_display_timing/PresentTimeInfo.txt
@@ -35,7 +35,7 @@ include::{generated}/api/structs/VkPresentTimesInfoGOOGLE.txt[]
     pname:swapchainCount must: be the same value as
     sname:VkPresentInfoKHR::pname:swapchainCount, where
     sname:VkPresentInfoKHR is included in the pname:pNext chain of this
-    sname:VkPresentTimesInfoGOOGLE structure.
+    sname:VkPresentTimesInfoGOOGLE structure
 ****
 
 include::{generated}/validity/structs/VkPresentTimesInfoGOOGLE.txt[]

--- a/chapters/VK_INTEL_performance_query/queries.txt
+++ b/chapters/VK_INTEL_performance_query/queries.txt
@@ -223,7 +223,7 @@ include::{generated}/api/structs/VkPerformanceStreamMarkerInfoINTEL.txt[]
   * [[VUID-VkPerformanceStreamMarkerInfoINTEL-marker-02735]]
     The value written by the application into pname:marker must: only used
     the valid bits as reported by flink:vkGetPerformanceParameterINTEL with
-    the ename:VK_PERFORMANCE_PARAMETER_TYPE_STREAM_MARKER_VALID_BITS_INTEL.
+    the ename:VK_PERFORMANCE_PARAMETER_TYPE_STREAM_MARKER_VALID_BITS_INTEL
 ****
 
 include::{generated}/validity/structs/VkPerformanceStreamMarkerInfoINTEL.txt[]
@@ -248,7 +248,7 @@ include::{generated}/api/protos/vkCmdSetPerformanceOverrideINTEL.txt[]
   * [[VUID-vkCmdSetPerformanceOverrideINTEL-pOverrideInfo-02736]]
     pname:pOverrideInfo must: not be used with a
     elink:VkPerformanceOverrideTypeINTEL that is not reported available by
-    fname:vkGetPerformanceParameterINTEL.
+    fname:vkGetPerformanceParameterINTEL
 ****
 
 include::{generated}/validity/protos/vkCmdSetPerformanceOverrideINTEL.txt[]
@@ -362,7 +362,7 @@ include::{generated}/api/protos/vkReleasePerformanceConfigurationINTEL.txt[]
   * [[VUID-vkReleasePerformanceConfigurationINTEL-configuration-02737]]
     pname:configuration must: not be released before all command buffers
     submitted while the configuration was set are in
-    <<commandbuffers-lifecycle, pending state>>.
+    <<commandbuffers-lifecycle, pending state>>
 ****
 
 include::{generated}/validity/protos/vkReleasePerformanceConfigurationINTEL.txt[]

--- a/chapters/VK_KHR_android_surface/platformCreateSurface_android.txt
+++ b/chapters/VK_KHR_android_surface/platformCreateSurface_android.txt
@@ -68,7 +68,7 @@ include::{generated}/api/structs/VkAndroidSurfaceCreateInfoKHR.txt[]
 .Valid Usage
 ****
   * [[VUID-VkAndroidSurfaceCreateInfoKHR-window-01248]]
-    pname:window must: point to a valid Android dlink:ANativeWindow.
+    pname:window must: point to a valid Android dlink:ANativeWindow
 ****
 
 include::{generated}/validity/structs/VkAndroidSurfaceCreateInfoKHR.txt[]

--- a/chapters/VK_KHR_incremental_present/wsi.txt
+++ b/chapters/VK_KHR_incremental_present/wsi.txt
@@ -82,11 +82,11 @@ include::{generated}/api/structs/VkRectLayerKHR.txt[]
   * [[VUID-VkRectLayerKHR-offset-01261]]
     The sum of pname:offset and pname:extent must: be no greater than the
     pname:imageExtent member of the sname:VkSwapchainCreateInfoKHR structure
-    given to flink:vkCreateSwapchainKHR.
+    given to flink:vkCreateSwapchainKHR
   * [[VUID-VkRectLayerKHR-layer-01262]]
     pname:layer must: be less than pname:imageArrayLayers member of the
     sname:VkSwapchainCreateInfoKHR structure given to
-    flink:vkCreateSwapchainKHR.
+    flink:vkCreateSwapchainKHR
 ****
 
 include::{generated}/validity/structs/VkRectLayerKHR.txt[]

--- a/chapters/VK_KHR_pipeline_executable_properties/pipelines.txt
+++ b/chapters/VK_KHR_pipeline_executable_properties/pipelines.txt
@@ -32,10 +32,10 @@ ename:VK_INCOMPLETE.
 ****
   * [[VUID-vkGetPipelineExecutablePropertiesKHR-pipelineExecutableInfo-03270]]
     <<features-pipelineExecutableInfo, pname:pipelineExecutableInfo>> must:
-    be enabled.
+    be enabled
   * [[VUID-vkGetPipelineExecutablePropertiesKHR-pipeline-03271]]
     pname:pipeline member of pname:pPipelineInfo must: have been created
-    with pname:device.
+    with pname:device
 ****
 
 include::{generated}/validity/protos/vkGetPipelineExecutablePropertiesKHR.txt[]
@@ -129,15 +129,15 @@ ename:VK_INCOMPLETE.
 ****
   * [[VUID-vkGetPipelineExecutableStatisticsKHR-pipelineExecutableInfo-03272]]
     <<features-pipelineExecutableInfo, pname:pipelineExecutableInfo>> must:
-    be enabled.
+    be enabled
   * [[VUID-vkGetPipelineExecutableStatisticsKHR-pipeline-03273]]
     pname:pipeline member of pname:pExecutableInfo must: have been created
-    with pname:device.
+    with pname:device
   * [[VUID-vkGetPipelineExecutableStatisticsKHR-pipeline-03274]]
     pname:pipeline member of pname:pExecutableInfo must: have been created
     with ename:VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR set in the
     pname:flags field of slink:VkGraphicsPipelineCreateInfo or
-    slink:VkComputePipelineCreateInfo.
+    slink:VkComputePipelineCreateInfo
 ****
 
 include::{generated}/validity/protos/vkGetPipelineExecutableStatisticsKHR.txt[]
@@ -162,7 +162,7 @@ include::{generated}/api/structs/VkPipelineExecutableInfoKHR.txt[]
   * [[VUID-VkPipelineExecutableInfoKHR-executableIndex-03275]]
     pname:executableIndex must: be less than the number of executables
     associated with pname:pipeline as returned in the pname:pExecutableCount
-    parameter of fname:vkGetPipelineExecutablePropertiesKHR.
+    parameter of fname:vkGetPipelineExecutablePropertiesKHR
 ****
 
 include::{generated}/validity/structs/VkPipelineExecutableInfoKHR.txt[]
@@ -282,15 +282,15 @@ assembly (if any) last.
 ****
   * [[VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipelineExecutableInfo-03276]]
     <<features-pipelineExecutableInfo, pname:pipelineExecutableInfo>> must:
-    be enabled.
+    be enabled
   * [[VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipeline-03277]]
     pname:pipeline member of pname:pExecutableInfo must: have been created
-    with pname:device.
+    with pname:device
   * [[VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipeline-03278]]
     pname:pipeline member of pname:pExecutableInfo must: have been created
     with ename:VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR
     set in the pname:flags field of slink:VkGraphicsPipelineCreateInfo or
-    slink:VkComputePipelineCreateInfo.
+    slink:VkComputePipelineCreateInfo
 ****
 
 include::{generated}/validity/protos/vkGetPipelineExecutableInternalRepresentationsKHR.txt[]

--- a/chapters/VK_KHR_surface/wsi.txt
+++ b/chapters/VK_KHR_surface/wsi.txt
@@ -429,7 +429,7 @@ ifdef::VK_EXT_full_screen_exclusive+VK_KHR_win32_surface[]
     If a slink:VkSurfaceCapabilitiesFullScreenExclusiveEXT structure is
     included in the pname:pNext chain of pname:pSurfaceCapabilities, a
     slink:VkSurfaceFullScreenExclusiveWin32InfoEXT structure must: be
-    included in the pname:pNext chain of pname:pSurfaceInfo.
+    included in the pname:pNext chain of pname:pSurfaceInfo
 ****
 endif::VK_EXT_full_screen_exclusive+VK_KHR_win32_surface[]
 
@@ -845,7 +845,7 @@ format.
   * [[VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-surface-02739]]
     pname:surface must be supported by pname:physicalDevice, as reported by
     flink:vkGetPhysicalDeviceSurfaceSupportKHR or an equivalent
-    platform-specific mechanism.
+    platform-specific mechanism
 ****
 
 include::{generated}/validity/protos/vkGetPhysicalDeviceSurfaceFormatsKHR.txt[]
@@ -911,7 +911,7 @@ that not all the available values were returned.
   * [[VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceInfo-02740]]
     pname:pSurfaceInfo->surface must be supported by pname:physicalDevice,
     as reported by flink:vkGetPhysicalDeviceSurfaceSupportKHR or an
-    equivalent platform-specific mechanism.
+    equivalent platform-specific mechanism
 ****
 
 include::{generated}/validity/protos/vkGetPhysicalDeviceSurfaceFormats2KHR.txt[]

--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -517,7 +517,7 @@ include::{generated}/validity/structs/VkSwapchainDisplayNativeHdrCreateInfoAMD.t
   * [[VUID-VkSwapchainDisplayNativeHdrCreateInfoAMD-localDimmingEnable-XXXXX]]
     It is only valid to set pname:localDimmingEnable to ename:VK_TRUE if
     slink:VkDisplayNativeHdrSurfaceCapabilitiesAMD::pname:localDimmingSupport
-    is supported.
+    is supported
 ****
 --
 
@@ -540,7 +540,7 @@ include::{generated}/validity/protos/vkSetLocalDimmingAMD.txt[]
   * [[VUID-vkSetLocalDimmingAMD-XXXXX]]
     It is only valid to call flink:vkSetLocalDimmingAMD if
     slink:VkDisplayNativeHdrSurfaceCapabilitiesAMD::pname:localDimmingSupport
-    is supported.
+    is supported
 ****
 --
 endif::VK_AMD_display_native_hdr[]
@@ -1132,7 +1132,7 @@ endif::VK_KHR_display_swapchain[]
     When a semaphore wait operation referring to a binary semaphore defined
     by the elements of the pname:pWaitSemaphores member of
     pname:pPresentInfo executes on pname:queue, there must: be no other
-    queues waiting on the same semaphore.
+    queues waiting on the same semaphore
   * [[VUID-vkQueuePresentKHR-pWaitSemaphores-01295]]
     All elements of the pname:pWaitSemaphores member of pname:pPresentInfo
     must: be semaphores that are signaled, or have
@@ -1142,12 +1142,12 @@ ifdef::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
   * [[VUID-vkQueuePresentKHR-pWaitSemaphores-03267]]
     All elements of the pname:pWaitSemaphores member of pname:pPresentInfo
     must: be created with a elink:VkSemaphoreType of
-    ename:VK_SEMAPHORE_TYPE_BINARY.
+    ename:VK_SEMAPHORE_TYPE_BINARY
   * [[VUID-vkQueuePresentKHR-pWaitSemaphores-03268]]
     All elements of the pname:pWaitSemaphores member of pname:pPresentInfo
     must: reference a semaphore signal operation that has been submitted for
     execution and any semaphore signal operations on which it depends (if
-    any) must: have also been submitted for execution.
+    any) must: have also been submitted for execution
 endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
 ****
 
@@ -1361,7 +1361,7 @@ considered to be ename:VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR.
     If pname:mode is ename:VK_DEVICE_GROUP_PRESENT_MODE_REMOTE_BIT_KHR, then
     each element of pname:pDeviceMasks must: have exactly one bit set, and
     some physical device in the logical device must: include that bit in its
-    slink:VkDeviceGroupPresentCapabilitiesKHR::pname:presentMask.
+    slink:VkDeviceGroupPresentCapabilitiesKHR::pname:presentMask
   * [[VUID-VkDeviceGroupPresentInfoKHR-mode-01300]]
     If pname:mode is ename:VK_DEVICE_GROUP_PRESENT_MODE_SUM_BIT_KHR, then
     each element of pname:pDeviceMasks must: have a value for which all set

--- a/chapters/VK_KHR_wayland_surface/platformCreateSurface_wayland.txt
+++ b/chapters/VK_KHR_wayland_surface/platformCreateSurface_wayland.txt
@@ -42,9 +42,9 @@ include::{generated}/api/structs/VkWaylandSurfaceCreateInfoKHR.txt[]
 .Valid Usage
 ****
   * [[VUID-VkWaylandSurfaceCreateInfoKHR-display-01304]]
-    pname:display must: point to a valid Wayland code:wl_display.
+    pname:display must: point to a valid Wayland code:wl_display
   * [[VUID-VkWaylandSurfaceCreateInfoKHR-surface-01305]]
-    pname:surface must: point to a valid Wayland code:wl_surface.
+    pname:surface must: point to a valid Wayland code:wl_surface
 ****
 
 include::{generated}/validity/structs/VkWaylandSurfaceCreateInfoKHR.txt[]

--- a/chapters/VK_KHR_win32_surface/platformCreateSurface_win32.txt
+++ b/chapters/VK_KHR_win32_surface/platformCreateSurface_win32.txt
@@ -44,9 +44,9 @@ include::{generated}/api/structs/VkWin32SurfaceCreateInfoKHR.txt[]
 .Valid Usage
 ****
   * [[VUID-VkWin32SurfaceCreateInfoKHR-hinstance-01307]]
-    pname:hinstance must: be a valid Win32 code:HINSTANCE.
+    pname:hinstance must: be a valid Win32 code:HINSTANCE
   * [[VUID-VkWin32SurfaceCreateInfoKHR-hwnd-01308]]
-    pname:hwnd must: be a valid Win32 code:HWND.
+    pname:hwnd must: be a valid Win32 code:HWND
 ****
 
 include::{generated}/validity/structs/VkWin32SurfaceCreateInfoKHR.txt[]

--- a/chapters/VK_KHR_xcb_surface/platformCreateSurface_xcb.txt
+++ b/chapters/VK_KHR_xcb_surface/platformCreateSurface_xcb.txt
@@ -45,9 +45,9 @@ include::{generated}/api/structs/VkXcbSurfaceCreateInfoKHR.txt[]
 .Valid Usage
 ****
   * [[VUID-VkXcbSurfaceCreateInfoKHR-connection-01310]]
-    pname:connection must: point to a valid X11 code:xcb_connection_t.
+    pname:connection must: point to a valid X11 code:xcb_connection_t
   * [[VUID-VkXcbSurfaceCreateInfoKHR-window-01311]]
-    pname:window must: be a valid X11 code:xcb_window_t.
+    pname:window must: be a valid X11 code:xcb_window_t
 ****
 
 include::{generated}/validity/structs/VkXcbSurfaceCreateInfoKHR.txt[]

--- a/chapters/VK_KHR_xlib_surface/platformCreateSurface_xlib.txt
+++ b/chapters/VK_KHR_xlib_surface/platformCreateSurface_xlib.txt
@@ -44,9 +44,9 @@ include::{generated}/api/structs/VkXlibSurfaceCreateInfoKHR.txt[]
 .Valid Usage
 ****
   * [[VUID-VkXlibSurfaceCreateInfoKHR-dpy-01313]]
-    pname:dpy must: point to a valid Xlib code:Display.
+    pname:dpy must: point to a valid Xlib code:Display
   * [[VUID-VkXlibSurfaceCreateInfoKHR-window-01314]]
-    pname:window must: be a valid Xlib code:Window.
+    pname:window must: be a valid Xlib code:Window
 ****
 
 include::{generated}/validity/structs/VkXlibSurfaceCreateInfoKHR.txt[]

--- a/chapters/VK_MVK_ios_surface/platformCreateSurface_ios.txt
+++ b/chapters/VK_MVK_ios_surface/platformCreateSurface_ios.txt
@@ -41,7 +41,7 @@ include::{generated}/api/structs/VkIOSSurfaceCreateInfoMVK.txt[]
 ****
   * [[VUID-VkIOSSurfaceCreateInfoMVK-pView-01316]]
     pname:pView must: be a valid code:UIView and must: be backed by a
-    code:CALayer instance of type dlink:CAMetalLayer.
+    code:CALayer instance of type dlink:CAMetalLayer
 ****
 
 include::{generated}/validity/structs/VkIOSSurfaceCreateInfoMVK.txt[]

--- a/chapters/VK_MVK_macos_surface/platformCreateSurface_macos.txt
+++ b/chapters/VK_MVK_macos_surface/platformCreateSurface_macos.txt
@@ -41,7 +41,7 @@ include::{generated}/api/structs/VkMacOSSurfaceCreateInfoMVK.txt[]
 ****
   * [[VUID-VkMacOSSurfaceCreateInfoMVK-pView-01317]]
     pname:pView must: be a valid code:NSView and must: be backed by a
-    code:CALayer instance of type dlink:CAMetalLayer.
+    code:CALayer instance of type dlink:CAMetalLayer
 ****
 
 include::{generated}/validity/structs/VkMacOSSurfaceCreateInfoMVK.txt[]

--- a/chapters/VK_NV_device_generated_commands/generation.txt
+++ b/chapters/VK_NV_device_generated_commands/generation.txt
@@ -86,14 +86,14 @@ include::{generated}/api/protos/vkCmdExecuteGeneratedCommandsNV.txt[]
     Furthermore pname:pGeneratedCommandsInfo`s pname:indirectCommandsLayout
     must: have been created with the
     ename:VK_INDIRECT_COMMANDS_LAYOUT_USAGE_EXPLICIT_PREPROCESS_BIT_NV bit
-    set.
+    set
   * [[VUID-vkCmdExecuteGeneratedCommandsNV-pipeline-02909]]
     sname:VkGeneratedCommandsInfoNV::pname:pipeline must: match the current
     bound pipeline at
     sname:VkGeneratedCommandsInfoNV::pname:pipelineBindPoint.
 ifdef::VK_EXT_transform_feedback[]
   * [[VUID-vkCmdExecuteGeneratedCommandsNV-None-02910]]
-    Transform feedback must: not be active.
+    Transform feedback must: not be active
 endif::VK_EXT_transform_feedback[]
   * [[VUID-vkCmdExecuteGeneratedCommandsNV-deviceGeneratedCommands-02911]]
     The <<feature-device-generated-commands,
@@ -148,22 +148,22 @@ include::{generated}/api/structs/VkGeneratedCommandsInfoNV.txt[]
 ****
   * [[VUID-VkGeneratedCommandsInfoNV-pipeline-02912]]
     The provided pname:pipeline must: match the pipeline bound at execution
-    time.
+    time
   * [[VUID-VkGeneratedCommandsInfoNV-indirectCommandsLayout-02913]]
     If the pname:indirectCommandsLayout uses a token of
     ename:VK_INDIRECT_COMMANDS_TOKEN_TYPE_SHADER_GROUP_NV, then the
-    pname:pipeline must: have been created with multiple shader groups.
+    pname:pipeline must: have been created with multiple shader groups
   * [[VUID-VkGeneratedCommandsInfoNV-indirectCommandsLayout-02914]]
     If the pname:indirectCommandsLayout uses a token of
     ename:VK_INDIRECT_COMMANDS_TOKEN_TYPE_SHADER_GROUP_NV, then the
     pname:pipeline must: have been created with
     ename:VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV set in
-    sname:VkGraphicsPipelineCreateInfo::pname:flags.
+    sname:VkGraphicsPipelineCreateInfo::pname:flags
   * [[VUID-VkGeneratedCommandsInfoNV-indirectCommandsLayout-02915]]
     If the pname:indirectCommandsLayout uses a token of
     ename:VK_INDIRECT_COMMANDS_TOKEN_TYPE_PUSH_CONSTANT_NV, then the
     pname:pipeline`s sname:VkPipelineLayout must: match the
-    slink:VkIndirectCommandsLayoutTokenNV::pname:pushconstantPipelineLayout.
+    slink:VkIndirectCommandsLayoutTokenNV::pname:pushconstantPipelineLayout
   * [[VUID-VkGeneratedCommandsInfoNV-streamCount-02916]]
     pname:streamCount must: match the pname:indirectCommandsLayout's
     pname:streamCount
@@ -172,10 +172,10 @@ include::{generated}/api/structs/VkGeneratedCommandsInfoNV.txt[]
     slink:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:maxIndirectSequenceCount
     and
     slink:VkGeneratedCommandsMemoryRequirementsInfoNV::pname:maxSequencesCount
-    that was used to determine the pname:preprocessSize.
+    that was used to determine the pname:preprocessSize
   * [[VUID-VkGeneratedCommandsInfoNV-preprocessBuffer-02918]]
     pname:preprocessBuffer must: have the
-    ename:VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT bit set in its usage flag.
+    ename:VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT bit set in its usage flag
   * [[VUID-VkGeneratedCommandsInfoNV-preprocessOffset-02919]]
     pname:preprocessOffset must: be aligned to
     VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:minIndirectCommandsBufferOffsetAlignment
@@ -183,11 +183,11 @@ include::{generated}/api/structs/VkGeneratedCommandsInfoNV.txt[]
     pname:preprocessSize must: be at least equal to the memory requirement`s
     size returned by flink:vkGetGeneratedCommandsMemoryRequirementsNV using
     the matching inputs (pname:indirectCommandsLayout, ...) as within this
-    structure.
+    structure
   * [[VUID-VkGeneratedCommandsInfoNV-sequencesCountBuffer-02921]]
     pname:sequencesCountBuffer can: be set if the actual used count of
     sequences is sourced from the provided buffer.
-    In that case the pname:sequencesCount serves as upper bound.
+    In that case the pname:sequencesCount serves as upper bound
   * [[VUID-VkGeneratedCommandsInfoNV-sequencesCountBuffer-02922]]
     If pname:sequencesCountBuffer is used, its usage flag must: have the
     ename:VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT bit set
@@ -199,7 +199,7 @@ include::{generated}/api/structs/VkGeneratedCommandsInfoNV.txt[]
     pname:sequencesIndexBuffer must: be set if
     pname:indirectCommandsLayout's
     ename:VK_INDIRECT_COMMANDS_LAYOUT_USAGE_INDEXED_SEQUENCES_BIT_NV is set,
-    otherwise it must: be dlink:VK_NULL_HANDLE.
+    otherwise it must: be dlink:VK_NULL_HANDLE
   * [[VUID-VkGeneratedCommandsInfoNV-sequencesIndexBuffer-02925]]
     If pname:sequencesIndexBuffer is used, its usage flag must: have the
     ename:VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT bit set
@@ -257,7 +257,7 @@ include::{generated}/api/protos/vkCmdPreprocessGeneratedCommandsNV.txt[]
     pname:pGeneratedCommandsInfo`s pname:indirectCommandsLayout must: have
     been created with the
     ename:VK_INDIRECT_COMMANDS_LAYOUT_USAGE_EXPLICIT_PREPROCESS_BIT_NV bit
-    set.
+    set
   * [[VUID-vkCmdPreprocessGeneratedCommandsNV-deviceGeneratedCommands-02928]]
     The <<feature-device-generated-commands,
     sname:VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV->pname:deviceGeneratedCommands>>

--- a/chapters/VK_NV_device_generated_commands/indirectcommands.txt
+++ b/chapters/VK_NV_device_generated_commands/indirectcommands.txt
@@ -83,19 +83,19 @@ include::cmdProcessAllSequences.txt[]
     If pname:pTokens contains an entry of
     ename:VK_INDIRECT_COMMANDS_TOKEN_TYPE_SHADER_GROUP_NV it must: be the
     first element of the array and there must: be only a single element of
-    such token type.
+    such token type
   * [[VUID-VkIndirectCommandsLayoutCreateInfoNV-pTokens-02933]]
     If pname:pTokens contains an entry of
     ename:VK_INDIRECT_COMMANDS_TOKEN_TYPE_STATE_FLAGS_NV there must: be only
-    a single element of such token type.
+    a single element of such token type
   * [[VUID-VkIndirectCommandsLayoutCreateInfoNV-pTokens-02934]]
     All state tokens in pname:pTokens must: occur prior work provoking
     tokens (ename:VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_NV,
     ename:VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_NV,
-    ename:VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_TASKS_NV).
+    ename:VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_TASKS_NV)
   * [[VUID-VkIndirectCommandsLayoutCreateInfoNV-pTokens-02935]]
     The content of pname:pTokens must: include one single work provoking
-    token that is compatible with the pname:pipelineBindPoint.
+    token that is compatible with the pname:pipelineBindPoint
   * [[VUID-VkIndirectCommandsLayoutCreateInfoNV-streamCount-02936]]
     pname:streamCount must: be greater than `0` and less or equal to
     sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:maxIndirectCommandsStreamCount
@@ -103,7 +103,7 @@ include::cmdProcessAllSequences.txt[]
     each element of pname:pStreamStrides must: be greater than `0`and less
     than or equal to
     sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:maxIndirectCommandsStreamStride.
-    Furthermore the alignment of each token input must: be ensured.
+    Furthermore the alignment of each token input must: be ensured
 ****
 
 include::{generated}/validity/structs/VkIndirectCommandsLayoutCreateInfoNV.txt[]
@@ -196,10 +196,10 @@ include::{generated}/api/structs/VkIndirectCommandsStreamNV.txt[]
 ****
   * [[VUID-VkIndirectCommandsStreamNV-buffer-02942]]
     The pname:buffer's usage flag must: have the
-    ename:VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT bit set.
+    ename:VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT bit set
   * [[VUID-VkIndirectCommandsStreamNV-offset-02943]]
     The pname:offset must: be aligned to
-    sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:minIndirectCommandsBufferOffsetAlignment.
+    sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:minIndirectCommandsBufferOffsetAlignment
 ****
 
 include::{generated}/validity/structs/VkIndirectCommandsStreamNV.txt[]
@@ -238,7 +238,7 @@ include::{generated}/api/structs/VkBindShaderGroupIndirectCommandNV.txt[]
   * [[VUID-VkBindShaderGroupIndirectCommandNV-index-02945]]
     The pname:index must: be within range of the accessible shader groups of
     the current bound graphics pipeline.
-    See flink:vkCmdBindPipelineShaderGroupNV for further details.
+    See flink:vkCmdBindPipelineShaderGroupNV for further details
 ****
 
 include::{generated}/validity/structs/VkBindShaderGroupIndirectCommandNV.txt[]
@@ -267,9 +267,9 @@ include::{generated}/api/structs/VkBindIndexBufferIndirectCommandNV.txt[]
 ****
   * [[VUID-VkBindIndexBufferIndirectCommandNV-None-02946]]
     The buffer's usage flag from which the address was acquired must: have
-    the ename:VK_BUFFER_USAGE_INDEX_BUFFER_BIT bit set.
+    the ename:VK_BUFFER_USAGE_INDEX_BUFFER_BIT bit set
   * [[VUID-VkBindIndexBufferIndirectCommandNV-bufferAddress-02947]]
-    The pname:bufferAddress must: be aligned to the pname:indexType used.
+    The pname:bufferAddress must: be aligned to the pname:indexType used
   * [[VUID-VkBindIndexBufferIndirectCommandNV-None-02948]]
     Each element of the buffer from which the address was acquired and that
     is non-sparse must: be bound completely and contiguously to a single
@@ -302,7 +302,7 @@ include::{generated}/api/structs/VkBindVertexBufferIndirectCommandNV.txt[]
 ****
   * [[VUID-VkBindVertexBufferIndirectCommandNV-None-02949]]
     The buffer's usage flag from which the address was acquired must: have
-    the ename:VK_BUFFER_USAGE_VERTEX_BUFFER_BIT bit set.
+    the ename:VK_BUFFER_USAGE_VERTEX_BUFFER_BIT bit set
   * [[VUID-VkBindVertexBufferIndirectCommandNV-None-02950]]
     Each element of the buffer from which the address was acquired and that
     is non-sparse must: be bound completely and contiguously to a single
@@ -459,21 +459,21 @@ include::{generated}/api/structs/VkIndirectCommandsLayoutTokenNV.txt[]
 ****
   * [[VUID-VkIndirectCommandsLayoutTokenNV-stream-02951]]
     pname:stream must: be smaller than
-    sname:VkIndirectCommandsLayoutCreateInfoNV::pname:streamCount.
+    sname:VkIndirectCommandsLayoutCreateInfoNV::pname:streamCount
   * [[VUID-VkIndirectCommandsLayoutTokenNV-offset-02952]]
     pname:offset must: be less than or equal to
-    sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:maxIndirectCommandsTokenOffset.
+    sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:maxIndirectCommandsTokenOffset
   * [[VUID-VkIndirectCommandsLayoutTokenNV-vertexBindingUnit-02953]]
     pname:vertexBindingUnit must: stay within device supported limits for
-    the appropriate commands.
+    the appropriate commands
   * [[VUID-VkIndirectCommandsLayoutTokenNV-pushconstantOffset-02954]]
     pname:pushconstantOffset must: stay within device supported limits for
-    the appropriate commands.
+    the appropriate commands
   * [[VUID-VkIndirectCommandsLayoutTokenNV-pushconstantSize-02955]]
     pname:pushconstantSize must: stay within device supported limits for the
-    appropriate commands.
+    appropriate commands
   * [[VUID-VkIndirectCommandsLayoutTokenNV-indirectStateFlags-02956]]
-    pname:indirectStateFlags must: not be ´0´.
+    pname:indirectStateFlags must: not be ´0´
 ****
 
 include::{generated}/validity/structs/VkIndirectCommandsLayoutTokenNV.txt[]

--- a/chapters/VK_NV_external_memory_win32/import_memory_win32.txt
+++ b/chapters/VK_NV_external_memory_win32/import_memory_win32.txt
@@ -22,10 +22,10 @@ slink:VkMemoryAllocateInfo structure it is chained from.
 .Valid Usage
 ****
   * [[VUID-VkImportMemoryWin32HandleInfoNV-handleType-01327]]
-    pname:handleType must: not have more than one bit set.
+    pname:handleType must: not have more than one bit set
   * [[VUID-VkImportMemoryWin32HandleInfoNV-handle-01328]]
     pname:handle must: be a valid handle to memory, obtained as specified by
-    pname:handleType.
+    pname:handleType
 ****
 
 include::{generated}/validity/structs/VkImportMemoryWin32HandleInfoNV.txt[]

--- a/chapters/VK_NV_ray_tracing/raytracing-host-rtas.txt
+++ b/chapters/VK_NV_ray_tracing/raytracing-host-rtas.txt
@@ -137,7 +137,7 @@ endif::VK_KHR_deferred_host_operations[]
 ****
   * [[VUID-vkCopyAccelerationStructureKHR-None-03440]]
     All sname:VkAccelerationStructureKHR objects referenced by this command
-    must: be bound to host-visible memory.
+    must: be bound to host-visible memory
   * [[VUID-vkCopyAccelerationStructureKHR-rayTracingHostAccelerationStructureCommands-03441]]
     the <<feature-raytracing-hostascmds,
     sname:VkPhysicalDeviceRayTracingFeaturesKHR->pname:rayTracingHostAccelerationStructureCommands>>
@@ -174,10 +174,10 @@ endif::VK_KHR_deferred_host_operations[]
 ****
   * [[VUID-vkCopyMemoryToAccelerationStructureKHR-None-03442]]
     All sname:VkAccelerationStructureKHR objects referenced by this command
-    must: be bound to host-visible memory.
+    must: be bound to host-visible memory
   * [[VUID-vkCopyMemoryToAccelerationStructureKHR-None-03443]]
     All sname:VkDeviceOrHostAddressConstKHR referenced by this command must:
-    contain valid host pointers.
+    contain valid host pointers
   * [[VUID-vkCopyMemoryToAccelerationStructureKHR-rayTracingHostAccelerationStructureCommands-03444]]
     the <<feature-raytracing-hostascmds,
     sname:VkPhysicalDeviceRayTracingFeaturesKHR->pname:rayTracingHostAccelerationStructureCommands>>
@@ -219,10 +219,10 @@ endif::VK_KHR_deferred_host_operations[]
 ****
   * [[VUID-vkCopyAccelerationStructureToMemoryKHR-None-03445]]
     All sname:VkAccelerationStructureKHR objects referenced by this command
-    must: be bound to host-visible memory.
+    must: be bound to host-visible memory
   * [[VUID-vkCopyAccelerationStructureToMemoryKHR-None-03446]]
     All sname:VkDeviceOrHostAddressKHR referenced by this command must:
-    contain valid host pointers.
+    contain valid host pointers
   * [[VUID-vkCopyAccelerationStructureToMemoryKHR-rayTracingHostAccelerationStructureCommands-03447]]
     the <<feature-raytracing-hostascmds,
     sname:VkPhysicalDeviceRayTracingFeaturesKHR->pname:rayTracingHostAccelerationStructureCommands>>

--- a/chapters/VK_NV_ray_tracing/raytracing-pipelines.txt
+++ b/chapters/VK_NV_ray_tracing/raytracing-pipelines.txt
@@ -150,7 +150,7 @@ ifdef::VK_EXT_pipeline_creation_cache_control[]
     pname:flags must: not include both
     ename:VK_PIPELINE_CREATE_DEFER_COMPILE_BIT_NV and
     ename:VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_EXT at
-    the same time.
+    the same time
 endif::VK_EXT_pipeline_creation_cache_control[]
 ****
 
@@ -566,7 +566,7 @@ endif::VK_NV_ray_tracing[]
 ****
   * [[VUID-vkGetRayTracingShaderGroupHandlesKHR-firstGroup-02419]]
     The sum of pname:firstGroup and pname:groupCount must: be less than the
-    number of shader groups in pname:pipeline.
+    number of shader groups in pname:pipeline
   * [[VUID-vkGetRayTracingShaderGroupHandlesKHR-dataSize-02420]]
     pname:dataSize must: be at least
     [eq]#slink:VkPhysicalDeviceRayTracingPropertiesKHR::pname:shaderGroupHandleSize
@@ -606,14 +606,14 @@ include::{generated}/api/protos/vkGetRayTracingCaptureReplayShaderGroupHandlesKH
 ****
   * [[VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-firstGroup-03483]]
     The sum of pname:firstGroup and pname:groupCount must: be less than the
-    number of shader groups in pname:pipeline.
+    number of shader groups in pname:pipeline
   * [[VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-dataSize-03484]]
     pname:dataSize must: be at least
     [eq]#slink:VkPhysicalDeviceRayTracingPropertiesKHR::pname:shaderGroupHandleCaptureReplaySize
     {times} pname:groupCount#
   * [[VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-rayTracingShaderGroupHandleCaptureReplay-03485]]
     sname:VkPhysicalDeviceRayTracingFeaturesKHR::pname:rayTracingShaderGroupHandleCaptureReplay
-    must: be enabled to call this function.
+    must: be enabled to call this function
 ****
 
 include::{generated}/validity/protos/vkGetRayTracingCaptureReplayShaderGroupHandlesKHR.txt[]

--- a/chapters/VK_NV_ray_tracing/raytracing.txt
+++ b/chapters/VK_NV_ray_tracing/raytracing.txt
@@ -757,7 +757,7 @@ include::{generated}/api/protos/vkCmdBuildAccelerationStructureNV.txt[]
     slink:VkAccelerationStructureInfoNV::pname:geometryCount for pname:dst
     are greater than or equal to the build size and each geometry in
     slink:VkAccelerationStructureInfoNV::pname:pGeometries for pname:dst has
-    greater than or equal to the number of vertices, indices, and AABBs.
+    greater than or equal to the number of vertices, indices, and AABBs
   * [[VUID-vkCmdBuildAccelerationStructureNV-update-02489]]
     If pname:update is ename:VK_TRUE, pname:src must: not be
     dlink:VK_NULL_HANDLE
@@ -892,7 +892,7 @@ ifdef::VK_KHR_deferred_host_operations[]
   * [[VUID-vkCmdBuildAccelerationStructureKHR-pNext-03532]]
     The slink:VkDeferredOperationInfoKHR structure must: not be included in
     the pname:pNext chain of any of the provided
-    slink:VkAccelerationStructureBuildGeometryInfoKHR structures.
+    slink:VkAccelerationStructureBuildGeometryInfoKHR structures
 endif::VK_KHR_deferred_host_operations[]
 ****
 
@@ -940,7 +940,7 @@ ifdef::VK_KHR_deferred_host_operations[]
   * [[VUID-vkCmdBuildAccelerationStructureIndirectKHR-pNext-03536]]
     The slink:VkDeferredOperationInfoKHR structure must: not be included in
     the pname:pNext chain of any of the provided
-    slink:VkAccelerationStructureBuildGeometryInfoKHR structures.
+    slink:VkAccelerationStructureBuildGeometryInfoKHR structures
 endif::VK_KHR_deferred_host_operations[]
 ****
 
@@ -1557,7 +1557,7 @@ ifdef::VK_KHR_deferred_host_operations[]
   * [[VUID-vkCmdCopyAccelerationStructureKHR-pNext-03557]]
     The slink:VkDeferredOperationInfoKHR structure must: not be included in
     the pname:pNext chain of the slink:VkCopyAccelerationStructureInfoKHR
-    structure.
+    structure
 endif::VK_KHR_deferred_host_operations[]
 ****
 
@@ -1665,7 +1665,7 @@ provide when deserializing.
 ****
   * [[VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03558]]
     All sname:VkDeviceOrHostAddressConstKHR referenced by this command must:
-    contain valid device addresses.
+    contain valid device addresses
   * [[VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559]]
     All sname:VkAccelerationStructureKHR objects referenced by this command
     must: be bound to device memory.
@@ -1673,7 +1673,7 @@ ifdef::VK_KHR_deferred_host_operations[]
   * [[VUID-vkCmdCopyAccelerationStructureToMemoryKHR-pNext-03560]]
     The slink:VkDeferredOperationInfoKHR structure must: not be included in
     the pname:pNext chain of the
-    slink:VkCopyAccelerationStructureToMemoryInfoKHR structure.
+    slink:VkCopyAccelerationStructureToMemoryInfoKHR structure
 endif::VK_KHR_deferred_host_operations[]
 include::{chapters}/commonvalidity/copy_acceleration_structure_to_buffer_common.txt[]
 ****
@@ -1731,7 +1731,7 @@ These do not need to be built at deserialize time, but must: be created.
 ****
   * [[VUID-vkCmdCopyMemoryToAccelerationStructureKHR-None-03562]]
     All sname:VkDeviceOrHostAddressKHR referenced by this command must:
-    contain valid device addresses.
+    contain valid device addresses
   * [[VUID-vkCmdCopyMemoryToAccelerationStructureKHR-None-03563]]
     All sname:VkAccelerationStructureKHR objects referenced by this command
     must: be bound to device memory.
@@ -1739,7 +1739,7 @@ ifdef::VK_KHR_deferred_host_operations[]
   * [[VUID-vkCmdCopyMemoryToAccelerationStructureKHR-pNext-03564]]
     The slink:VkDeferredOperationInfoKHR structure must: not be included in
     the pname:pNext chain of the
-    slink:VkCopyMemoryToAccelerationStructureInfoKHR structure.
+    slink:VkCopyMemoryToAccelerationStructureInfoKHR structure
 endif::VK_KHR_deferred_host_operations[]
 include::{chapters}/commonvalidity/copy_buffer_to_acceleration_structure_common.txt[]
 ****

--- a/chapters/capabilities.txt
+++ b/chapters/capabilities.txt
@@ -78,8 +78,8 @@ ifdef::VK_EXT_image_drm_format_modifier[]
 .Valid Usage
 ****
   * [[VUID-vkGetPhysicalDeviceImageFormatProperties-tiling-02248]]
-    pname:tiling must: not be ename:VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT.
-    (Use flink:vkGetPhysicalDeviceImageFormatProperties2 instead).
+    pname:tiling must: not be ename:VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT
+    (use flink:vkGetPhysicalDeviceImageFormatProperties2 instead)
 ****
 endif::VK_EXT_image_drm_format_modifier[]
 
@@ -218,7 +218,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     chain of pname:pImageFormatInfo must: include a
     slink:VkPhysicalDeviceExternalImageFormatInfo structure with
     pname:handleType set to
-    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID.
+    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID
 ****
 endif::VK_ANDROID_external_memory_android_hardware_buffer[]
 
@@ -265,12 +265,12 @@ ifdef::VK_EXT_image_drm_format_modifier[]
   * [[VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249]]
     pname:tiling must: be ename:VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT if
     and only if the pname:pNext chain includes
-    slink:VkPhysicalDeviceImageDrmFormatModifierInfoEXT.
+    slink:VkPhysicalDeviceImageDrmFormatModifierInfoEXT
   * [[VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02313]]
     If pname:tiling is ename:VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT and
     pname:flags contains ename:VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, then the
     pname:pNext chain must: include a slink:VkImageFormatListCreateInfo
-    structure with non-zero pname:viewFormatCount.
+    structure with non-zero pname:viewFormatCount
 ****
 endif::VK_EXT_image_drm_format_modifier[]
 
@@ -698,16 +698,16 @@ including unknown and invalid modifier values.
   * [[VUID-VkPhysicalDeviceImageDrmFormatModifierInfoEXT-sharingMode-02314]]
     If pname:sharingMode is ename:VK_SHARING_MODE_CONCURRENT, then
     pname:pQueueFamilyIndices must: be a valid pointer to an array of
-    pname:queueFamilyIndexCount code:uint32_t values.
+    pname:queueFamilyIndexCount code:uint32_t values
   * [[VUID-VkPhysicalDeviceImageDrmFormatModifierInfoEXT-sharingMode-02315]]
     If pname:sharingMode is ename:VK_SHARING_MODE_CONCURRENT, then
-    pname:queueFamilyIndexCount must: be greater than `1`.
+    pname:queueFamilyIndexCount must: be greater than `1`
   * [[VUID-VkPhysicalDeviceImageDrmFormatModifierInfoEXT-sharingMode-02316]]
     If pname:sharingMode is ename:VK_SHARING_MODE_CONCURRENT, each element
     of pname:pQueueFamilyIndices must: be unique and must: be less than the
     pname:pQueueFamilyPropertyCount returned by
     flink:vkGetPhysicalDeviceQueueFamilyProperties2 for the
-    pname:physicalDevice that was used to create pname:device.
+    pname:physicalDevice that was used to create pname:device
 ****
 
 include::{generated}/validity/structs/VkPhysicalDeviceImageDrmFormatModifierInfoEXT.txt[]
@@ -877,7 +877,7 @@ include::{generated}/validity/structs/VkFilterCubicImageViewImageFormatPropertie
     structure, the pname:pNext chain of the
     slink:VkPhysicalDeviceImageFormatInfo2 structure must: include a
     slink:VkPhysicalDeviceImageViewImageFormatInfoEXT structure with an
-    pname:imageViewType that is compatible with pname:imageType.
+    pname:imageViewType that is compatible with pname:imageType
 ****
 --
 

--- a/chapters/clears.txt
+++ b/chapters/clears.txt
@@ -49,7 +49,7 @@ pname:pColor.
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdClearColorImage-image-01993]]
     The <<resources-image-format-features,format features>> of pname:image
-    must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT.
+    must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdClearColorImage-image-00002]]
     pname:image must: have been created with
@@ -146,7 +146,7 @@ include::{generated}/api/protos/vkCmdClearDepthStencilImage.txt[]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdClearDepthStencilImage-image-01994]]
     The <<resources-image-format-features,format features>> of pname:image
-    must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT.
+    must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
 ifndef::VK_VERSION_1_2,VK_EXT_separate_stencil_usage[]
   * [[VUID-vkCmdClearDepthStencilImage-image-00009]]
@@ -297,7 +297,7 @@ ename:VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT stages.
     If the pname:aspectMask member of any element of pname:pAttachments
     contains ename:VK_IMAGE_ASPECT_COLOR_BIT, then the pname:colorAttachment
     member of that element must: either refer to a color attachment which is
-    ename:VK_ATTACHMENT_UNUSED, or must: be a valid color attachment.
+    ename:VK_ATTACHMENT_UNUSED, or must: be a valid color attachment
   * [[VUID-vkCmdClearAttachments-aspectMask-02502]]
     If the pname:aspectMask member of any element of pname:pAttachments
     contains ename:VK_IMAGE_ASPECT_DEPTH_BIT, then the current subpass'
@@ -326,15 +326,15 @@ ename:VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT stages.
 ifdef::VK_VERSION_1_1[]
   * [[VUID-vkCmdClearAttachments-commandBuffer-02504]]
     If pname:commandBuffer is an unprotected command buffer, then each
-    attachment to be cleared must: not be a protected image.
+    attachment to be cleared must: not be a protected image
   * [[VUID-vkCmdClearAttachments-commandBuffer-02505]]
     If pname:commandBuffer is a protected command buffer, then each
-    attachment to be cleared must: not be an unprotected image.
+    attachment to be cleared must: not be an unprotected image
 endif::VK_VERSION_1_1[]
 ifdef::VK_VERSION_1_1,VK_KHR_multiview[]
   * [[VUID-vkCmdClearAttachments-baseArrayLayer-00018]]
     If the render pass instance this is recorded in uses multiview, then
-    pname:baseArrayLayer must: be zero and pname:layerCount must: be one.
+    pname:baseArrayLayer must: be zero and pname:layerCount must: be one
 endif::VK_VERSION_1_1,VK_KHR_multiview[]
 ****
 
@@ -399,7 +399,7 @@ described for flink:vkCreateRenderPass.
 ifdef::VK_EXT_image_drm_format_modifier[]
   * [[VUID-VkClearAttachment-aspectMask-02246]]
     pname:aspectMask must: not include
-    etext:VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT for any index etext:i.
+    etext:VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT for any index etext:i
 endif::VK_EXT_image_drm_format_modifier[]
   * [[VUID-VkClearAttachment-clearValue-00021]]
     pname:clearValue must: be a valid sname:VkClearValue union

--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -176,7 +176,7 @@ include::{generated}/api/protos/vkCreateCommandPool.txt[]
 ****
   * [[VUID-vkCreateCommandPool-queueFamilyIndex-01937]]
     pname:pCreateInfo->queueFamilyIndex must: be the index of a queue family
-    available in the logical device pname:device.
+    available in the logical device pname:device
 ****
 
 include::{generated}/validity/protos/vkCreateCommandPool.txt[]
@@ -204,7 +204,7 @@ ifdef::VK_VERSION_1_1[]
   * [[VUID-VkCommandPoolCreateInfo-flags-02860]]
     If the protected memory feature is not enabled, the
     ename:VK_COMMAND_POOL_CREATE_PROTECTED_BIT bit of pname:flags must: not
-    be set.
+    be set
 endif::VK_VERSION_1_1[]
 ****
 
@@ -407,7 +407,7 @@ into it, becomes <<commandbuffers-lifecycle, invalid>>.
 ****
   * [[VUID-vkDestroyCommandPool-commandPool-00041]]
     All sname:VkCommandBuffer objects allocated from pname:commandPool must:
-    not be in the <<commandbuffers-lifecycle, pending state>>.
+    not be in the <<commandbuffers-lifecycle, pending state>>
   * [[VUID-vkDestroyCommandPool-commandPool-00042]]
     If sname:VkAllocationCallbacks were provided when pname:commandPool was
     created, a compatible set of callbacks must: be provided here
@@ -882,7 +882,7 @@ pass instance.
     pname:transform must: be VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
     VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR,
     VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR, or
-    VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR.
+    VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR
 ****
 
 include::{generated}/validity/structs/VkCommandBufferInheritanceRenderPassTransformInfoQCOM.txt[]
@@ -919,7 +919,7 @@ executable state>>.
 ****
   * [[VUID-vkEndCommandBuffer-commandBuffer-00059]]
     pname:commandBuffer must: be in the <<commandbuffers-lifecycle,
-    recording state>>.
+    recording state>>
   * [[VUID-vkEndCommandBuffer-commandBuffer-00060]]
     If pname:commandBuffer is a primary command buffer, there must: not be
     an active render pass instance
@@ -936,14 +936,14 @@ ifdef::VK_EXT_debug_utils[]
     If pname:commandBuffer is a secondary command buffer, there must: not be
     an outstanding flink:vkCmdBeginDebugUtilsLabelEXT command recorded to
     pname:commandBuffer that has not previously been ended by a call to
-    flink:vkCmdEndDebugUtilsLabelEXT.
+    flink:vkCmdEndDebugUtilsLabelEXT
 endif::VK_EXT_debug_utils[]
 ifdef::VK_EXT_debug_marker[]
   * [[VUID-vkEndCommandBuffer-commandBuffer-00062]]
     If pname:commandBuffer is a secondary command buffer, there must: not be
     an outstanding flink:vkCmdDebugMarkerBeginEXT command recorded to
     pname:commandBuffer that has not previously been ended by a call to
-    flink:vkCmdDebugMarkerEndEXT.
+    flink:vkCmdDebugMarkerEndEXT
 endif::VK_EXT_debug_marker[]
 ****
 
@@ -1216,7 +1216,7 @@ ifdef::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     value which does not differ from the current value of the semaphore or
     the value of any outstanding semaphore wait or signal operation on that
     semaphore by more than <<limits-maxTimelineSemaphoreValueDifference,
-    pname:maxTimelineSemaphoreValueDifference>>.
+    pname:maxTimelineSemaphoreValueDifference>>
   * [[VUID-VkSubmitInfo-pSignalSemaphores-03244]]
     For each element of pname:pSignalSemaphores created with a
     elink:VkSemaphoreType of ename:VK_SEMAPHORE_TYPE_TIMELINE the
@@ -1225,7 +1225,7 @@ ifdef::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     value which does not differ from the current value of the semaphore or
     the value of any outstanding semaphore wait or signal operation on that
     semaphore by more than <<limits-maxTimelineSemaphoreValueDifference,
-    pname:maxTimelineSemaphoreValueDifference>>.
+    pname:maxTimelineSemaphoreValueDifference>>
 endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
 ifdef::VK_NV_mesh_shader[]
   * [[VUID-VkSubmitInfo-pWaitDstStageMask-02089]]
@@ -1346,12 +1346,12 @@ endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     pname:waitSemaphoreValuesCount must: be the same value as
     sname:VkSubmitInfo::pname:waitSemaphoreCount, where sname:VkSubmitInfo
     is in the pname:pNext chain of this sname:VkD3D12FenceSubmitInfoKHR
-    structure.
+    structure
   * [[VUID-VkD3D12FenceSubmitInfoKHR-signalSemaphoreValuesCount-00080]]
     pname:signalSemaphoreValuesCount must: be the same value as
     sname:VkSubmitInfo::pname:signalSemaphoreCount, where sname:VkSubmitInfo
     is in the pname:pNext chain of this sname:VkD3D12FenceSubmitInfoKHR
-    structure.
+    structure
 ****
 
 include::{generated}/validity/structs/VkD3D12FenceSubmitInfoKHR.txt[]
@@ -1407,7 +1407,7 @@ include::{generated}/api/structs/VkWin32KeyedMutexAcquireReleaseInfoKHR.txt[]
     device memory object imported by setting
     slink:VkImportMemoryWin32HandleInfoKHR::pname:handleType to
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT or
-    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT.
+    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT
 ****
 
 include::{generated}/validity/structs/VkWin32KeyedMutexAcquireReleaseInfoKHR.txt[]
@@ -1441,18 +1441,18 @@ include::{generated}/api/structs/VkProtectedSubmitInfo.txt[]
 ****
   * [[VUID-VkProtectedSubmitInfo-protectedSubmit-01816]]
     If the protected memory feature is not enabled, pname:protectedSubmit
-    must: not be ename:VK_TRUE.
+    must: not be ename:VK_TRUE
   * [[VUID-VkProtectedSubmitInfo-protectedSubmit-01817]]
     If pname:protectedSubmit is ename:VK_TRUE, then each element of the
-    pname:pCommandBuffers array must: be a protected command buffer.
+    pname:pCommandBuffers array must: be a protected command buffer
   * [[VUID-VkProtectedSubmitInfo-protectedSubmit-01818]]
     If pname:protectedSubmit is ename:VK_FALSE, then each element of the
-    pname:pCommandBuffers array must: be an unprotected command buffer.
+    pname:pCommandBuffers array must: be an unprotected command buffer
   * [[VUID-VkProtectedSubmitInfo-pNext-01819]]
     If the sname:VkSubmitInfo::pname:pNext chain does not include a
     sname:VkProtectedSubmitInfo structure, then each element of the command
     buffer of the pname:pCommandBuffers array must: be an unprotected
-    command buffer.
+    command buffer
 ****
 
 include::{generated}/validity/structs/VkProtectedSubmitInfo.txt[]
@@ -1866,12 +1866,12 @@ beginning the corresponding render pass instance.
   * [[VUID-vkCmdSetDeviceMask-deviceMask-00110]]
     pname:deviceMask must: not include any set bits that were not in the
     slink:VkDeviceGroupCommandBufferBeginInfo::pname:deviceMask value when
-    the command buffer began recording.
+    the command buffer began recording
   * [[VUID-vkCmdSetDeviceMask-deviceMask-00111]]
     If fname:vkCmdSetDeviceMask is called inside a render pass instance,
     pname:deviceMask must: not include any set bits that were not in the
     slink:VkDeviceGroupRenderPassBeginInfo::pname:deviceMask value when the
-    render pass instance began recording.
+    render pass instance began recording
 ****
 
 include::{generated}/validity/protos/vkCmdSetDeviceMask.txt[]

--- a/chapters/commonvalidity/build_acceleration_structure_common.txt
+++ b/chapters/commonvalidity/build_acceleration_structure_common.txt
@@ -25,7 +25,7 @@
     for pname:dstAccelerationStructure has greater than or equal to the
     number of vertices, indices, and AABBs,
     slink:VkAccelerationStructureGeometryTrianglesDataKHR::pname:transformData
-    is both 0 or both non-zero, and all other parameters are the same.
+    is both 0 or both non-zero, and all other parameters are the same
   * [[VUID-{refpage}-pInfos-03405]]
     For each pname:pInfos[i], if pname:update is ename:VK_TRUE, then objects
     that were previously active for that acceleration structure must: not be

--- a/chapters/commonvalidity/create_ray_tracing_pipelines_common.txt
+++ b/chapters/commonvalidity/create_ray_tracing_pipelines_common.txt
@@ -16,6 +16,6 @@ ifdef::VK_EXT_pipeline_creation_cache_control[]
     If pname:pipelineCache was created with
     ename:VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT, host
     access to pname:pipelineCache must: be
-    <<fundamentals-threadingbehavior,externally synchronized>>.
+    <<fundamentals-threadingbehavior,externally synchronized>>
 endif::VK_EXT_pipeline_creation_cache_control[]
 // Common Valid Usage

--- a/chapters/commonvalidity/draw_common.txt
+++ b/chapters/commonvalidity/draw_common.txt
@@ -5,12 +5,12 @@ include::draw_dispatch_common.txt[]
     The current render pass must: be <<renderpass-compatibility,compatible>>
     with the pname:renderPass member of the
     sname:VkGraphicsPipelineCreateInfo structure specified when creating the
-    sname:VkPipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS.
+    sname:VkPipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
   * [[VUID-{refpage}-subpass-02685]]
     The subpass index of the current render pass must: be equal to the
     pname:subpass member of the sname:VkGraphicsPipelineCreateInfo structure
     specified when creating the sname:VkPipeline bound to
-    ename:VK_PIPELINE_BIND_POINT_GRAPHICS.
+    ename:VK_PIPELINE_BIND_POINT_GRAPHICS
   * [[VUID-{refpage}-None-02686]]
     Every input attachment used by the current subpass must: be bound to the
     pipeline via a descriptor set
@@ -21,7 +21,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_multiview[]
   * [[VUID-{refpage}-maxMultiviewInstanceIndex-02688]]
     If the draw is recorded in a render pass instance with multiview
     enabled, the maximum instance index must: be less than or equal to
-    slink:VkPhysicalDeviceMultiviewProperties::pname:maxMultiviewInstanceIndex.
+    slink:VkPhysicalDeviceMultiviewProperties::pname:maxMultiviewInstanceIndex
 endif::VK_VERSION_1_1,VK_KHR_multiview[]
 ifdef::VK_EXT_sample_locations[]
   * [[VUID-{refpage}-sampleLocationsEnable-02689]]

--- a/chapters/commonvalidity/draw_dispatch_common.txt
+++ b/chapters/commonvalidity/draw_dispatch_common.txt
@@ -46,7 +46,7 @@ ifdef::VK_NV_corner_sampled_image[]
     containing ename:VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV sampled as a
     result of this command must: only be sampled using a
     elink:VkSamplerAddressMode of
-    ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE.
+    ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE
 endif::VK_NV_corner_sampled_image[]
   * [[VUID-{refpage}-None-02697]]
     For each set _n_ that is statically used by the sname:VkPipeline bound

--- a/chapters/commonvalidity/performance_query_begin_common.txt
+++ b/chapters/commonvalidity/performance_query_begin_common.txt
@@ -32,6 +32,6 @@ ifdef::VK_KHR_performance_query[]
     ename:VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR, this command must: not be
     recorded in a command buffer that, either directly or through secondary
     command buffers, also contains a fname:vkCmdResetQueryPool command
-    affecting the same query.
+    affecting the same query
 endif::VK_KHR_performance_query[]
 // Common Valid Usage

--- a/chapters/copies.txt
+++ b/chapters/copies.txt
@@ -349,7 +349,7 @@ images, but both images must: have the same number of samples.
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdCopyImage-srcImage-01995]]
     The <<resources-image-format-features,format features>> of
-    pname:srcImage must: contain ename:VK_FORMAT_FEATURE_TRANSFER_SRC_BIT.
+    pname:srcImage must: contain ename:VK_FORMAT_FEATURE_TRANSFER_SRC_BIT
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdCopyImage-srcImage-00126]]
     pname:srcImage must: have been created with
@@ -384,7 +384,7 @@ endif::VK_KHR_shared_presentable_image[]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdCopyImage-dstImage-01996]]
     The <<resources-image-format-features,format features>> of
-    pname:dstImage must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT.
+    pname:dstImage must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdCopyImage-dstImage-00131]]
     pname:dstImage must: have been created with
@@ -622,7 +622,7 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-VkImageCopy-srcImage-00146]]
     If the calling command's pname:srcImage is of type
     ename:VK_IMAGE_TYPE_1D, then pname:srcOffset.y must: be `0` and
-    pname:extent.height must: be `1`.
+    pname:extent.height must: be `1`
   * [[VUID-VkImageCopy-srcOffset-00147]]
     pname:srcOffset.z and [eq]#(pname:extent.depth {plus}
     pname:srcOffset.z)# must: both be greater than or equal to `0` and less
@@ -630,36 +630,36 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-VkImageCopy-srcImage-01785]]
     If the calling command's pname:srcImage is of type
     ename:VK_IMAGE_TYPE_1D, then pname:srcOffset.z must: be `0` and
-    pname:extent.depth must: be `1`.
+    pname:extent.depth must: be `1`
   * [[VUID-VkImageCopy-dstImage-01786]]
     If the calling command's pname:dstImage is of type
     ename:VK_IMAGE_TYPE_1D, then pname:dstOffset.z must: be `0` and
-    pname:extent.depth must: be `1`.
+    pname:extent.depth must: be `1`
   * [[VUID-VkImageCopy-srcImage-01787]]
     If the calling command's pname:srcImage is of type
-    ename:VK_IMAGE_TYPE_2D, then pname:srcOffset.z must: be `0`.
+    ename:VK_IMAGE_TYPE_2D, then pname:srcOffset.z must: be `0`
   * [[VUID-VkImageCopy-dstImage-01788]]
     If the calling command's pname:dstImage is of type
     ename:VK_IMAGE_TYPE_2D, then pname:dstOffset.z must: be `0`.
 ifndef::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-VkImageCopy-srcImage-01789]]
     If the calling command's pname:srcImage or pname:dstImage is of type
-    ename:VK_IMAGE_TYPE_2D, then pname:extent.depth must: be `1`.
+    ename:VK_IMAGE_TYPE_2D, then pname:extent.depth must: be `1`
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-VkImageCopy-srcImage-01790]]
     If both pname:srcImage and pname:dstImage are of type
-    ename:VK_IMAGE_TYPE_2D then pname:extent.depth must: be `1`.
+    ename:VK_IMAGE_TYPE_2D then pname:extent.depth must: be `1`
   * [[VUID-VkImageCopy-srcImage-01791]]
     If the calling command's pname:srcImage is of type
     ename:VK_IMAGE_TYPE_2D, and the pname:dstImage is of type
     ename:VK_IMAGE_TYPE_3D, then pname:extent.depth must: equal to the
-    pname:layerCount member of pname:srcSubresource.
+    pname:layerCount member of pname:srcSubresource
   * [[VUID-VkImageCopy-dstImage-01792]]
     If the calling command's pname:dstImage is of type
     ename:VK_IMAGE_TYPE_2D, and the pname:srcImage is of type
     ename:VK_IMAGE_TYPE_3D, then pname:extent.depth must: equal to the
-    pname:layerCount member of pname:dstSubresource.
+    pname:layerCount member of pname:dstSubresource
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-VkImageCopy-dstOffset-00150]]
     pname:dstOffset.x and [eq]#(pname:extent.width {plus}
@@ -672,7 +672,7 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-VkImageCopy-dstImage-00152]]
     If the calling command's pname:dstImage is of type
     ename:VK_IMAGE_TYPE_1D, then pname:dstOffset.y must: be `0` and
-    pname:extent.height must: be `1`.
+    pname:extent.height must: be `1`
   * [[VUID-VkImageCopy-dstOffset-00153]]
     pname:dstOffset.z and [eq]#(pname:extent.depth {plus}
     pname:dstOffset.z)# must: both be greater than or equal to `0` and less
@@ -815,7 +815,7 @@ include::{generated}/api/structs/VkImageSubresourceLayers.txt[]
 ifdef::VK_EXT_image_drm_format_modifier[]
   * [[VUID-VkImageSubresourceLayers-aspectMask-02247]]
     pname:aspectMask must: not include
-    etext:VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT for any index etext:i.
+    etext:VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT for any index etext:i
 endif::VK_EXT_image_drm_format_modifier[]
   * [[VUID-VkImageSubresourceLayers-layerCount-01700]]
     pname:layerCount must: be greater than 0
@@ -890,7 +890,7 @@ endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdCopyBufferToImage-dstImage-01997]]
     The <<resources-image-format-features,format features>> of
-    pname:dstImage must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT.
+    pname:dstImage must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdCopyBufferToImage-srcBuffer-00176]]
     If pname:srcBuffer is non-sparse then it must: be bound completely and
@@ -1014,7 +1014,7 @@ endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdCopyImageToBuffer-srcImage-01998]]
     The <<resources-image-format-features,format features>> of
-    pname:srcImage must: contain ename:VK_FORMAT_FEATURE_TRANSFER_SRC_BIT.
+    pname:srcImage must: contain ename:VK_FORMAT_FEATURE_TRANSFER_SRC_BIT
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-vkCmdCopyImageToBuffer-srcImage-00186]]
     pname:srcImage must: have been created with
@@ -1152,14 +1152,14 @@ ifndef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-VkBufferImageCopy-bufferOffset-00193]]
     If the calling command's sname:VkImage parameter's format is not a
     depth/stencil format, then pname:bufferOffset must: be a multiple of the
-    format's texel block size.
+    format's texel block size
 endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
 ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-VkBufferImageCopy-bufferOffset-01558]]
     If the calling command's sname:VkImage parameter's format is not a
     depth/stencil format or a
     <<formats-requiring-sampler-ycbcr-conversion,multi-planar format>>, then
-    pname:bufferOffset must: be a multiple of the format's texel block size.
+    pname:bufferOffset must: be a multiple of the format's texel block size
   * [[VUID-VkBufferImageCopy-bufferOffset-01559]]
     If the calling command's sname:VkImage parameter's format is a
     <<formats-requiring-sampler-ycbcr-conversion,multi-planar format>>, then
@@ -1197,7 +1197,7 @@ endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
     If the calling command's pname:srcImage (flink:vkCmdCopyImageToBuffer)
     or pname:dstImage (flink:vkCmdCopyBufferToImage) is of type
     ename:VK_IMAGE_TYPE_1D, then pname:imageOffset.y must: be `0` and
-    pname:imageExtent.height must: be `1`.
+    pname:imageExtent.height must: be `1`
   * [[VUID-VkBufferImageCopy-imageOffset-00200]]
     pname:imageOffset.z and [eq]#(imageExtent.depth {plus}
     pname:imageOffset.z)# must: both be greater than or equal to `0` and
@@ -1621,7 +1621,7 @@ ifdef::VK_IMG_filter_cubic,VK_EXT_filter_cubic[]
     If pname:filter is ename:VK_FILTER_CUBIC_EXT, then the
     <<resources-image-format-features,format features>> of pname:srcImage
     must: contain
-    ename:VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT.
+    ename:VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT
   * [[VUID-vkCmdBlitImage-filter-00237]]
     If pname:filter is ename:VK_FILTER_CUBIC_EXT, pname:srcImage must: have
     a elink:VkImageType of ename:VK_IMAGE_TYPE_2D
@@ -1715,7 +1715,7 @@ the specified source and destination regions.
   * [[VUID-VkImageBlit-srcImage-00245]]
     If the calling command's pname:srcImage is of type
     ename:VK_IMAGE_TYPE_1D, then pname:srcOffset[0].y must: be `0` and
-    pname:srcOffset[1].y must: be `1`.
+    pname:srcOffset[1].y must: be `1`
   * [[VUID-VkImageBlit-srcOffset-00246]]
     pname:srcOffset[0].z and pname:srcOffset[1].z must: both be greater than
     or equal to `0` and less than or equal to the source image subresource
@@ -1723,7 +1723,7 @@ the specified source and destination regions.
   * [[VUID-VkImageBlit-srcImage-00247]]
     If the calling command's pname:srcImage is of type
     ename:VK_IMAGE_TYPE_1D or ename:VK_IMAGE_TYPE_2D, then
-    pname:srcOffset[0].z must: be `0` and pname:srcOffset[1].z must: be `1`.
+    pname:srcOffset[0].z must: be `0` and pname:srcOffset[1].z must: be `1`
   * [[VUID-VkImageBlit-dstOffset-00248]]
     pname:dstOffset[0].x and pname:dstOffset[1].x must: both be greater than
     or equal to `0` and less than or equal to the destination image
@@ -1735,7 +1735,7 @@ the specified source and destination regions.
   * [[VUID-VkImageBlit-dstImage-00250]]
     If the calling command's pname:dstImage is of type
     ename:VK_IMAGE_TYPE_1D, then pname:dstOffset[0].y must: be `0` and
-    pname:dstOffset[1].y must: be `1`.
+    pname:dstOffset[1].y must: be `1`
   * [[VUID-VkImageBlit-dstOffset-00251]]
     pname:dstOffset[0].z and pname:dstOffset[1].z must: both be greater than
     or equal to `0` and less than or equal to the destination image
@@ -1743,7 +1743,7 @@ the specified source and destination regions.
   * [[VUID-VkImageBlit-dstImage-00252]]
     If the calling command's pname:dstImage is of type
     ename:VK_IMAGE_TYPE_1D or ename:VK_IMAGE_TYPE_2D, then
-    pname:dstOffset[0].z must: be `0` and pname:dstOffset[1].z must: be `1`.
+    pname:dstOffset[0].z must: be `0` and pname:dstOffset[1].z must: be `1`
 ****
 
 include::{generated}/validity/structs/VkImageBlit.txt[]
@@ -1848,7 +1848,7 @@ endif::VK_KHR_shared_presentable_image[]
   * [[VUID-vkCmdResolveImage-dstImage-02003]]
     The <<resources-image-format-features,format features>> of
     pname:dstImage must: contain
-    ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT.
+    ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT
   * [[VUID-vkCmdResolveImage-srcImage-01386]]
     pname:srcImage and pname:dstImage must: have been created with the same
     image format
@@ -1934,7 +1934,7 @@ include::{generated}/api/structs/VkImageResolve.txt[]
   * [[VUID-VkImageResolve-srcImage-00271]]
     If the calling command's pname:srcImage is of type
     ename:VK_IMAGE_TYPE_1D, then pname:srcOffset.y must: be `0` and
-    pname:extent.height must: be `1`.
+    pname:extent.height must: be `1`
   * [[VUID-VkImageResolve-srcOffset-00272]]
     pname:srcOffset.z and [eq]#(pname:extent.depth {plus}
     pname:srcOffset.z)# must: both be greater than or equal to `0` and less
@@ -1942,7 +1942,7 @@ include::{generated}/api/structs/VkImageResolve.txt[]
   * [[VUID-VkImageResolve-srcImage-00273]]
     If the calling command's pname:srcImage is of type
     ename:VK_IMAGE_TYPE_1D or ename:VK_IMAGE_TYPE_2D, then pname:srcOffset.z
-    must: be `0` and pname:extent.depth must: be `1`.
+    must: be `0` and pname:extent.depth must: be `1`
   * [[VUID-VkImageResolve-dstOffset-00274]]
     pname:dstOffset.x and [eq]#(pname:extent.width {plus}
     pname:dstOffset.x)# must: both be greater than or equal to `0` and less
@@ -1954,7 +1954,7 @@ include::{generated}/api/structs/VkImageResolve.txt[]
   * [[VUID-VkImageResolve-dstImage-00276]]
     If the calling command's pname:dstImage is of type
     ename:VK_IMAGE_TYPE_1D, then pname:dstOffset.y must: be `0` and
-    pname:extent.height must: be `1`.
+    pname:extent.height must: be `1`
   * [[VUID-VkImageResolve-dstOffset-00277]]
     pname:dstOffset.z and [eq]#(pname:extent.depth {plus}
     pname:dstOffset.z)# must: both be greater than or equal to `0` and less
@@ -1962,7 +1962,7 @@ include::{generated}/api/structs/VkImageResolve.txt[]
   * [[VUID-VkImageResolve-dstImage-00278]]
     If the calling command's pname:dstImage is of type
     ename:VK_IMAGE_TYPE_1D or ename:VK_IMAGE_TYPE_2D, then pname:dstOffset.z
-    must: be `0` and pname:extent.depth must: be `1`.
+    must: be `0` and pname:extent.depth must: be `1`
 ****
 
 include::{generated}/validity/structs/VkImageResolve.txt[]

--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -2362,7 +2362,7 @@ ignored.
     If slink:VkDescriptorSetAllocateInfo::pname:pSetLayouts[i] has a
     variable descriptor count binding, then pname:pDescriptorCounts[i] must:
     be less than or equal to the descriptor count specified for that binding
-    when the descriptor set layout was created.
+    when the descriptor set layout was created
 ****
 
 include::{generated}/validity/structs/VkDescriptorSetVariableDescriptorCountAllocateInfo.txt[]
@@ -2496,7 +2496,7 @@ ifndef::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
     The pname:dstSet member of each element of pname:pDescriptorWrites or
     pname:pDescriptorCopies must: not be used by any command that was
     recorded to a command buffer which is in the <<commandbuffers-lifecycle,
-    pending state>>.
+    pending state>>
 endif::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
 ifdef::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
   * [[VUID-vkUpdateDescriptorSets-None-03047]]
@@ -2504,7 +2504,7 @@ ifdef::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
     the ename:VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT or
     ename:VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT bits set
     must: not be used by any command that was recorded to a command buffer
-    which is in the <<commandbuffers-lifecycle,pending state>>.
+    which is in the <<commandbuffers-lifecycle,pending state>>
 endif::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
 ****
 
@@ -2623,11 +2623,11 @@ endif::VK_EXT_inline_uniform_block[]
   * [[VUID-VkWriteDescriptorSet-descriptorCount-00317]]
     All consecutive bindings updated via a single sname:VkWriteDescriptorSet
     structure, except those with a pname:descriptorCount of zero, must: have
-    identical pname:descriptorType and pname:stageFlags.
+    identical pname:descriptorType and pname:stageFlags
   * [[VUID-VkWriteDescriptorSet-descriptorCount-00318]]
     All consecutive bindings updated via a single sname:VkWriteDescriptorSet
     structure, except those with a pname:descriptorCount of zero, must: all
-    either use immutable samplers or must: all not use immutable samplers.
+    either use immutable samplers or must: all not use immutable samplers
   * [[VUID-VkWriteDescriptorSet-descriptorType-00319]]
     pname:descriptorType must: match the type of pname:dstBinding within
     pname:dstSet
@@ -2808,7 +2808,7 @@ ifdef::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
   * [[VUID-VkWriteDescriptorSet-descriptorCount-03048]]
     All consecutive bindings updated via a single sname:VkWriteDescriptorSet
     structure, except those with a pname:descriptorCount of zero, must: have
-    identical elink:VkDescriptorBindingFlagBits.
+    identical elink:VkDescriptorBindingFlagBits
 endif::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
   * [[VUID-VkWriteDescriptorSet-descriptorType-02752]]
     If pname:descriptorType is ename:VK_DESCRIPTOR_TYPE_SAMPLER, then
@@ -2986,7 +2986,7 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
     If pname:imageView is created from a depth/stencil image, the
     pname:aspectMask used to create the pname:imageView must: include either
     ename:VK_IMAGE_ASPECT_DEPTH_BIT or ename:VK_IMAGE_ASPECT_STENCIL_BIT but
-    not both.
+    not both
   * [[VUID-VkDescriptorImageInfo-imageLayout-00344]]
     pname:imageLayout must: match the actual elink:VkImageLayout of each
     subresource accessible from pname:imageView at the time this descriptor
@@ -3446,7 +3446,7 @@ endif::VK_EXT_inline_uniform_block[]
   * [[VUID-VkDescriptorUpdateTemplateEntry-dstBinding-00354]]
     pname:dstBinding must: be a valid binding in the descriptor set layout
     implicitly specified when using a descriptor update template to update
-    descriptors.
+    descriptors
   * [[VUID-VkDescriptorUpdateTemplateEntry-dstArrayElement-00355]]
     pname:dstArrayElement and pname:descriptorCount must: be less than or
     equal to the number of array elements in the descriptor set binding

--- a/chapters/devsandqueues.txt
+++ b/chapters/devsandqueues.txt
@@ -1029,7 +1029,7 @@ ename:VK_ERROR_TOO_MANY_OBJECTS.
     All <<extendingvulkan-extensions-extensiondependencies, required
     extensions>> for each extension in the
     slink:VkDeviceCreateInfo::pname:ppEnabledExtensionNames list must: also
-    be present in that list.
+    be present in that list
 ****
 
 include::{generated}/validity/protos/vkCreateDevice.txt[]
@@ -1239,7 +1239,7 @@ In particular, the device index of that physical device is zero.
   * [[VUID-VkDeviceGroupDeviceCreateInfo-physicalDeviceCount-00377]]
     If pname:physicalDeviceCount is not `0`, the pname:physicalDevice
     parameter of flink:vkCreateDevice must: be an element of
-    pname:pPhysicalDevices.
+    pname:pPhysicalDevices
 ****
 
 include::{generated}/validity/structs/VkDeviceGroupDeviceCreateInfo.txt[]
@@ -1640,7 +1640,7 @@ ifdef::VK_VERSION_1_1[]
   * [[VUID-VkDeviceQueueCreateInfo-flags-02861]]
     If the <<features-protectedMemory, protected memory>> feature is not
     enabled, the ename:VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT bit of
-    pname:flags must: not be set.
+    pname:flags must: not be set
 endif::VK_VERSION_1_1[]
 ****
 

--- a/chapters/dispatch.txt
+++ b/chapters/dispatch.txt
@@ -187,7 +187,7 @@ include::{chapters}/commonvalidity/draw_dispatch_common.txt[]
   * [[VUID-vkCmdDispatchBase-baseGroupX-00427]]
     If any of pname:baseGroupX, pname:baseGroupY, or pname:baseGroupZ are
     not zero, then the bound compute pipeline must: have been created with
-    the ename:VK_PIPELINE_CREATE_DISPATCH_BASE flag.
+    the ename:VK_PIPELINE_CREATE_DISPATCH_BASE flag
 ****
 
 include::{generated}/validity/protos/vkCmdDispatchBase.txt[]

--- a/chapters/drawing.txt
+++ b/chapters/drawing.txt
@@ -556,7 +556,7 @@ include::{generated}/api/protos/vkCmdBindIndexBuffer.txt[]
     contiguously to a single sname:VkDeviceMemory object
 ifdef::VK_NV_ray_tracing,VK_KHR_ray_tracing[]
   * [[VUID-vkCmdBindIndexBuffer-indexType-02507]]
-    pname:indexType must: not be ename:VK_INDEX_TYPE_NONE_KHR.
+    pname:indexType must: not be ename:VK_INDEX_TYPE_NONE_KHR
 endif::VK_NV_ray_tracing,VK_KHR_ray_tracing[]
 ifdef::VK_EXT_index_type_uint8[]
   * [[VUID-vkCmdBindIndexBuffer-indexType-02765]]
@@ -1216,7 +1216,7 @@ command.
     ename:VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT bit set
   * [[VUID-VkConditionalRenderingBeginInfoEXT-offset-01983]]
     pname:offset must: be less than the size of pname:buffer by at least 32
-    bits.
+    bits
   * [[VUID-VkConditionalRenderingBeginInfoEXT-offset-01984]]
     pname:offset must: be a multiple of 4
 ****

--- a/chapters/features.txt
+++ b/chapters/features.txt
@@ -1001,7 +1001,7 @@ pname:pNext chain of slink:VkDeviceCreateInfo to enable the features.
 ****
   * [[VUID-VkPhysicalDeviceVariablePointersFeatures-variablePointers-01431]]
     If pname:variablePointers is enabled then
-    pname:variablePointersStorageBuffer must: also be enabled.
+    pname:variablePointersStorageBuffer must: also be enabled
 ****
 
 include::{generated}/validity/structs/VkPhysicalDeviceVariablePointersFeatures.txt[]
@@ -1057,10 +1057,10 @@ pname:pNext chain of slink:VkDeviceCreateInfo to enable the features.
 ****
   * [[VUID-VkPhysicalDeviceMultiviewFeatures-multiviewGeometryShader-00580]]
     If pname:multiviewGeometryShader is enabled then pname:multiview must:
-    also be enabled.
+    also be enabled
   * [[VUID-VkPhysicalDeviceMultiviewFeatures-multiviewTessellationShader-00581]]
     If pname:multiviewTessellationShader is enabled then pname:multiview
-    must: also be enabled.
+    must: also be enabled
 ****
 
 include::{generated}/validity/structs/VkPhysicalDeviceMultiviewFeatures.txt[]

--- a/chapters/fragops.txt
+++ b/chapters/fragops.txt
@@ -418,7 +418,7 @@ values determining the size in pixels.
 ****
   * [[VUID-vkCmdSetExclusiveScissorNV-None-02031]]
     The <<features-exclusiveScissor,exclusive scissor>> feature must: be
-    enabled.
+    enabled
   * [[VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02033]]
     pname:firstExclusiveScissor must: be less than
     sname:VkPhysicalDeviceLimits::pname:maxViewports

--- a/chapters/framebuffer.txt
+++ b/chapters/framebuffer.txt
@@ -168,13 +168,13 @@ ifdef::VK_EXT_blend_operation_advanced[]
     slink:VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT::pname:advancedBlendIndependentBlend
     is ename:VK_FALSE and pname:colorBlendOp is an
     <<framebuffer-blend-advanced,advanced blend operation>>, then
-    pname:colorBlendOp must: be the same for all attachments.
+    pname:colorBlendOp must: be the same for all attachments
   * [[VUID-VkPipelineColorBlendAttachmentState-advancedBlendIndependentBlend-01408]]
     If
     slink:VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT::pname:advancedBlendIndependentBlend
     is ename:VK_FALSE and pname:alphaBlendOp is an
     <<framebuffer-blend-advanced,advanced blend operation>>, then
-    pname:alphaBlendOp must: be the same for all attachments.
+    pname:alphaBlendOp must: be the same for all attachments
   * [[VUID-VkPipelineColorBlendAttachmentState-advancedBlendAllOperations-01409]]
     If
     slink:VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT::pname:advancedBlendAllOperations

--- a/chapters/fxvertex.txt
+++ b/chapters/fxvertex.txt
@@ -520,10 +520,10 @@ then the divisor has a logical default value of 1.
   * [[VUID-VkVertexInputBindingDivisorDescriptionEXT-divisor-01870]]
     pname:divisor must: be a value between `0` and
     sname:VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT::pname:maxVertexAttribDivisor,
-    inclusive.
+    inclusive
   * [[VUID-VkVertexInputBindingDivisorDescriptionEXT-inputRate-01871]]
     slink:VkVertexInputBindingDescription::pname:inputRate must: be of type
-    ename:VK_VERTEX_INPUT_RATE_INSTANCE for this pname:binding.
+    ename:VK_VERTEX_INPUT_RATE_INSTANCE for this pname:binding
 ****
 
 include::{generated}/validity/structs/VkVertexInputBindingDivisorDescriptionEXT.txt[]

--- a/chapters/initialization.txt
+++ b/chapters/initialization.txt
@@ -251,7 +251,7 @@ creation to succeed.
     All <<extendingvulkan-extensions-extensiondependencies, required
     extensions>> for each extension in the
     slink:VkInstanceCreateInfo::pname:ppEnabledExtensionNames list must:
-    also be present in that list.
+    also be present in that list
 ****
 
 include::{generated}/validity/protos/vkCreateInstance.txt[]

--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -1036,7 +1036,7 @@ endif::VK_AMD_memory_overallocation_behavior[]
     where `memindex` =
     slink:VkPhysicalDeviceMemoryProperties::pname:memoryTypes[pAllocateInfo\->memoryTypeIndex].heapIndex
     as returned by flink:vkGetPhysicalDeviceMemoryProperties for the
-    slink:VkPhysicalDevice that pname:device was created from.
+    slink:VkPhysicalDevice that pname:device was created from
   * [[VUID-vkAllocateMemory-pAllocateInfo-01714]]
     pname:pAllocateInfo->memoryTypeIndex must: be less than
     slink:VkPhysicalDeviceMemoryProperties::pname:memoryTypeCount as
@@ -1153,14 +1153,14 @@ ifdef::VK_NV_external_memory[]
   * [[VUID-VkMemoryAllocateInfo-pNext-00640]]
     If the pname:pNext chain includes a slink:VkExportMemoryAllocateInfo
     structure, it must: not include a slink:VkExportMemoryAllocateInfoNV or
-    slink:VkExportMemoryWin32HandleInfoNV structure.
+    slink:VkExportMemoryWin32HandleInfoNV structure
 endif::VK_NV_external_memory[]
 endif::VK_KHR_external_memory[]
 ifdef::VK_KHR_external_memory_win32+VK_NV_external_memory_win32[]
   * [[VUID-VkMemoryAllocateInfo-pNext-00641]]
     If the pname:pNext chain includes a
     slink:VkImportMemoryWin32HandleInfoKHR structure, it must: not include a
-    slink:VkImportMemoryWin32HandleInfoNV structure.
+    slink:VkImportMemoryWin32HandleInfoNV structure
 endif::VK_KHR_external_memory_win32+VK_NV_external_memory_win32[]
 ifdef::VK_KHR_external_memory_fd[]
   * [[VUID-VkMemoryAllocateInfo-allocationSize-01742]]
@@ -1168,34 +1168,34 @@ ifdef::VK_KHR_external_memory_fd[]
     specified was created by the Vulkan API, and the external handle type is
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR, then the values
     of pname:allocationSize and pname:memoryTypeIndex must: match those
-    specified when the memory object being imported was created.
+    specified when the memory object being imported was created
 endif::VK_KHR_external_memory_fd[]
 ifdef::VK_KHR_external_memory+VK_KHR_device_group[]
   * [[VUID-VkMemoryAllocateInfo-None-00643]]
     If the parameters define an import operation and the external handle
     specified was created by the Vulkan API, the device mask specified by
     slink:VkMemoryAllocateFlagsInfo must: match that specified when the
-    memory object being imported was allocated.
+    memory object being imported was allocated
   * [[VUID-VkMemoryAllocateInfo-None-00644]]
     If the parameters define an import operation and the external handle
     specified was created by the Vulkan API, the list of physical devices
     that comprise the logical device passed to flink:vkAllocateMemory must:
     match the list of physical devices that comprise the logical device on
-    which the memory was originally allocated.
+    which the memory was originally allocated
 endif::VK_KHR_external_memory+VK_KHR_device_group[]
 ifdef::VK_KHR_external_memory_win32[]
   * [[VUID-VkMemoryAllocateInfo-memoryTypeIndex-00645]]
     If the parameters define an import operation and the external handle is
     an NT handle or a global share handle created outside of the Vulkan API,
     the value of pname:memoryTypeIndex must: be one of those returned by
-    flink:vkGetMemoryWin32HandlePropertiesKHR.
+    flink:vkGetMemoryWin32HandlePropertiesKHR
   * [[VUID-VkMemoryAllocateInfo-allocationSize-01743]]
     If the parameters define an import operation, the external handle was
     created by the Vulkan API, and the external handle type is
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR or
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR, then the
     values of pname:allocationSize and pname:memoryTypeIndex must: match
-    those specified when the memory object being imported was created.
+    those specified when the memory object being imported was created
   * [[VUID-VkMemoryAllocateInfo-allocationSize-00646]]
     If the parameters define an import operation and the external handle
     type is ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT,
@@ -1204,25 +1204,25 @@ ifdef::VK_KHR_external_memory_win32[]
     pname:allocationSize must: match the size reported in the memory
     requirements of the pname:image or pname:buffer member of the
     sname:VkDedicatedAllocationMemoryAllocateInfoNV structure included in
-    the pname:pNext chain.
+    the pname:pNext chain
   * [[VUID-VkMemoryAllocateInfo-allocationSize-00647]]
     If the parameters define an import operation and the external handle
     type is ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_BIT,
     pname:allocationSize must: match the size specified when creating the
-    Direct3D 12 heap from which the external handle was extracted.
+    Direct3D 12 heap from which the external handle was extracted
 endif::VK_KHR_external_memory_win32[]
 ifdef::VK_KHR_external_memory_fd[]
   * [[VUID-VkMemoryAllocateInfo-memoryTypeIndex-00648]]
     If the parameters define an import operation and the external handle is
     a POSIX file descriptor created outside of the Vulkan API, the value of
     pname:memoryTypeIndex must: be one of those returned by
-    flink:vkGetMemoryFdPropertiesKHR.
+    flink:vkGetMemoryFdPropertiesKHR
 endif::VK_KHR_external_memory_fd[]
 ifdef::VK_VERSION_1_1[]
   * [[VUID-VkMemoryAllocateInfo-memoryTypeIndex-01872]]
     If the protected memory feature is not enabled, the
     sname:VkMemoryAllocateInfo::pname:memoryTypeIndex must: not indicate a
-    memory type that reports ename:VK_MEMORY_PROPERTY_PROTECTED_BIT.
+    memory type that reports ename:VK_MEMORY_PROPERTY_PROTECTED_BIT
 endif::VK_VERSION_1_1[]
 ifdef::VK_EXT_external_memory_host[]
   * [[VUID-VkMemoryAllocateInfo-memoryTypeIndex-01744]]
@@ -1239,7 +1239,7 @@ ifdef::VK_NV_dedicated_allocation[]
     a host pointer, the pname:pNext chain must: not include a
     slink:VkDedicatedAllocationMemoryAllocateInfoNV structure with either
     its pname:image or pname:buffer field set to a value other than
-    dlink:VK_NULL_HANDLE.
+    dlink:VK_NULL_HANDLE
 endif::VK_NV_dedicated_allocation[]
 ifdef::VK_KHR_dedicated_allocation[]
   * [[VUID-VkMemoryAllocateInfo-pNext-02806]]
@@ -1247,7 +1247,7 @@ ifdef::VK_KHR_dedicated_allocation[]
     a host pointer, the pname:pNext chain must: not include a
     slink:VkMemoryDedicatedAllocateInfo structure with either its
     pname:image or pname:buffer field set to a value other than
-    dlink:VK_NULL_HANDLE.
+    dlink:VK_NULL_HANDLE
 endif::VK_KHR_dedicated_allocation[]
 endif::VK_EXT_external_memory_host[]
 ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
@@ -1257,7 +1257,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID,
     pname:allocationSize must: be the size returned by
     flink:vkGetAndroidHardwareBufferPropertiesANDROID for the Android
-    hardware buffer.
+    hardware buffer
   * [[VUID-VkMemoryAllocateInfo-pNext-02384]]
     If the parameters define an import operation and the external handle
     type is
@@ -1269,14 +1269,14 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     code:AHardwareBuffer_Desc::code:format of
     code:AHARDWAREBUFFER_FORMAT_BLOB and a
     code:AHardwareBuffer_Desc::code:usage that includes
-    code:AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER.
+    code:AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER
   * [[VUID-VkMemoryAllocateInfo-memoryTypeIndex-02385]]
     If the parameters define an import operation and the external handle
     type is
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID,
     pname:memoryTypeIndex must: be one of those returned by
     flink:vkGetAndroidHardwareBufferPropertiesANDROID for the Android
-    hardware buffer.
+    hardware buffer
   * [[VUID-VkMemoryAllocateInfo-pNext-01874]]
     If the parameters do not define an import operation, and the pname:pNext
     chain includes a sname:VkExportMemoryAllocateInfo structure with
@@ -1284,7 +1284,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     included in its pname:handleTypes member, and the pname:pNext chain
     includes a slink:VkMemoryDedicatedAllocateInfo structure with
     pname:image not equal to dlink:VK_NULL_HANDLE, then pname:allocationSize
-    must: be `0`, otherwise pname:allocationSize must: be greater than `0`.
+    must: be `0`, otherwise pname:allocationSize must: be greater than `0`
   * [[VUID-VkMemoryAllocateInfo-pNext-02386]]
     If the parameters define an import operation, the external handle is an
     Android hardware buffer, and the pname:pNext chain includes a
@@ -1292,7 +1292,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     dlink:VK_NULL_HANDLE, the Android hardware buffer's
     dlink:AHardwareBuffer::code:usage must: include at least one of
     code:AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT or
-    code:AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE.
+    code:AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE
   * [[VUID-VkMemoryAllocateInfo-pNext-02387]]
     If the parameters define an import operation, the external handle is an
     Android hardware buffer, and the pname:pNext chain includes a
@@ -1301,14 +1301,14 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     ename:VK_FORMAT_UNDEFINED or the format returned by
     flink:vkGetAndroidHardwareBufferPropertiesANDROID in
     slink:VkAndroidHardwareBufferFormatPropertiesANDROID::pname:format for
-    the Android hardware buffer.
+    the Android hardware buffer
   * [[VUID-VkMemoryAllocateInfo-pNext-02388]]
     If the parameters define an import operation, the external handle is an
     Android hardware buffer, and the pname:pNext chain includes a
     slink:VkMemoryDedicatedAllocateInfo structure with pname:image that is
     not dlink:VK_NULL_HANDLE, the width, height, and array layer dimensions
     of pname:image and the Android hardware buffer's
-    code:AHardwareBuffer_Desc must: be identical.
+    code:AHardwareBuffer_Desc must: be identical
   * [[VUID-VkMemoryAllocateInfo-pNext-02389]]
     If the parameters define an import operation, the external handle is an
     Android hardware buffer, and the pname:pNext chain includes a
@@ -1316,7 +1316,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     not dlink:VK_NULL_HANDLE, and the Android hardware buffer's
     dlink:AHardwareBuffer::code:usage includes
     code:AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE, the pname:image must:
-    have a complete mipmap chain.
+    have a complete mipmap chain
   * [[VUID-VkMemoryAllocateInfo-pNext-02586]]
     If the parameters define an import operation, the external handle is an
     Android hardware buffer, and the pname:pNext chain includes a
@@ -1324,7 +1324,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     not dlink:VK_NULL_HANDLE, and the Android hardware buffer's
     dlink:AHardwareBuffer::code:usage does not include
     code:AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE, the pname:image must:
-    have exactly one mipmap level.
+    have exactly one mipmap level
   * [[VUID-VkMemoryAllocateInfo-pNext-02390]]
     If the parameters define an import operation, the external handle is an
     Android hardware buffer, and the pname:pNext chain includes a
@@ -1334,7 +1334,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     <<memory-external-android-hardware-buffer-usage,AHardwareBuffer Usage
     Equivalence>>, and if there is a corresponding
     code:AHARDWAREBUFFER_USAGE bit listed that bit must: be included in the
-    Android hardware buffer's code:AHardwareBuffer_Desc::code:usage.
+    Android hardware buffer's code:AHardwareBuffer_Desc::code:usage
 endif::VK_ANDROID_external_memory_android_hardware_buffer[]
 ifdef::VK_VERSION_1_2,VK_KHR_buffer_device_address[]
   * [[VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03329]]
@@ -1428,7 +1428,7 @@ ifdef::VK_KHR_external_memory_win32[]
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT, and the
     external handle was created by the Vulkan API, then the memory being
     imported must: also be a dedicated image allocation and pname:image must
-    be identical to the image associated with the imported memory.
+    be identical to the image associated with the imported memory
   * [[VUID-VkMemoryDedicatedAllocateInfo-buffer-01877]]
     If pname:buffer is not dlink:VK_NULL_HANDLE and
     slink:VkMemoryAllocateInfo defines a memory import operation with handle
@@ -1440,7 +1440,7 @@ ifdef::VK_KHR_external_memory_win32[]
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT, and the
     external handle was created by the Vulkan API, then the memory being
     imported must: also be a dedicated buffer allocation and pname:buffer
-    must be identical to the buffer associated with the imported memory.
+    must be identical to the buffer associated with the imported memory
 endif::VK_KHR_external_memory_win32[]
 ifdef::VK_KHR_external_memory_fd[]
   * [[VUID-VkMemoryDedicatedAllocateInfo-image-01878]]
@@ -1449,14 +1449,14 @@ ifdef::VK_KHR_external_memory_fd[]
     type ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT, the memory
     being imported must: also be a dedicated image allocation and
     pname:image must be identical to the image associated with the imported
-    memory.
+    memory
   * [[VUID-VkMemoryDedicatedAllocateInfo-buffer-01879]]
     If pname:buffer is not dlink:VK_NULL_HANDLE and
     slink:VkMemoryAllocateInfo defines a memory import operation with handle
     type ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT, the memory
     being imported must: also be a dedicated buffer allocation and
     pname:buffer must be identical to the buffer associated with the
-    imported memory.
+    imported memory
 endif::VK_KHR_external_memory_fd[]
 ifdef::VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-VkMemoryDedicatedAllocateInfo-image-01797]]
@@ -1521,13 +1521,13 @@ ifdef::VK_KHR_external_memory_win32,VK_KHR_external_memory_fd[]
     slink:VkMemoryAllocateInfo defines a memory import operation, the memory
     being imported must: also be a dedicated image allocation and
     pname:image must: be identical to the image associated with the imported
-    memory.
+    memory
   * [[VUID-VkDedicatedAllocationMemoryAllocateInfoNV-buffer-00655]]
     If pname:buffer is not dlink:VK_NULL_HANDLE and
     slink:VkMemoryAllocateInfo defines a memory import operation, the memory
     being imported must: also be a dedicated buffer allocation and
     pname:buffer must: be identical to the buffer associated with the
-    imported memory.
+    imported memory
 endif::VK_KHR_external_memory_win32,VK_KHR_external_memory_fd[]
 ****
 
@@ -1607,7 +1607,7 @@ endif::VK_KHR_external_memory[]
   * [[VUID-VkExportMemoryAllocateInfo-handleTypes-00656]]
     The bits in pname:handleTypes must: be supported and compatible, as
     reported by slink:VkExternalImageFormatProperties or
-    slink:VkExternalBufferProperties.
+    slink:VkExternalBufferProperties
 ****
 
 include::{generated}/validity/structs/VkExportMemoryAllocateInfo.txt[]
@@ -1678,7 +1678,7 @@ code:GENERIC_ALL
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_BIT, or
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT, a
     sname:VkExportMemoryWin32HandleInfoKHR structure must: not be included
-    in the pname:pNext chain of slink:VkMemoryAllocateInfo.
+    in the pname:pNext chain of slink:VkMemoryAllocateInfo
 ****
 
 include::{generated}/validity/structs/VkExportMemoryWin32HandleInfoKHR.txt[]
@@ -1719,40 +1719,40 @@ sname:VkDeviceMemory object.
   * [[VUID-VkImportMemoryWin32HandleInfoKHR-handleType-00658]]
     If pname:handleType is not `0`, it must: be supported for import, as
     reported by slink:VkExternalImageFormatProperties or
-    slink:VkExternalBufferProperties.
+    slink:VkExternalBufferProperties
   * [[VUID-VkImportMemoryWin32HandleInfoKHR-handle-00659]]
     The memory from which pname:handle was exported, or the memory named by
     pname:name must: have been created on the same underlying physical
-    device as pname:device.
+    device as pname:device
   * [[VUID-VkImportMemoryWin32HandleInfoKHR-handleType-00660]]
     If pname:handleType is not `0`, it must: be defined as an NT handle or a
-    global share handle.
+    global share handle
   * [[VUID-VkImportMemoryWin32HandleInfoKHR-handleType-01439]]
     If pname:handleType is not
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT,
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT,
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_BIT, or
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT, pname:name
-    must: be `NULL`.
+    must: be `NULL`
   * [[VUID-VkImportMemoryWin32HandleInfoKHR-handleType-01440]]
     If pname:handleType is not `0` and pname:handle is `NULL`, pname:name
     must: name a valid memory resource of the type specified by
-    pname:handleType.
+    pname:handleType
   * [[VUID-VkImportMemoryWin32HandleInfoKHR-handleType-00661]]
     If pname:handleType is not `0` and pname:name is `NULL`, pname:handle
-    must: be a valid handle of the type specified by pname:handleType.
+    must: be a valid handle of the type specified by pname:handleType
   * [[VUID-VkImportMemoryWin32HandleInfoKHR-handle-01441]]
-    if pname:handle is not `NULL`, pname:name must be `NULL`.
+    if pname:handle is not `NULL`, pname:name must be `NULL`
   * [[VUID-VkImportMemoryWin32HandleInfoKHR-handle-01518]]
     If pname:handle is not `NULL`, it must: obey any requirements listed for
     pname:handleType in
     <<external-memory-handle-types-compatibility,external memory handle
-    types compatibility>>.
+    types compatibility>>
   * [[VUID-VkImportMemoryWin32HandleInfoKHR-name-01519]]
     If pname:name is not `NULL`, it must: obey any requirements listed for
     pname:handleType in
     <<external-memory-handle-types-compatibility,external memory handle
-    types compatibility>>.
+    types compatibility>>
 ****
 
 include::{generated}/validity/structs/VkImportMemoryWin32HandleInfoKHR.txt[]
@@ -1805,14 +1805,14 @@ properties of the defined external memory handle types.
   * [[VUID-VkMemoryGetWin32HandleInfoKHR-handleType-00662]]
     pname:handleType must: have been included in
     slink:VkExportMemoryAllocateInfo::pname:handleTypes when pname:memory
-    was created.
+    was created
   * [[VUID-VkMemoryGetWin32HandleInfoKHR-handleType-00663]]
     If pname:handleType is defined as an NT handle,
     flink:vkGetMemoryWin32HandleKHR must: be called no more than once for
-    each valid unique combination of pname:memory and pname:handleType.
+    each valid unique combination of pname:memory and pname:handleType
   * [[VUID-VkMemoryGetWin32HandleInfoKHR-handleType-00664]]
     pname:handleType must: be defined as an NT handle or a global share
-    handle.
+    handle
 ****
 
 include::{generated}/validity/structs/VkMemoryGetWin32HandleInfoKHR.txt[]
@@ -1838,9 +1838,9 @@ include::{generated}/api/protos/vkGetMemoryWin32HandlePropertiesKHR.txt[]
 ****
   * [[VUID-vkGetMemoryWin32HandlePropertiesKHR-handle-00665]]
     pname:handle must: be an external memory handle created outside of the
-    Vulkan API.
+    Vulkan API
   * [[VUID-vkGetMemoryWin32HandlePropertiesKHR-handleType-00666]]
-    pname:handleType must: not be one of the handle types defined as opaque.
+    pname:handleType must: not be one of the handle types defined as opaque
 ****
 
 include::{generated}/validity/protos/vkGetMemoryWin32HandlePropertiesKHR.txt[]
@@ -1897,25 +1897,25 @@ sname:VkDeviceMemory object.
   * [[VUID-VkImportMemoryFdInfoKHR-handleType-00667]]
     If pname:handleType is not `0`, it must: be supported for import, as
     reported by slink:VkExternalImageFormatProperties or
-    slink:VkExternalBufferProperties.
+    slink:VkExternalBufferProperties
   * [[VUID-VkImportMemoryFdInfoKHR-fd-00668]]
     The memory from which pname:fd was exported must: have been created on
-    the same underlying physical device as pname:device.
+    the same underlying physical device as pname:device
   * [[VUID-VkImportMemoryFdInfoKHR-handleType-00669]]
     If pname:handleType is not `0`, it must: be defined as a POSIX file
-    descriptor handle.
+    descriptor handle
   * [[VUID-VkImportMemoryFdInfoKHR-handleType-00670]]
     If pname:handleType is not `0`, pname:fd must: be a valid handle of the
-    type specified by pname:handleType.
+    type specified by pname:handleType
   * [[VUID-VkImportMemoryFdInfoKHR-fd-01746]]
     The memory represented by pname:fd must: have been created from a
     physical device and driver that is compatible with pname:device and
     pname:handleType, as described in
-    <<external-memory-handle-types-compatibility>>.
+    <<external-memory-handle-types-compatibility>>
   * [[VUID-VkImportMemoryFdInfoKHR-fd-01520]]
     pname:fd must: obey any requirements listed for pname:handleType in
     <<external-memory-handle-types-compatibility,external memory handle
-    types compatibility>>.
+    types compatibility>>
 ****
 
 include::{generated}/validity/structs/VkImportMemoryFdInfoKHR.txt[]
@@ -1983,9 +1983,9 @@ endif::VK_EXT_external_memory_dma_buf[]
   * [[VUID-VkMemoryGetFdInfoKHR-handleType-00671]]
     pname:handleType must: have been included in
     slink:VkExportMemoryAllocateInfo::pname:handleTypes when pname:memory
-    was created.
+    was created
   * [[VUID-VkMemoryGetFdInfoKHR-handleType-00672]]
-    pname:handleType must: be defined as a POSIX file descriptor handle.
+    pname:handleType must: be defined as a POSIX file descriptor handle
 ****
 
 include::{generated}/validity/structs/VkMemoryGetFdInfoKHR.txt[]
@@ -2013,10 +2013,10 @@ include::{generated}/api/protos/vkGetMemoryFdPropertiesKHR.txt[]
 ****
   * [[VUID-vkGetMemoryFdPropertiesKHR-fd-00673]]
     pname:fd must: be an external memory handle created outside of the
-    Vulkan API.
+    Vulkan API
   * [[VUID-vkGetMemoryFdPropertiesKHR-handleType-00674]]
     pname:handleType must: not be
-    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR.
+    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR
 ****
 
 include::{generated}/validity/protos/vkGetMemoryFdPropertiesKHR.txt[]
@@ -2197,13 +2197,13 @@ If the command fails, the implementation must: not retain a reference.
     If pname:buffer is not `NULL`, Android hardware buffers must: be
     supported for import, as reported by
     slink:VkExternalImageFormatProperties or
-    slink:VkExternalBufferProperties.
+    slink:VkExternalBufferProperties
   * [[VUID-VkImportAndroidHardwareBufferInfoANDROID-buffer-01881]]
     If pname:buffer is not `NULL`, it must: be a valid Android hardware
     buffer object with code:AHardwareBuffer_Desc::code:format and
     code:AHardwareBuffer_Desc::code:usage compatible with Vulkan as
     described in <<memory-external-android-hardware-buffer,Android Hardware
-    Buffers>>.
+    Buffers>>
 ****
 
 include::{generated}/validity/structs/VkImportAndroidHardwareBufferInfoANDROID.txt[]
@@ -2262,12 +2262,12 @@ include::{generated}/api/structs/VkMemoryGetAndroidHardwareBufferInfoANDROID.txt
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID
     must: have been included in
     slink:VkExportMemoryAllocateInfo::pname:handleTypes when pname:memory
-    was created.
+    was created
   * [[VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-pNext-01883]]
     If the pname:pNext chain of the slink:VkMemoryAllocateInfo used to
     allocate pname:memory included a slink:VkMemoryDedicatedAllocateInfo
     with non-`NULL` pname:image member, then that pname:image must: already
-    be bound to pname:memory.
+    be bound to pname:memory
 ****
 
 include::{generated}/validity/structs/VkMemoryGetAndroidHardwareBufferInfoANDROID.txt[]
@@ -2502,7 +2502,7 @@ allocations.
 ****
   * [[VUID-VkMemoryAllocateFlagsInfo-deviceMask-00675]]
     If ename:VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT is set, pname:deviceMask
-    must: be a valid device mask.
+    must: be a valid device mask
   * [[VUID-VkMemoryAllocateFlagsInfo-deviceMask-00676]]
     If ename:VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT is set, pname:deviceMask
     must: not be zero
@@ -2758,7 +2758,7 @@ to maintaining memory access ordering.
     ename:VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
 ifdef::VK_KHR_device_group[]
   * [[VUID-vkMapMemory-memory-00683]]
-    pname:memory must: not have been allocated with multiple instances.
+    pname:memory must: not have been allocated with multiple instances
 endif::VK_KHR_device_group[]
 ****
 
@@ -2925,7 +2925,7 @@ include::{generated}/api/structs/VkMappedMemoryRange.txt[]
     If pname:size is equal to ename:VK_WHOLE_SIZE, the end of the current
     mapping of pname:memory must: be a multiple of
     slink:VkPhysicalDeviceLimits::pname:nonCoherentAtomSize bytes from the
-    beginning of the memory object.
+    beginning of the memory object
   * [[VUID-VkMappedMemoryRange-offset-00687]]
     pname:offset must: be a multiple of
     slink:VkPhysicalDeviceLimits::pname:nonCoherentAtomSize
@@ -2933,7 +2933,7 @@ include::{generated}/api/structs/VkMappedMemoryRange.txt[]
     If pname:size is not equal to ename:VK_WHOLE_SIZE, pname:size must:
     either be a multiple of
     slink:VkPhysicalDeviceLimits::pname:nonCoherentAtomSize, or pname:offset
-    plus pname:size must: equal the size of pname:memory.
+    plus pname:size must: equal the size of pname:memory
 ****
 
 include::{generated}/validity/structs/VkMappedMemoryRange.txt[]

--- a/chapters/pipelines.txt
+++ b/chapters/pipelines.txt
@@ -187,7 +187,7 @@ ifdef::VK_EXT_pipeline_creation_cache_control[]
     If pname:pipelineCache was created with
     ename:VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT, host
     access to pname:pipelineCache must: be
-    <<fundamentals-threadingbehavior,externally synchronized>>.
+    <<fundamentals-threadingbehavior,externally synchronized>>
 endif::VK_EXT_pipeline_creation_cache_control[]
 ****
 
@@ -412,38 +412,38 @@ ifdef::VK_NV_mesh_shader[]
     entry point must: have an code:OpExecutionMode instruction that
     specifies a maximum output vertex count, code:OutputVertices, that is
     greater than `0` and less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesNV::pname:maxMeshOutputVertices.
+    sname:VkPhysicalDeviceMeshShaderPropertiesNV::pname:maxMeshOutputVertices
   * [[VUID-VkPipelineShaderStageCreateInfo-stage-02094]]
     If pname:stage is ename:VK_SHADER_STAGE_MESH_BIT_NV, the identified
     entry point must: have an code:OpExecutionMode instruction that
     specifies a maximum output primitive count, code:OutputPrimitivesNV,
     that is greater than `0` and less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesNV::pname:maxMeshOutputPrimitives.
+    sname:VkPhysicalDeviceMeshShaderPropertiesNV::pname:maxMeshOutputPrimitives
 endif::VK_NV_mesh_shader[]
 ifdef::VK_EXT_subgroup_size_control[]
   * [[VUID-VkPipelineShaderStageCreateInfo-flags-02784]]
     If pname:flags has the
     ename:VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT
     flag set, the <<features-subgroupSizeControl,
-    pname:subgroupSizeControl>> feature must: be enabled.
+    pname:subgroupSizeControl>> feature must: be enabled
   * [[VUID-VkPipelineShaderStageCreateInfo-flags-02785]]
     If pname:flags has the
     ename:VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT
     flag set, the <<features-computeFullSubgroups,
-    pname:computeFullSubgroups>> feature must: be enabled.
+    pname:computeFullSubgroups>> feature must: be enabled
   * [[VUID-VkPipelineShaderStageCreateInfo-pNext-02754]]
     If a slink:VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT
     structure is included in the pname:pNext chain, pname:flags must: not
     have the
     ename:VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT
-    flag set.
+    flag set
   * [[VUID-VkPipelineShaderStageCreateInfo-pNext-02755]]
     If a slink:VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT
     structure is included in the pname:pNext chain, the
     <<features-subgroupSizeControl, pname:subgroupSizeControl>> feature
     must: be enabled, and pname:stage must: be a valid bit specified in
     <<limits-required-subgroup-size-stages,
-    pname:requiredSubgroupSizeStages>>.
+    pname:requiredSubgroupSizeStages>>
   * [[VUID-VkPipelineShaderStageCreateInfo-pNext-02756]]
     If a slink:VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT
     structure is included in the pname:pNext chain and pname:stage is
@@ -451,21 +451,21 @@ ifdef::VK_EXT_subgroup_size_control[]
     shader must: be less than or equal to the product of
     slink:VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT::pname:requiredSubgroupSize
     and
-    <<limits-max-subgroups-per-workgroup,pname:maxComputeWorkgroupSubgroups>>.
+    <<limits-max-subgroups-per-workgroup,pname:maxComputeWorkgroupSubgroups>>
   * [[VUID-VkPipelineShaderStageCreateInfo-pNext-02757]]
     If a slink:VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT
     structure is included in the pname:pNext chain, and pname:flags has the
     ename:VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT
     flag set, the local workgroup size in the X dimension of the pipeline
     must: be a multiple of
-    slink:VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT::pname:requiredSubgroupSize.
+    slink:VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT::pname:requiredSubgroupSize
   * [[VUID-VkPipelineShaderStageCreateInfo-flags-02758]]
     If pname:flags has both the
     ename:VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT and
     ename:VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT
     flags set, the local workgroup size in the X dimension of the pipeline
     must: be a multiple of
-    <<limits-max-subgroup-size,pname:maxSubgroupSize>>.
+    <<limits-max-subgroup-size,pname:maxSubgroupSize>>
   * [[VUID-VkPipelineShaderStageCreateInfo-flags-02759]]
     If pname:flags has the
     ename:VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT
@@ -475,7 +475,7 @@ ifdef::VK_EXT_subgroup_size_control[]
     slink:VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT structure
     is included in the pname:pNext chain, the local workgroup size in the X
     dimension of the pipeline must: be a multiple of
-    <<limits-subgroup-size,pname:subgroupSize>>.
+    <<limits-subgroup-size,pname:subgroupSize>>
 endif::VK_EXT_subgroup_size_control[]
 ****
 
@@ -599,13 +599,13 @@ include::{generated}/api/structs/VkPipelineShaderStageRequiredSubgroupSizeCreate
 .Valid Usage
 ****
   * [[VUID-VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT-requiredSubgroupSize-02760]]
-    pname:requiredSubgroupSize must: be a power-of-two integer.
+    pname:requiredSubgroupSize must: be a power-of-two integer
   * [[VUID-VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT-requiredSubgroupSize-02761]]
     pname:requiredSubgroupSize must: be greater or equal to
-    <<limits-min-subgroup-size,minSubgroupSize>>.
+    <<limits-min-subgroup-size,minSubgroupSize>>
   * [[VUID-VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT-requiredSubgroupSize-02762]]
     pname:requiredSubgroupSize must: be less than or equal to
-    <<limits-max-subgroup-size,maxSubgroupSize>>.
+    <<limits-max-subgroup-size,maxSubgroupSize>>
 ****
 
 
@@ -669,7 +669,7 @@ ifdef::VK_EXT_pipeline_creation_cache_control[]
     If pname:pipelineCache was created with
     ename:VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT, host
     access to pname:pipelineCache must: be
-    <<fundamentals-threadingbehavior,externally synchronized>>.
+    <<fundamentals-threadingbehavior,externally synchronized>>
 endif::VK_EXT_pipeline_creation_cache_control[]
 ****
 
@@ -802,10 +802,10 @@ ifdef::VK_NV_mesh_shader[]
     ename:VK_SHADER_STAGE_VERTEX_BIT,
     ename:VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
     ename:VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, or
-    ename:VK_SHADER_STAGE_GEOMETRY_BIT).
+    ename:VK_SHADER_STAGE_GEOMETRY_BIT)
   * [[VUID-VkGraphicsPipelineCreateInfo-stage-02096]]
     The pname:stage member of one element of pname:pStages must: be either
-    ename:VK_SHADER_STAGE_VERTEX_BIT or ename:VK_SHADER_STAGE_MESH_BIT_NV.
+    ename:VK_SHADER_STAGE_VERTEX_BIT or ename:VK_SHADER_STAGE_MESH_BIT_NV
 endif::VK_NV_mesh_shader[]
   * [[VUID-VkGraphicsPipelineCreateInfo-stage-00728]]
     The pname:stage member of each element of pname:pStages must: not be
@@ -925,7 +925,7 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
     member of the corresponding element of the pname:pAttachment member of
     pname:pColorBlendState must: be ename:VK_FALSE if the attached image's
     <<resources-image-format-features,format features>> does not contain
-    ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT.
+    ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT
   * [[VUID-VkGraphicsPipelineCreateInfo-attachmentCount-00746]]
     If rasterization is not disabled and the subpass uses color attachments,
     the pname:attachmentCount member of pname:pColorBlendState must: be
@@ -1076,11 +1076,11 @@ ifdef::VK_VERSION_1_1,VK_KHR_multiview[]
     If the pname:renderPass has multiview enabled and pname:subpass has more
     than one bit set in the view mask and pname:multiviewTessellationShader
     is not enabled, then pname:pStages must: not include tessellation
-    shaders.
+    shaders
   * [[VUID-VkGraphicsPipelineCreateInfo-renderPass-00761]]
     If the pname:renderPass has multiview enabled and pname:subpass has more
     than one bit set in the view mask and pname:multiviewGeometryShader is
-    not enabled, then pname:pStages must: not include a geometry shader.
+    not enabled, then pname:pStages must: not include a geometry shader
   * [[VUID-VkGraphicsPipelineCreateInfo-renderPass-00762]]
     If the pname:renderPass has multiview enabled and pname:subpass has more
     than one bit set in the view mask, shaders in the pipeline must: not
@@ -1088,12 +1088,12 @@ ifdef::VK_VERSION_1_1,VK_KHR_multiview[]
   * [[VUID-VkGraphicsPipelineCreateInfo-renderPass-00763]]
     If the pname:renderPass has multiview enabled, then all shaders must:
     not include variables decorated with the code:Layer built-in decoration
-    in their interfaces.
+    in their interfaces
 endif::VK_VERSION_1_1,VK_KHR_multiview[]
 ifdef::VK_VERSION_1_1,VK_KHR_device_group[]
   * [[VUID-VkGraphicsPipelineCreateInfo-flags-00764]]
     pname:flags must: not contain the ename:VK_PIPELINE_CREATE_DISPATCH_BASE
-    flag.
+    flag
 endif::VK_VERSION_1_1,VK_KHR_device_group[]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkGraphicsPipelineCreateInfo-pStages-01565]]
@@ -1102,7 +1102,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
     slink:VkRenderPassInputAttachmentAspectCreateInfo at pname:renderPass
     create time, its shader code must: not read from any aspect that was not
     specified in the pname:aspectMask of the corresponding
-    slink:VkInputAttachmentAspectReference structure.
+    slink:VkInputAttachmentAspectReference structure
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkGraphicsPipelineCreateInfo-layout-01688]]
     The number of resources in pname:layout accessible to each shader stage
@@ -1160,7 +1160,7 @@ ifdef::VK_EXT_transform_feedback[]
 ifdef::VK_NV_mesh_shader[]
   * [[VUID-VkGraphicsPipelineCreateInfo-None-02322]]
     If there are any mesh shader stages in the pipeline there must: not be
-    any shader stage in the pipeline with a code:Xfb execution mode.
+    any shader stage in the pipeline with a code:Xfb execution mode
 endif::VK_NV_mesh_shader[]
 endif::VK_EXT_transform_feedback[]
 ifdef::VK_EXT_line_rasterization[]
@@ -1642,36 +1642,36 @@ based on the pipelines that make use of them.
 ****
   * [[VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-groupCount-02879]]
     pname:groupCount must: be at least `1` and as maximum
-    sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:maxGraphicsShaderGroupCount.
+    sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:maxGraphicsShaderGroupCount
   * [[VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-groupCount-02880]]
     The sum of pname:groupCount including those groups added from referenced
     pname:pPipelines must: also be as maximum
-    sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:maxGraphicsShaderGroupCount.
+    sname:VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV::pname:maxGraphicsShaderGroupCount
   * [[VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pGroups-02881]]
     The state of the first element of pname:pGroups must match its
-    equivalent within the parent's sname:VkGraphicsPipelineCreateInfo.
+    equivalent within the parent's sname:VkGraphicsPipelineCreateInfo
   * [[VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pGroups-02882]]
     Each element of pname:pGroups must: in combination with the rest of the
     pipeline state yield a valid state configuration
 ifndef::VK_NV_mesh_shader[]
   * [[VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pGroups-02883]]
     All elements of pname:pGroups must: use the same shader stage
-    combinations.
+    combinations
 endif::VK_NV_mesh_shader[]
 ifdef::VK_NV_mesh_shader[]
   * [[VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pGroups-02884]]
     All elements of pname:pGroups must: use the same shader stage
     combinations unless any mesh shader stage is used, then either
-    combination of task and mesh or just mesh shader is valid.
+    combination of task and mesh or just mesh shader is valid
   * [[VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pGroups-02885]]
     Mesh and regular primitive shading stages cannot be mixed across
-    pname:pGroups.
+    pname:pGroups
 endif::VK_NV_mesh_shader[]
   * [[VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pPipelines-02886]]
     Each element of the pname:pPipelines member of pname:libraries must:
     have been created with identical state to the pipeline currently created
     except the state that can be overriden by
-    sname:VkGraphicsShaderGroupCreateInfoNV.
+    sname:VkGraphicsShaderGroupCreateInfoNV
   * [[VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-deviceGeneratedCommands-02887]]
     The <<feature-device-generated-commands,
     sname:VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV->pname:deviceGeneratedCommands>>
@@ -1709,16 +1709,16 @@ include::{generated}/api/structs/VkGraphicsShaderGroupCreateInfoNV.txt[]
 ****
   * [[VUID-VkGraphicsShaderGroupCreateInfoNV-stageCount-02888]]
     For pname:stageCount, the same restrictions as in
-    sname:VkGraphicsPipelineCreateInfo::pname:stageCount apply.
+    sname:VkGraphicsPipelineCreateInfo::pname:stageCount apply
   * [[VUID-VkGraphicsShaderGroupCreateInfoNV-pStages-02889]]
     For pname:pStages, the same restrictions as in
-    sname:VkGraphicsPipelineCreateInfo::pname:pStages apply.
+    sname:VkGraphicsPipelineCreateInfo::pname:pStages apply
   * [[VUID-VkGraphicsShaderGroupCreateInfoNV-pVertexInputState-02890]]
     For pname:pVertexInputState, the same restrictions as in
-    sname:VkGraphicsPipelineCreateInfo::pname:pVertexInputState apply.
+    sname:VkGraphicsPipelineCreateInfo::pname:pVertexInputState apply
   * [[VUID-VkGraphicsShaderGroupCreateInfoNV-pTessellationState-02891]]
     For pname:pTessellationState, the same restrictions as in
-    sname:VkGraphicsPipelineCreateInfo::pname:pTessellationState apply.
+    sname:VkGraphicsPipelineCreateInfo::pname:pTessellationState apply
 ****
 
 include::{generated}/validity/structs/VkGraphicsShaderGroupCreateInfoNV.txt[]
@@ -2459,7 +2459,7 @@ endif::VK_NV_ray_tracing,VK_KHR_ray_tracing[]
 ifdef::VK_KHR_pipeline_library[]
   * [[VUID-vkCmdBindPipeline-pipeline-03382]]
     The pname:pipeline must: not have been created with
-    ename:VK_PIPELINE_CREATE_LIBRARY_BIT_KHR set.
+    ename:VK_PIPELINE_CREATE_LIBRARY_BIT_KHR set
 endif::VK_KHR_pipeline_library[]
 
 ****
@@ -2509,14 +2509,14 @@ include::{generated}/api/protos/vkCmdBindPipelineShaderGroupNV.txt[]
   * [[VUID-vkCmdBindPipelineShaderGroupNV-groupIndex-02893]]
     pname:groupIndex must be `0` or less than the effective
     slink:VkGraphicsPipelineShaderGroupsCreateInfoNV::pname:groupCount
-    including the referenced pipelines.
+    including the referenced pipelines
   * [[VUID-vkCmdBindPipelineShaderGroupNV-pipelineBindPoint-02894]]
     The pname:pipelineBindPoint must be
     ename:VK_PIPELINE_BIND_POINT_GRAPHICS
   * [[VUID-vkCmdBindPipelineShaderGroupNV-groupIndex-02895]]
     The same restrictions as flink:vkCmdBindPipeline apply as if the bound
     pipeline was created only with the Shader Group from the
-    pname:groupIndex information.
+    pname:groupIndex information
   * [[VUID-vkCmdBindPipelineShaderGroupNV-deviceGeneratedCommands-02896]]
     The <<feature-device-generated-commands,
     sname:VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV->pname:deviceGeneratedCommands>>

--- a/chapters/primsrast.txt
+++ b/chapters/primsrast.txt
@@ -852,14 +852,14 @@ include::{generated}/api/protos/vkCmdBindShadingRateImageNV.txt[]
 ****
   * [[VUID-vkCmdBindShadingRateImageNV-None-02058]]
     The <<features-shadingRateImage,shading rate image>> feature must: be
-    enabled.
+    enabled
   * [[VUID-vkCmdBindShadingRateImageNV-imageView-02059]]
     If pname:imageView is not dlink:VK_NULL_HANDLE, it must: be a valid
     slink:VkImageView handle of type ename:VK_IMAGE_VIEW_TYPE_2D or
-    ename:VK_IMAGE_VIEW_TYPE_2D_ARRAY.
+    ename:VK_IMAGE_VIEW_TYPE_2D_ARRAY
   * [[VUID-vkCmdBindShadingRateImageNV-imageView-02060]]
     If pname:imageView is not dlink:VK_NULL_HANDLE, it must: have a format
-    of ename:VK_FORMAT_R8_UINT.
+    of ename:VK_FORMAT_R8_UINT
   * [[VUID-vkCmdBindShadingRateImageNV-imageView-02061]]
     If pname:imageView is not dlink:VK_NULL_HANDLE, it must: have been
     created with a pname:usage value including
@@ -867,11 +867,11 @@ include::{generated}/api/protos/vkCmdBindShadingRateImageNV.txt[]
   * [[VUID-vkCmdBindShadingRateImageNV-imageView-02062]]
     If pname:imageView is not dlink:VK_NULL_HANDLE, pname:imageLayout must:
     match the actual elink:VkImageLayout of each subresource accessible from
-    pname:imageView at the time the subresource is accessed.
+    pname:imageView at the time the subresource is accessed
   * [[VUID-vkCmdBindShadingRateImageNV-imageLayout-02063]]
     If pname:imageView is not dlink:VK_NULL_HANDLE, pname:imageLayout must:
     be ename:VK_IMAGE_LAYOUT_SHADING_RATE_OPTIMAL_NV or
-    ename:VK_IMAGE_LAYOUT_GENERAL.
+    ename:VK_IMAGE_LAYOUT_GENERAL
 ****
 
 include::{generated}/validity/protos/vkCmdBindShadingRateImageNV.txt[]
@@ -935,7 +935,7 @@ include::{generated}/api/protos/vkCmdSetViewportShadingRatePaletteNV.txt[]
 ****
   * [[VUID-vkCmdSetViewportShadingRatePaletteNV-None-02064]]
     The <<features-shadingRateImage,shading rate image>> feature must: be
-    enabled.
+    enabled
   * [[VUID-vkCmdSetViewportShadingRatePaletteNV-firstViewport-02066]]
     pname:firstViewport must: be less than
     sname:VkPhysicalDeviceLimits::pname:maxViewports
@@ -1141,7 +1141,7 @@ specified by flink:vkCmdSetCoarseSampleOrderNV.
   * [[VUID-VkPipelineViewportCoarseSampleOrderStateCreateInfoNV-pCustomSampleOrders-02234]]
     The array pname:pCustomSampleOrders must: not contain two structures
     with matching values for both the pname:shadingRate and
-    pname:sampleCount members.
+    pname:sampleCount members
 ****
 include::{generated}/validity/structs/VkPipelineViewportCoarseSampleOrderStateCreateInfoNV.txt[]
 --
@@ -1230,22 +1230,22 @@ corresponds to the coverage sample numbered _i_ in the multi-pixel fragment.
 ****
   * [[VUID-VkCoarseSampleOrderCustomNV-shadingRate-02073]]
     pname:shadingRate must: be a shading rate that generates fragments with
-    more than one pixel.
+    more than one pixel
   * [[VUID-VkCoarseSampleOrderCustomNV-sampleCount-02074]]
     pname:sampleCount must: correspond to a sample count enumerated in
     tlink:VkSampleCountFlags whose corresponding bit is set in
-    slink:VkPhysicalDeviceLimits::pname:framebufferNoAttachmentsSampleCounts.
+    slink:VkPhysicalDeviceLimits::pname:framebufferNoAttachmentsSampleCounts
   * [[VUID-VkCoarseSampleOrderCustomNV-sampleLocationCount-02075]]
     pname:sampleLocationCount must: be equal to the product of
     pname:sampleCount, the fragment width for pname:shadingRate, and the
-    fragment height for pname:shadingRate.
+    fragment height for pname:shadingRate
   * [[VUID-VkCoarseSampleOrderCustomNV-sampleLocationCount-02076]]
     pname:sampleLocationCount must: be less than or equal to the value of
-    sname:VkPhysicalDeviceShadingRateImagePropertiesNV::pname:shadingRateMaxCoarseSamples.
+    sname:VkPhysicalDeviceShadingRateImagePropertiesNV::pname:shadingRateMaxCoarseSamples
   * [[VUID-VkCoarseSampleOrderCustomNV-pSampleLocations-02077]]
     The array pname:pSampleLocations must: contain exactly one entry for
     every combination of valid values for pname:pixelX, pname:pixelY, and
-    pname:sample in the structure slink:VkCoarseSampleOrderCustomNV.
+    pname:sample in the structure slink:VkCoarseSampleOrderCustomNV
 ****
 include::{generated}/validity/structs/VkCoarseSampleOrderCustomNV.txt[]
 --
@@ -1270,12 +1270,12 @@ include::{generated}/api/structs/VkCoarseSampleLocationNV.txt[]
 .Valid Usage
 ****
   * [[VUID-VkCoarseSampleLocationNV-pixelX-02078]]
-    pname:pixelX must: be less than the width (in pixels) of the fragment.
+    pname:pixelX must: be less than the width (in pixels) of the fragment
   * [[VUID-VkCoarseSampleLocationNV-pixelY-02079]]
-    pname:pixelY must: be less than the height (in pixels) of the fragment.
+    pname:pixelY must: be less than the height (in pixels) of the fragment
   * [[VUID-VkCoarseSampleLocationNV-sample-02080]]
     pname:sample must: be less than the number of coverage samples in each
-    pixel belonging to the fragment.
+    pixel belonging to the fragment
 ****
 
 include::{generated}/validity/structs/VkCoarseSampleLocationNV.txt[]

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -183,7 +183,7 @@ a write, a subpass dependency needs to be included between them.
     ename:VK_ATTACHMENT_LOAD_OP_CLEAR, the first use of that attachment
     must: not specify a pname:layout equal to
     ename:VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL or
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL.
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
   * [[VUID-VkRenderPassCreateInfo-pAttachments-02511]]
     For any member of pname:pAttachments with a pname:stencilLoadOp equal to
     ename:VK_ATTACHMENT_LOAD_OP_CLEAR, the first use of that attachment
@@ -195,12 +195,12 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
     For any member of pname:pAttachments with a pname:loadOp equal to
     ename:VK_ATTACHMENT_LOAD_OP_CLEAR, the first use of that attachment
     must: not specify a pname:layout equal to
-    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL.
+    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
   * [[VUID-VkRenderPassCreateInfo-pAttachments-01567]]
     For any member of pname:pAttachments with a pname:stencilLoadOp equal to
     ename:VK_ATTACHMENT_LOAD_OP_CLEAR, the first use of that attachment
     must: not specify a pname:layout equal to
-    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL.
+    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL
   * [[VUID-VkRenderPassCreateInfo-pNext-01926]]
     If the pname:pNext chain includes a
     slink:VkRenderPassInputAttachmentAspectCreateInfo structure, the
@@ -518,11 +518,11 @@ pname:fragmentDensityMapAttachment was given as ename:VK_ATTACHMENT_UNUSED.
     If pname:fragmentDensityMapAttachment is not ename:VK_ATTACHMENT_UNUSED,
     pname:fragmentDensityMapAttachment must: reference an attachment with a
     pname:loadOp equal to ename:VK_ATTACHMENT_LOAD_OP_LOAD or
-    ename:VK_ATTACHMENT_LOAD_OP_DONT_CARE.
+    ename:VK_ATTACHMENT_LOAD_OP_DONT_CARE
   * [[VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02551]]
     If pname:fragmentDensityMapAttachment is not ename:VK_ATTACHMENT_UNUSED,
     pname:fragmentDensityMapAttachment must: reference an attachment with a
-    pname:storeOp equal to ename:VK_ATTACHMENT_STORE_OP_DONT_CARE.
+    pname:storeOp equal to ename:VK_ATTACHMENT_STORE_OP_DONT_CARE
 ****
 
 include::{generated}/validity/structs/VkRenderPassFragmentDensityMapCreateInfoEXT.txt[]
@@ -933,7 +933,7 @@ endif::VK_KHR_maintenance2[]
 ifdef::VK_EXT_image_drm_format_modifier[]
   * [[VUID-VkInputAttachmentAspectReference-aspectMask-02250]]
     pname:aspectMask must: not include
-    etext:VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT for any index etext:i.
+    etext:VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT for any index etext:i
 endif::VK_EXT_image_drm_format_modifier[]
 ****
 
@@ -1099,7 +1099,7 @@ attachment.
     All attachments in pname:pInputAttachments that are not
     ename:VK_ATTACHMENT_UNUSED must: have formats whose features contain at
     least one of ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or
-    ename:VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.
+    ename:VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT
   * [[VUID-VkSubpassDescription-pColorAttachments-02648]]
     All attachments in pname:pColorAttachments that are not
     ename:VK_ATTACHMENT_UNUSED must: have formats whose features contain
@@ -1139,13 +1139,13 @@ ifdef::VK_NVX_multiview_per_view_attributes[]
   * [[VUID-VkSubpassDescription-flags-00856]]
     If pname:flags includes
     ename:VK_SUBPASS_DESCRIPTION_PER_VIEW_POSITION_X_ONLY_BIT_NVX, it must:
-    also include ename:VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX.
+    also include ename:VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX
 endif::VK_NVX_multiview_per_view_attributes[]
 ifdef::VK_QCOM_render_pass_transform[]
   * [[VUID-VkSubpassDescription-pInputAttachments-02868]]
     If the render pass is created with
     ename:VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM each of the elements of
-    pname:pInputAttachments must: be ename:VK_ATTACHMENT_UNUSED.
+    pname:pInputAttachments must: be ename:VK_ATTACHMENT_UNUSED
 endif::VK_QCOM_render_pass_transform[]
 ****
 
@@ -1790,7 +1790,7 @@ respectively.
     must: not specify a pname:layout equal to
     ename:VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, or
-    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL.
+    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL
   * [[VUID-VkRenderPassCreateInfo2-pDependencies-03054]]
     For any element of pname:pDependencies, if the pname:srcSubpass is not
     ename:VK_SUBPASS_EXTERNAL, all stage flags included in the
@@ -2139,7 +2139,7 @@ corresponding subpass.
     All attachments in pname:pInputAttachments that are not
     ename:VK_ATTACHMENT_UNUSED must: have formats whose features contain at
     least one of ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or
-    ename:VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.
+    ename:VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT
   * [[VUID-VkSubpassDescription2-pColorAttachments-02898]]
     All attachments in pname:pColorAttachments that are not
     ename:VK_ATTACHMENT_UNUSED must: have formats whose features contain
@@ -2179,7 +2179,7 @@ ifdef::VK_NVX_multiview_per_view_attributes[]
   * [[VUID-VkSubpassDescription2-flags-03076]]
     If pname:flags includes
     ename:VK_SUBPASS_DESCRIPTION_PER_VIEW_POSITION_X_ONLY_BIT_NVX, it must:
-    also include ename:VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX.
+    also include ename:VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX
 endif::VK_NVX_multiview_per_view_attributes[]
   * [[VUID-VkSubpassDescription2-attachment-02799]]
     If the pname:attachment member of any element of pname:pInputAttachments
@@ -2836,13 +2836,13 @@ ifdef::VK_EXT_fragment_density_map[]
   * [[VUID-VkFramebufferCreateInfo-pAttachments-02552]]
     Each element of pname:pAttachments that is used as a fragment density
     map attachment by pname:renderPass must: not have been created with a
-    pname:flags value including ename:VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.
+    pname:flags value including ename:VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT
   * [[VUID-VkFramebufferCreateInfo-renderPass-02553]]
     If pname:renderPass has a fragment density map attachment and
     <<features-nonsubsampledimages,non-subsample image feature>> is not
     enabled, each element of pname:pAttachments must: have been created with
     a pname:flags value including ename:VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT
-    unless that element is the fragment density map attachment.
+    unless that element is the fragment density map attachment
 endif::VK_EXT_fragment_density_map[]
   * [[VUID-VkFramebufferCreateInfo-pAttachments-00880]]
     If pname:flags does not include
@@ -2925,17 +2925,17 @@ endif::VK_EXT_fragment_density_map[]
     ename:VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT, each element of
     pname:pAttachments must: have been created with the identity swizzle
   * [[VUID-VkFramebufferCreateInfo-width-00885]]
-    pname:width must: be greater than `0`.
+    pname:width must: be greater than `0`
   * [[VUID-VkFramebufferCreateInfo-width-00886]]
     pname:width must: be less than or equal to
     sname:VkPhysicalDeviceLimits::pname:maxFramebufferWidth
   * [[VUID-VkFramebufferCreateInfo-height-00887]]
-    pname:height must: be greater than `0`.
+    pname:height must: be greater than `0`
   * [[VUID-VkFramebufferCreateInfo-height-00888]]
     pname:height must: be less than or equal to
     sname:VkPhysicalDeviceLimits::pname:maxFramebufferHeight
   * [[VUID-VkFramebufferCreateInfo-layers-00889]]
-    pname:layers must: be greater than `0`.
+    pname:layers must: be greater than `0`
   * [[VUID-VkFramebufferCreateInfo-layers-00890]]
     pname:layers must: be less than or equal to
     sname:VkPhysicalDeviceLimits::pname:maxFramebufferLayers
@@ -3776,12 +3776,12 @@ ifdef::VK_QCOM_render_pass_transform[]
   * [[VUID-VkRenderPassBeginInfo-pNext-02869]]
     If the pname:pNext chain includes
     slink:VkRenderPassTransformBeginInfoQCOM, pname:renderArea::pname:offset
-    must: equal (0,0).
+    must: equal (0,0)
   * [[VUID-VkRenderPassBeginInfo-pNext-02870]]
     If the pname:pNext chain includes
     slink:VkRenderPassTransformBeginInfoQCOM, pname:renderArea::pname:extent
     transformed by slink:VkRenderPassTransformBeginInfoQCOM::pname:transform
-    must: equal the pname:framebuffer dimensions.
+    must: equal the pname:framebuffer dimensions
 endif::VK_QCOM_render_pass_transform[]
 ****
 
@@ -3937,11 +3937,11 @@ include::{generated}/api/structs/VkRenderPassTransformBeginInfoQCOM.txt[]
     pname:transform must: be VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
     VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR,
     VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR, or
-    VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR.
+    VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR
   * [[VUID-VkRenderPassTransformBeginInfoQCOM-flags-02872]]
     The renderpass must have been created with
     slink:VkRenderPassCreateInfo::pname:flags containing
-    VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM.
+    VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM
 ****
 
 include::{generated}/validity/structs/VkRenderPassTransformBeginInfoQCOM.txt[]
@@ -4053,7 +4053,7 @@ devices.
     device mask
   * [[VUID-VkDeviceGroupRenderPassBeginInfo-deviceRenderAreaCount-00908]]
     pname:deviceRenderAreaCount must: either be zero or equal to the number
-    of physical devices in the logical device.
+    of physical devices in the logical device
 ****
 
 include::{generated}/validity/structs/VkDeviceGroupRenderPassBeginInfo.txt[]

--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -1043,7 +1043,7 @@ endif::VK_VERSION_1_1,VK_KHR_external_memory[]
     <<resources-image-creation-limits,Image Creation Limits>>) must: not be
     undefined: pname:imageCreateMaxMipLevels,
     pname:imageCreateMaxArrayLayers, pname:imageCreateMaxExtent, and
-    pname:imageCreateSampleCounts.
+    pname:imageCreateSampleCounts
   * [[VUID-VkImageCreateInfo-sharingMode-00941]]
     If pname:sharingMode is ename:VK_SHARING_MODE_CONCURRENT,
     pname:pQueueFamilyIndices must: be a valid pointer to an array of
@@ -1076,19 +1076,19 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
   * [[VUID-VkImageCreateInfo-pNext-01974]]
     If the pname:pNext chain includes a slink:VkExternalFormatANDROID
     structure, and its pname:externalFormat member is non-zero the
-    pname:format must: be ename:VK_FORMAT_UNDEFINED.
+    pname:format must: be ename:VK_FORMAT_UNDEFINED
   * [[VUID-VkImageCreateInfo-pNext-01975]]
     If the pname:pNext chain does not include a
     slink:VkExternalFormatANDROID structure, or does and its
     pname:externalFormat member is `0`, the pname:format must: not be
-    ename:VK_FORMAT_UNDEFINED.
+    ename:VK_FORMAT_UNDEFINED
 endif::VK_ANDROID_external_memory_android_hardware_buffer[]
   * [[VUID-VkImageCreateInfo-extent-00944]]
-    pname:extent.width must: be greater than `0`.
+    pname:extent.width must: be greater than `0`
   * [[VUID-VkImageCreateInfo-extent-00945]]
-    pname:extent.height must: be greater than `0`.
+    pname:extent.height must: be greater than `0`
   * [[VUID-VkImageCreateInfo-extent-00946]]
-    pname:extent.depth must: be greater than `0`.
+    pname:extent.depth must: be greater than `0`
   * [[VUID-VkImageCreateInfo-mipLevels-00947]]
     pname:mipLevels must: be greater than `0`
   * [[VUID-VkImageCreateInfo-arrayLayers-00948]]
@@ -1110,15 +1110,15 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-VkImageCreateInfo-extent-02252]]
     pname:extent.width must: be less than or equal to
     pname:imageCreateMaxExtent.width (as defined in
-    <<resources-image-creation-limits,Image Creation Limits>>).
+    <<resources-image-creation-limits,Image Creation Limits>>)
   * [[VUID-VkImageCreateInfo-extent-02253]]
     pname:extent.height must: be less than or equal to
     pname:imageCreateMaxExtent.height (as defined in
-    <<resources-image-creation-limits,Image Creation Limits>>).
+    <<resources-image-creation-limits,Image Creation Limits>>)
   * [[VUID-VkImageCreateInfo-extent-02254]]
     pname:extent.depth must: be less than or equal to
     pname:imageCreateMaxExtent.depth (as defined in
-    <<resources-image-creation-limits,Image Creation Limits>>).
+    <<resources-image-creation-limits,Image Creation Limits>>)
   * [[VUID-VkImageCreateInfo-imageType-00954]]
     If pname:imageType is ename:VK_IMAGE_TYPE_2D and pname:flags contains
     ename:VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, pname:extent.width and
@@ -1133,18 +1133,18 @@ endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
   * [[VUID-VkImageCreateInfo-mipLevels-00958]]
     pname:mipLevels must: be less than or equal to the number of levels in
     the complete mipmap chain based on [eq]#pname:extent.width#,
-    [eq]#pname:extent.height#, and [eq]#pname:extent.depth#.
+    [eq]#pname:extent.height#, and [eq]#pname:extent.depth#
   * [[VUID-VkImageCreateInfo-mipLevels-02255]]
     pname:mipLevels must: be less than or equal to
     pname:imageCreateMaxMipLevels (as defined in
-    <<resources-image-creation-limits,Image Creation Limits>>).
+    <<resources-image-creation-limits,Image Creation Limits>>)
   * [[VUID-VkImageCreateInfo-arrayLayers-02256]]
     pname:arrayLayers must: be less than or equal to
     pname:imageCreateMaxArrayLayers (as defined in
-    <<resources-image-creation-limits,Image Creation Limits>>).
+    <<resources-image-creation-limits,Image Creation Limits>>)
   * [[VUID-VkImageCreateInfo-imageType-00961]]
     If pname:imageType is ename:VK_IMAGE_TYPE_3D, pname:arrayLayers must: be
-    `1`.
+    `1`
   * [[VUID-VkImageCreateInfo-samples-02257]]
     If pname:samples is not ename:VK_SAMPLE_COUNT_1_BIT, then
     pname:imageType must: be ename:VK_IMAGE_TYPE_2D, pname:flags must: not
@@ -1193,11 +1193,11 @@ endif::VK_EXT_fragment_density_map[]
     pname:usage must: also contain at least one of
     ename:VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
     ename:VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, or
-    ename:VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT.
+    ename:VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT
   * [[VUID-VkImageCreateInfo-samples-02258]]
     pname:samples must: be a bit value that is set in
     pname:imageCreateSampleCounts (as defined in
-    <<resources-image-creation-limits,Image Creation Limits>>).
+    <<resources-image-creation-limits,Image Creation Limits>>)
   * [[VUID-VkImageCreateInfo-usage-00968]]
     If the <<features-shaderStorageImageMultisample,multisampled storage
     images>> feature is not enabled, and pname:usage contains
@@ -1260,19 +1260,19 @@ endif::VK_EXT_fragment_density_map[]
 ifdef::VK_VERSION_1_1[]
   * [[VUID-VkImageCreateInfo-flags-01890]]
     If the protected memory feature is not enabled, pname:flags must: not
-    contain ename:VK_IMAGE_CREATE_PROTECTED_BIT.
+    contain ename:VK_IMAGE_CREATE_PROTECTED_BIT
   * [[VUID-VkImageCreateInfo-None-01891]]
     If any of the bits ename:VK_IMAGE_CREATE_SPARSE_BINDING_BIT,
     ename:VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT, or
     ename:VK_IMAGE_CREATE_SPARSE_ALIASED_BIT are set,
-    ename:VK_IMAGE_CREATE_PROTECTED_BIT must: not also be set.
+    ename:VK_IMAGE_CREATE_PROTECTED_BIT must: not also be set
 endif::VK_VERSION_1_1[]
 ifdef::VK_VERSION_1_1,VK_KHR_external_memory[]
 ifdef::VK_NV_external_memory[]
   * [[VUID-VkImageCreateInfo-pNext-00988]]
     If the pname:pNext chain includes a
     slink:VkExternalMemoryImageCreateInfoNV structure, it must: not contain
-    a slink:VkExternalMemoryImageCreateInfo structure.
+    a slink:VkExternalMemoryImageCreateInfo structure
 endif::VK_NV_external_memory[]
   * [[VUID-VkImageCreateInfo-pNext-00990]]
     If the pname:pNext chain includes a
@@ -1312,7 +1312,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_device_group[]
     pname:imageType must: be ename:VK_IMAGE_TYPE_2D.
     and pname:imageCreateMaybeLinear (as defined in
     <<resources-image-creation-limits,Image Creation Limits>>) must: be
-    `false`.
+    `false`
 endif::VK_VERSION_1_1,VK_KHR_device_group[]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkImageCreateInfo-flags-01572]]
@@ -1320,11 +1320,11 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
     ename:VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT, then pname:format
     must: be a <<appendix-compressedtex-bc,block-compressed image format>>,
     an <<appendix-compressedtex-etc2, ETC compressed image format>>, or an
-    <<appendix-compressedtex-astc, ASTC compressed image format>>.
+    <<appendix-compressedtex-astc, ASTC compressed image format>>
   * [[VUID-VkImageCreateInfo-flags-01573]]
     If pname:flags contains
     ename:VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT, then pname:flags
-    must: also contain ename:VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.
+    must: also contain ename:VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkImageCreateInfo-initialLayout-00993]]
     pname:initialLayout must: be ename:VK_IMAGE_LAYOUT_UNDEFINED or
@@ -1392,7 +1392,7 @@ ifdef::VK_EXT_image_drm_format_modifier[]
     If pname:tiling is ename:VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT and
     pname:flags contains ename:VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, then the
     pname:pNext chain must: include a slink:VkImageFormatListCreateInfo
-    structure with non-zero pname:viewFormatCount.
+    structure with non-zero pname:viewFormatCount
 endif::VK_EXT_image_drm_format_modifier[]
 ifdef::VK_EXT_sample_locations[]
   * [[VUID-VkImageCreateInfo-flags-01533]]
@@ -1406,7 +1406,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     slink:VkExternalMemoryImageCreateInfo structure whose pname:handleTypes
     member includes
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID,
-    pname:imageType must: be ename:VK_IMAGE_TYPE_2D.
+    pname:imageType must: be ename:VK_IMAGE_TYPE_2D
   * [[VUID-VkImageCreateInfo-pNext-02394]]
     If the pname:pNext chain includes a
     slink:VkExternalMemoryImageCreateInfo structure whose pname:handleTypes
@@ -1414,19 +1414,19 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID,
     pname:mipLevels must: either be `1` or equal to the number of levels in
     the complete mipmap chain based on [eq]#pname:extent.width#,
-    [eq]#pname:extent.height#, and [eq]#pname:extent.depth#.
+    [eq]#pname:extent.height#, and [eq]#pname:extent.depth#
   * [[VUID-VkImageCreateInfo-pNext-02396]]
     If the pname:pNext chain includes a slink:VkExternalFormatANDROID
     structure whose pname:externalFormat member is not `0`, pname:flags
-    must: not include ename:VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.
+    must: not include ename:VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT
   * [[VUID-VkImageCreateInfo-pNext-02397]]
     If the pname:pNext chain includes a slink:VkExternalFormatANDROID
     structure whose pname:externalFormat member is not `0`, pname:usage
-    must: not include any usages except ename:VK_IMAGE_USAGE_SAMPLED_BIT.
+    must: not include any usages except ename:VK_IMAGE_USAGE_SAMPLED_BIT
   * [[VUID-VkImageCreateInfo-pNext-02398]]
     If the pname:pNext chain includes a slink:VkExternalFormatANDROID
     structure whose pname:externalFormat member is not `0`, pname:tiling
-    must: be ename:VK_IMAGE_TILING_OPTIMAL.
+    must: be ename:VK_IMAGE_TILING_OPTIMAL
 endif::VK_ANDROID_external_memory_android_hardware_buffer[]
 ifdef::VK_EXT_separate_stencil_usage[]
   * [[VUID-VkImageCreateInfo-format-02795]]
@@ -1496,13 +1496,13 @@ endif::VK_NV_corner_sampled_image[]
 ifdef::VK_NV_shading_rate_image[]
   * [[VUID-VkImageCreateInfo-imageType-02082]]
     If pname:usage includes ename:VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV,
-    pname:imageType must: be ename:VK_IMAGE_TYPE_2D.
+    pname:imageType must: be ename:VK_IMAGE_TYPE_2D
   * [[VUID-VkImageCreateInfo-samples-02083]]
     If pname:usage includes ename:VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV,
-    pname:samples must: be ename:VK_SAMPLE_COUNT_1_BIT.
+    pname:samples must: be ename:VK_SAMPLE_COUNT_1_BIT
   * [[VUID-VkImageCreateInfo-tiling-02084]]
     If pname:usage includes ename:VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV,
-    pname:tiling must: be ename:VK_IMAGE_TILING_OPTIMAL.
+    pname:tiling must: be ename:VK_IMAGE_TILING_OPTIMAL
 endif::VK_NV_shading_rate_image[]
 ifdef::VK_EXT_fragment_density_map[]
   * [[VUID-VkImageCreateInfo-flags-02565]]
@@ -1789,14 +1789,14 @@ not included in the pname:pNext list of slink:VkImageCreateInfo.
     If pname:viewFormatCount is not `0`, all of the formats in the
     pname:pViewFormats array must: be compatible with the format specified
     in the pname:format field of sname:VkImageCreateInfo, as described in
-    the <<formats-compatibility,compatibility table>>.
+    the <<formats-compatibility,compatibility table>>
   * [[VUID-VkImageFormatListCreateInfo-flags-01579]]
     If sname:VkImageCreateInfo::pname:flags does not contain
     ename:VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT, pname:viewFormatCount must: be
-    `0` or `1`.
+    `0` or `1`
   * [[VUID-VkImageFormatListCreateInfo-viewFormatCount-01580]]
     If pname:viewFormatCount is not `0`,
-    sname:VkImageCreateInfo::pname:format must: be in pname:pViewFormats.
+    sname:VkImageCreateInfo::pname:format must: be in pname:pViewFormats
 ****
 
 include::{generated}/validity/structs/VkImageFormatListCreateInfo.txt[]
@@ -1830,7 +1830,7 @@ include::{generated}/api/structs/VkImageDrmFormatModifierListCreateInfoEXT.txt[]
     Each _modifier_ in pname:pDrmFormatModifiers must be compatible with the
     parameters in slink:VkImageCreateInfo and its pname:pNext chain, as
     determined by querying slink:VkPhysicalDeviceImageFormatInfo2 extended
-    with slink:VkPhysicalDeviceImageDrmFormatModifierInfoEXT.
+    with slink:VkPhysicalDeviceImageDrmFormatModifierInfoEXT
 ****
 
 include::{generated}/validity/structs/VkImageDrmFormatModifierListCreateInfoEXT.txt[]
@@ -1885,21 +1885,21 @@ ename:VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT.
     pname:drmFormatModifier must be compatible with the parameters in
     slink:VkImageCreateInfo and its pname:pNext chain, as determined by
     querying slink:VkPhysicalDeviceImageFormatInfo2 extended with
-    slink:VkPhysicalDeviceImageDrmFormatModifierInfoEXT.
+    slink:VkPhysicalDeviceImageDrmFormatModifierInfoEXT
   * [[VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-drmFormatModifierPlaneCount-02265]]
     pname:drmFormatModifierPlaneCount must: be equal to the
     slink:VkDrmFormatModifierPropertiesEXT::pname:drmFormatModifierPlaneCount
     associated with slink:VkImageCreateInfo::pname:format and
     pname:drmFormatModifier, as found by querying
-    slink:VkDrmFormatModifierPropertiesListEXT.
+    slink:VkDrmFormatModifierPropertiesListEXT
   * [[VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-size-02267]]
     For each element of pname:pPlaneLayouts, pname:size must: be 0
   * [[VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-arrayPitch-02268]]
     For each element of pname:pPlaneLayouts, pname:arrayPitch must: be 0 if
-    slink:VkImageCreateInfo::pname:arrayLayers is 1.
+    slink:VkImageCreateInfo::pname:arrayLayers is 1
   * [[VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-depthPitch-02269]]
     For each element of pname:pPlaneLayouts, pname:depthPitch must: be 0 if
-    slink:VkImageCreateInfo::pname:extent.depth is 1.
+    slink:VkImageCreateInfo::pname:extent.depth is 1
 ****
 
 include::{generated}/validity/structs/VkImageDrmFormatModifierExplicitCreateInfoEXT.txt[]
@@ -2238,7 +2238,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
   * [[VUID-vkGetImageSubresourceLayout-image-01895]]
     If pname:image was created with the
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID
-    external memory handle type, then pname:image must: be bound to memory.
+    external memory handle type, then pname:image must: be bound to memory
 endif::VK_ANDROID_external_memory_android_hardware_buffer[]
 ifdef::VK_EXT_image_drm_format_modifier[]
   * [[VUID-vkGetImageSubresourceLayout-tiling-02271]]
@@ -2250,7 +2250,7 @@ ifdef::VK_EXT_image_drm_format_modifier[]
     <<VkDrmFormatModifierPropertiesEXT,pname:drmFormatModifierPlaneCount>>
     associated with the image's
    <<VkImageCreateInfo,pname:format>> and
-   <<VkImageDrmFormatModifierPropertiesEXT,pname:drmFormatModifier>>.
+   <<VkImageDrmFormatModifierPropertiesEXT,pname:drmFormatModifier>>
 endif::VK_EXT_image_drm_format_modifier[]
 ****
 
@@ -2417,7 +2417,7 @@ include::{generated}/api/protos/vkGetImageDrmFormatModifierPropertiesEXT.txt[]
   * [[VUID-vkGetImageDrmFormatModifierPropertiesEXT-image-02272]]
     pname:image must: have been created with
     <<VkImageCreateInfo,pname:tiling>> equal to
-    ename:VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT.
+    ename:VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT
 ****
 
 include::{generated}/validity/protos/vkGetImageDrmFormatModifierPropertiesEXT.txt[]
@@ -3273,31 +3273,31 @@ endif::VK_NV_shading_rate_image[]
 endif::VK_EXT_fragment_density_map[]
   * [[VUID-VkImageViewCreateInfo-None-02273]]
     The <<resources-image-view-format-features,format features>> of the
-    resultant image view must: contain at least one bit.
+    resultant image view must: contain at least one bit
   * [[VUID-VkImageViewCreateInfo-usage-02274]]
     If pname:usage contains ename:VK_IMAGE_USAGE_SAMPLED_BIT, then the
     <<resources-image-view-format-features,format features>> of the
     resultant image view must: contain
-    ename:VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT.
+    ename:VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT
   * [[VUID-VkImageViewCreateInfo-usage-02275]]
     If pname:usage contains ename:VK_IMAGE_USAGE_STORAGE_BIT, then the image
     view's <<resources-image-view-format-features,format features>> must:
-    contain ename:VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+    contain ename:VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT
   * [[VUID-VkImageViewCreateInfo-usage-02276]]
     If pname:usage contains ename:VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, then
     the image view's <<resources-image-view-format-features,format
-    features>> must: contain ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT.
+    features>> must: contain ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT
   * [[VUID-VkImageViewCreateInfo-usage-02277]]
     If pname:usage contains
     ename:VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, then the image view's
     <<resources-image-view-format-features,format features>> must: contain
-    ename:VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.
+    ename:VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT
   * [[VUID-VkImageViewCreateInfo-usage-02652]]
     If pname:usage contains ename:VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, then
     the image view's <<resources-image-view-format-features,format
     features>> must: contain at least one of
     ename:VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or
-    ename:VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.
+    ename:VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT
   * [[VUID-VkImageViewCreateInfo-subresourceRange-01478]]
     pname:subresourceRange.baseMipLevel must: be less than the
     pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
@@ -3353,7 +3353,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
     computed from pname:baseMipLevel and pname:extent.depth specified in
     slink:VkImageCreateInfo when pname:image was created, according to the
     formula defined in <<resources-image-miplevel-sizing,Image Miplevel
-    Sizing>>.
+    Sizing>>
   * [[VUID-VkImageViewCreateInfo-subresourceRange-02725]]
     If pname:subresourceRange.layerCount is not
     ename:VK_REMAINING_ARRAY_LAYERS, pname:image is a 3D image created with
@@ -3365,7 +3365,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
     depth computed from pname:baseMipLevel and pname:extent.depth specified
     in slink:VkImageCreateInfo when pname:image was created, according to
     the formula defined in <<resources-image-miplevel-sizing,Image Miplevel
-    Sizing>>.
+    Sizing>>
 endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
 // The VU below comes in 4 alternate versions
 // both disabled, both enabled, maintenance2 only, ycbcr only
@@ -3431,12 +3431,12 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
     If pname:image was created with the
     ename:VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT flag, pname:format
     must: be compatible with, or must: be an uncompressed format that is
-    size-compatible with, the pname:format used to create pname:image.
+    size-compatible with, the pname:format used to create pname:image
   * [[VUID-VkImageViewCreateInfo-image-01584]]
     If pname:image was created with the
     ename:VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT flag, the
     pname:levelCount and pname:layerCount members of pname:subresourceRange
-    must: both be `1`.
+    must: both be `1`
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
 ifdef::VK_VERSION_1_2,VK_KHR_image_format_list[]
   * [[VUID-VkImageViewCreateInfo-pNext-01585]]
@@ -3445,7 +3445,7 @@ ifdef::VK_VERSION_1_2,VK_KHR_image_format_list[]
     creating pname:image and the pname:viewFormatCount field of
     sname:VkImageFormatListCreateInfo is not zero then pname:format must: be
     one of the formats in
-    sname:VkImageFormatListCreateInfo::pname:pViewFormats.
+    sname:VkImageFormatListCreateInfo::pname:pViewFormats
 endif::VK_VERSION_1_2,VK_KHR_image_format_list[]
 ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-VkImageViewCreateInfo-image-01586]]
@@ -3488,7 +3488,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
     If the pname:pNext chain includes a slink:VkSamplerYcbcrConversionInfo
     structure with a pname:conversion value other than dlink:VK_NULL_HANDLE,
     all members of pname:components must: have the value
-    ename:VK_COMPONENT_SWIZZLE_IDENTITY.
+    ename:VK_COMPONENT_SWIZZLE_IDENTITY
 endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-VkImageViewCreateInfo-image-01020]]
     If pname:image is non-sparse then it must: be bound completely and
@@ -3501,18 +3501,18 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
   * [[VUID-VkImageViewCreateInfo-image-02399]]
     If pname:image has an
     <<memory-external-android-hardware-buffer-external-formats,external
-    format>>, pname:format must: be ename:VK_FORMAT_UNDEFINED.
+    format>>, pname:format must: be ename:VK_FORMAT_UNDEFINED
   * [[VUID-VkImageViewCreateInfo-image-02400]]
     If pname:image has an
     <<memory-external-android-hardware-buffer-external-formats,external
     format>>, the pname:pNext chain must: include a
     slink:VkSamplerYcbcrConversionInfo structure with a pname:conversion
-    object created with the same external format as pname:image.
+    object created with the same external format as pname:image
   * [[VUID-VkImageViewCreateInfo-image-02401]]
     If pname:image has an
     <<memory-external-android-hardware-buffer-external-formats,external
     format>>, all members of pname:components must: be
-    ename:VK_COMPONENT_SWIZZLE_IDENTITY.
+    ename:VK_COMPONENT_SWIZZLE_IDENTITY
 endif::VK_ANDROID_external_memory_android_hardware_buffer[]
 ifdef::VK_NV_shading_rate_image[]
   * [[VUID-VkImageViewCreateInfo-image-02086]]
@@ -3545,7 +3545,7 @@ ifndef::VK_EXT_separate_stencil_usage[]
     If the pname:pNext chain includes a slink:VkImageViewUsageCreateInfo
     structure, its pname:usage member must: not include any bits that were
     not set in the pname:usage member of the slink:VkImageCreateInfo
-    structure used to create pname:image.
+    structure used to create pname:image
 endif::VK_EXT_separate_stencil_usage[]
 ifdef::VK_EXT_separate_stencil_usage[]
   * [[VUID-VkImageViewCreateInfo-pNext-02662]]
@@ -4479,7 +4479,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
   * [[VUID-VkImageMemoryRequirementsInfo2-image-01897]]
     If pname:image was created with the
     ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID
-    external memory handle type, then pname:image must: be bound to memory.
+    external memory handle type, then pname:image must: be bound to memory
 endif::VK_ANDROID_external_memory_android_hardware_buffer[]
 ****
 
@@ -4739,7 +4739,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_dedicated_allocation[]
     slink:VkMemoryDedicatedAllocateInfo::pname:buffer was not
     dlink:VK_NULL_HANDLE, then pname:buffer must: equal
     slink:VkMemoryDedicatedAllocateInfo::pname:buffer, and
-    pname:memoryOffset must: be zero.
+    pname:memoryOffset must: be zero
 endif::VK_VERSION_1_1,VK_KHR_dedicated_allocation[]
 ifdef::VK_VERSION_1_1[]
   * [[VUID-vkBindBufferMemory-None-01898]]
@@ -4888,7 +4888,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_dedicated_allocation[]
     slink:VkMemoryDedicatedAllocateInfo::pname:buffer was not
     dlink:VK_NULL_HANDLE, then pname:buffer must: equal
     slink:VkMemoryDedicatedAllocateInfo::pname:buffer and pname:memoryOffset
-    must: be zero.
+    must: be zero
 endif::VK_VERSION_1_1,VK_KHR_dedicated_allocation[]
 ifdef::VK_NV_dedicated_allocation[]
   * [[VUID-VkBindBufferMemoryInfo-buffer-01603]]
@@ -5035,7 +5035,7 @@ endif::VK_VERSION_1_1,VK_KHR_bind_memory2[]
 ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-vkBindImageMemory-image-01608]]
     pname:image must: not have been created with the
-    ename:VK_IMAGE_CREATE_DISJOINT_BIT set.
+    ename:VK_IMAGE_CREATE_DISJOINT_BIT set
 endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-vkBindImageMemory-image-01044]]
     pname:image must: not already be backed by a memory object
@@ -5084,7 +5084,7 @@ ifdef::VK_NV_dedicated_allocation_image_aliasing[]
     pname:pNext chain, and slink:VkMemoryDedicatedAllocateInfo::pname:image
     was not dlink:VK_NULL_HANDLE, then pname:image must: equal
     slink:VkMemoryDedicatedAllocateInfo::pname:image and pname:memoryOffset
-    must: be zero.
+    must: be zero
   * [[VUID-vkBindImageMemory-memory-02629]]
     If the <<features-dedicatedAllocationImageAliasing,dedicated allocation
     image aliasing>> feature is enabled, and the sname:VkMemoryAllocateInfo
@@ -5100,7 +5100,7 @@ ifdef::VK_NV_dedicated_allocation_image_aliasing[]
     parameter of the image being bound must: be equal to or smaller than the
     original image for which the allocation was created; and the
     pname:arrayLayers parameter of the image being bound must: be equal to
-    or smaller than the original image for which the allocation was created.
+    or smaller than the original image for which the allocation was created
 endif::VK_NV_dedicated_allocation_image_aliasing[]
 endif::VK_VERSION_1_1,VK_KHR_dedicated_allocation[]
 ifdef::VK_VERSION_1_1[]
@@ -5261,7 +5261,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-VkBindImageMemoryInfo-pNext-01618]]
     If the pname:pNext chain includes a slink:VkBindImagePlaneMemoryInfo
     structure, pname:image must: have been created with the
-    ename:VK_IMAGE_CREATE_DISJOINT_BIT bit set.
+    ename:VK_IMAGE_CREATE_DISJOINT_BIT bit set
   * [[VUID-VkBindImageMemoryInfo-pNext-01619]]
     If the pname:pNext chain includes a slink:VkBindImagePlaneMemoryInfo
     structure, pname:memory must: have been allocated using one of the
@@ -5306,7 +5306,7 @@ ifndef::VK_NV_dedicated_allocation_image_aliasing[]
     slink:VkMemoryDedicatedAllocateInfo::pname:image was not
     dlink:VK_NULL_HANDLE, then pname:image must: equal
     slink:VkMemoryDedicatedAllocateInfo::pname:image and pname:memoryOffset
-    must: be zero.
+    must: be zero
 endif::VK_NV_dedicated_allocation_image_aliasing[]
 ifdef::VK_NV_dedicated_allocation_image_aliasing[]
   * [[VUID-VkBindImageMemoryInfo-memory-02630]]
@@ -5317,7 +5317,7 @@ ifdef::VK_NV_dedicated_allocation_image_aliasing[]
     pname:pNext chain, and slink:VkMemoryDedicatedAllocateInfo::pname:image
     was not dlink:VK_NULL_HANDLE, then pname:image must: equal
     slink:VkMemoryDedicatedAllocateInfo::pname:image and pname:memoryOffset
-    must: be zero.
+    must: be zero
   * [[VUID-VkBindImageMemoryInfo-memory-02631]]
     If the <<features-dedicatedAllocationImageAliasing,dedicated allocation
     image aliasing>> feature is enabled, and the sname:VkMemoryAllocateInfo
@@ -5333,7 +5333,7 @@ ifdef::VK_NV_dedicated_allocation_image_aliasing[]
     parameter of the image being bound must: be equal to or smaller than the
     original image for which the allocation was created; and the
     pname:arrayLayers parameter of the image being bound must: be equal to
-    or smaller than the original image for which the allocation was created.
+    or smaller than the original image for which the allocation was created
 endif::VK_NV_dedicated_allocation_image_aliasing[]
 endif::VK_VERSION_1_1,VK_KHR_dedicated_allocation[]
 ifdef::VK_NV_dedicated_allocation[]
@@ -5388,7 +5388,7 @@ ifdef::VK_KHR_swapchain[]
     slink:VkImageSwapchainCreateInfoKHR::pname:swapchain, then the
     pname:pNext chain must: include a
     slink:VkBindImageMemorySwapchainInfoKHR structure containing the same
-    swapchain handle.
+    swapchain handle
   * [[VUID-VkBindImageMemoryInfo-pNext-01631]]
     If the pname:pNext chain includes a
     slink:VkBindImageMemorySwapchainInfoKHR structure, pname:memory must: be
@@ -5485,18 +5485,18 @@ In other words, by default each physical device attaches to instance zero.
 ****
   * [[VUID-VkBindImageMemoryDeviceGroupInfo-deviceIndexCount-01633]]
     At least one of pname:deviceIndexCount and
-    pname:splitInstanceBindRegionCount must: be zero.
+    pname:splitInstanceBindRegionCount must: be zero
   * [[VUID-VkBindImageMemoryDeviceGroupInfo-deviceIndexCount-01634]]
     pname:deviceIndexCount must: either be zero or equal to the number of
     physical devices in the logical device
   * [[VUID-VkBindImageMemoryDeviceGroupInfo-pDeviceIndices-01635]]
-    All elements of pname:pDeviceIndices must: be valid device indices.
+    All elements of pname:pDeviceIndices must: be valid device indices
   * [[VUID-VkBindImageMemoryDeviceGroupInfo-splitInstanceBindRegionCount-01636]]
     pname:splitInstanceBindRegionCount must: either be zero or equal to the
     number of physical devices in the logical device squared
   * [[VUID-VkBindImageMemoryDeviceGroupInfo-pSplitInstanceBindRegions-01637]]
     Elements of pname:pSplitInstanceBindRegions that correspond to the same
-    instance of an image must: not overlap.
+    instance of an image must: not overlap
   * [[VUID-VkBindImageMemoryDeviceGroupInfo-offset-01638]]
     The pname:offset.x member of any element of
     pname:pSplitInstanceBindRegions must: be a multiple of the sparse image

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -244,27 +244,27 @@ endif::VK_VERSION_1_2,VK_EXT_sampler_filter_minmax[]
 ifdef::VK_EXT_fragment_density_map[]
   * [[VUID-VkSamplerCreateInfo-flags-02574]]
     If pname:flags includes ename:VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, then
-    pname:minFilter and pname:magFilter must: be equal.
+    pname:minFilter and pname:magFilter must: be equal
   * [[VUID-VkSamplerCreateInfo-flags-02575]]
     If pname:flags includes ename:VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, then
-    pname:mipmapMode must: be ename:VK_SAMPLER_MIPMAP_MODE_NEAREST.
+    pname:mipmapMode must: be ename:VK_SAMPLER_MIPMAP_MODE_NEAREST
   * [[VUID-VkSamplerCreateInfo-flags-02576]]
     If pname:flags includes ename:VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, then
-    pname:minLod and pname:maxLod must: be zero.
+    pname:minLod and pname:maxLod must: be zero
   * [[VUID-VkSamplerCreateInfo-flags-02577]]
     If pname:flags includes ename:VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, then
     pname:addressModeU and pname:addressModeV must: each be either
     ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE or
-    ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER.
+    ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER
   * [[VUID-VkSamplerCreateInfo-flags-02578]]
     If pname:flags includes ename:VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, then
-    pname:anisotropyEnable must: be ename:VK_FALSE.
+    pname:anisotropyEnable must: be ename:VK_FALSE
   * [[VUID-VkSamplerCreateInfo-flags-02579]]
     If pname:flags includes ename:VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, then
-    pname:compareEnable must: be ename:VK_FALSE.
+    pname:compareEnable must: be ename:VK_FALSE
   * [[VUID-VkSamplerCreateInfo-flags-02580]]
     If pname:flags includes ename:VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, then
-    pname:unnormalizedCoordinates must: be ename:VK_FALSE.
+    pname:unnormalizedCoordinates must: be ename:VK_FALSE
 endif::VK_EXT_fragment_density_map[]
 ****
 
@@ -663,7 +663,7 @@ ifdef::VK_ANDROID_external_memory_android_hardware_buffer[]
   * [[VUID-VkSamplerYcbcrConversionCreateInfo-format-01904]]
     If an external format conversion is being created, pname:format must: be
     ename:VK_FORMAT_UNDEFINED, otherwise it must: not be
-    ename:VK_FORMAT_UNDEFINED.
+    ename:VK_FORMAT_UNDEFINED
 endif::VK_ANDROID_external_memory_android_hardware_buffer[]
   * [[VUID-VkSamplerYcbcrConversionCreateInfo-format-01650]]
     The <<resources-sampler-ycbcr-conversion-format-features,sampler {YCbCr}
@@ -719,7 +719,7 @@ endif::VK_ANDROID_external_memory_android_hardware_buffer[]
   * [[VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrRange-02748]]
     If pname:ycbcrRange is ename:VK_SAMPLER_YCBCR_RANGE_ITU_NARROW then the
     R, G and B channels obtained by applying the pname:component swizzle to
-    pname:format must: each have a bit-depth greater than or equal to 8.
+    pname:format must: each have a bit-depth greater than or equal to 8
   * [[VUID-VkSamplerYcbcrConversionCreateInfo-forceExplicitReconstruction-01656]]
     If the <<resources-sampler-ycbcr-conversion-format-features,sampler
     {YCbCr} conversion's features>> do not support

--- a/chapters/shaders.txt
+++ b/chapters/shaders.txt
@@ -143,7 +143,7 @@ endif::VK_NV_glsl_shader[]
   * [[VUID-VkShaderModuleCreateInfo-pCode-01091]]
     If pname:pCode declares any of the capabilities listed as optional: in
     the <<spirvenv-capabilities-table,SPIR-V Environment>> appendix, the
-    corresponding feature(s) must: be enabled.
+    corresponding feature(s) must: be enabled
 ****
 
 include::{generated}/validity/structs/VkShaderModuleCreateInfo.txt[]

--- a/chapters/sparsemem.txt
+++ b/chapters/sparsemem.txt
@@ -1374,13 +1374,13 @@ ifdef::VK_VERSION_1_1,VK_KHR_external_memory[]
     least one handle type it contained must: also have been set in
     slink:VkExternalMemoryBufferCreateInfo::pname:handleTypes or
     slink:VkExternalMemoryImageCreateInfo::pname:handleTypes when the
-    resource was created.
+    resource was created
   * [[VUID-VkSparseMemoryBind-memory-02731]]
     If pname:memory was created by a memory import operation, the external
     handle type of the imported memory must: also have been set in
     slink:VkExternalMemoryBufferCreateInfo::pname:handleTypes or
     slink:VkExternalMemoryImageCreateInfo::pname:handleTypes when the
-    resource was created.
+    resource was created
 endif::VK_VERSION_1_1,VK_KHR_external_memory[]
 ****
 
@@ -1596,12 +1596,12 @@ ifdef::VK_VERSION_1_1,VK_KHR_external_memory[]
     slink:VkExportMemoryAllocateInfo::pname:handleTypes not equal to `0`, at
     least one handle type it contained must: also have been set in
     slink:VkExternalMemoryImageCreateInfo::pname:handleTypes when the image
-    was created.
+    was created
   * [[VUID-VkSparseImageMemoryBind-memory-02733]]
     If pname:memory was created by a memory import operation, the external
     handle type of the imported memory must: also have been set in
     slink:VkExternalMemoryImageCreateInfo::pname:handleTypes when
-    pname:image was created.
+    pname:image was created
 endif::VK_VERSION_1_1,VK_KHR_external_memory[]
 ****
 
@@ -1663,7 +1663,7 @@ Additional information about fence and semaphore operation is described in
     When a semaphore wait operation referring to a binary semaphore defined
     by any element of the pname:pWaitSemaphores member of any element of
     pname:pBindInfo executes on pname:queue, there must: be no other queues
-    waiting on the same semaphore.
+    waiting on the same semaphore
   * [[VUID-vkQueueBindSparse-pWaitSemaphores-01117]]
     All elements of the pname:pWaitSemaphores member of all elements of
     pname:pBindInfo member referring to a binary semaphore must: be
@@ -1677,7 +1677,7 @@ ifdef::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     ename:VK_SEMAPHORE_TYPE_BINARY must: reference a semaphore signal
     operation that has been submitted for execution and any semaphore signal
     operations on which it depends (if any) must: have also been submitted
-    for execution.
+    for execution
 endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
 ****
 
@@ -1760,7 +1760,7 @@ ifdef::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     from the value of any outstanding semaphore wait or signal operation on
     that semaphore by more than
     <<limits-maxTimelineSemaphoreValueDifference,
-    pname:maxTimelineSemaphoreValueDifference>>.
+    pname:maxTimelineSemaphoreValueDifference>>
   * [[VUID-VkBindSparseInfo-pSignalSemaphores-03251]]
     For each element of pname:pSignalSemaphores created with a
     elink:VkSemaphoreType of ename:VK_SEMAPHORE_TYPE_TIMELINE the
@@ -1770,7 +1770,7 @@ ifdef::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     from the value of any outstanding semaphore wait or signal operation on
     that semaphore by more than
     <<limits-maxTimelineSemaphoreValueDifference,
-    pname:maxTimelineSemaphoreValueDifference>>.
+    pname:maxTimelineSemaphoreValueDifference>>
 ****
 endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
 
@@ -1823,10 +1823,10 @@ pname:memoryDeviceIndex are assumed to be zero.
 ****
   * [[VUID-VkDeviceGroupBindSparseInfo-resourceDeviceIndex-01118]]
     pname:resourceDeviceIndex and pname:memoryDeviceIndex must: both be
-    valid device indices.
+    valid device indices
   * [[VUID-VkDeviceGroupBindSparseInfo-memoryDeviceIndex-01119]]
     Each memory allocation bound in this batch must: have allocated an
-    instance for pname:memoryDeviceIndex.
+    instance for pname:memoryDeviceIndex
 ****
 
 include::{generated}/validity/structs/VkDeviceGroupBindSparseInfo.txt[]

--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -1361,7 +1361,7 @@ endif::VK_KHR_external_fence[]
 ****
   * [[VUID-VkExportFenceCreateInfo-handleTypes-01446]]
     The bits in pname:handleTypes must be supported and compatible, as
-    reported by slink:VkExternalFenceProperties.
+    reported by slink:VkExternalFenceProperties
 ****
 
 include::{generated}/validity/structs/VkExportFenceCreateInfo.txt[]
@@ -1417,7 +1417,7 @@ ename:VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT
     If slink:VkExportFenceCreateInfo::pname:handleTypes does not include
     ename:VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT, a
     sname:VkExportFenceWin32HandleInfoKHR structure must: not be included in
-    the pname:pNext chain of slink:VkFenceCreateInfo.
+    the pname:pNext chain of slink:VkFenceCreateInfo
 ****
 
 include::{generated}/validity/structs/VkExportFenceWin32HandleInfoKHR.txt[]
@@ -1472,26 +1472,26 @@ properties of the defined external fence handle types.
   * [[VUID-VkFenceGetWin32HandleInfoKHR-handleType-01448]]
     pname:handleType must: have been included in
     slink:VkExportFenceCreateInfo::pname:handleTypes when the pname:fence's
-    current payload was created.
+    current payload was created
   * [[VUID-VkFenceGetWin32HandleInfoKHR-handleType-01449]]
     If pname:handleType is defined as an NT handle,
     flink:vkGetFenceWin32HandleKHR must: be called no more than once for
-    each valid unique combination of pname:fence and pname:handleType.
+    each valid unique combination of pname:fence and pname:handleType
   * [[VUID-VkFenceGetWin32HandleInfoKHR-fence-01450]]
     pname:fence must: not currently have its payload replaced by an imported
     payload as described below in
     <<synchronization-fences-importing,Importing Fence Payloads>> unless
     that imported payload's handle type was included in
     slink:VkExternalFenceProperties::pname:exportFromImportedHandleTypes for
-    pname:handleType.
+    pname:handleType
   * [[VUID-VkFenceGetWin32HandleInfoKHR-handleType-01451]]
     If pname:handleType refers to a handle type with copy payload
     transference semantics, pname:fence must: be signaled, or have an
     associated <<synchronization-fences-signaling,fence signal operation>>
-    pending execution.
+    pending execution
   * [[VUID-VkFenceGetWin32HandleInfoKHR-handleType-01452]]
     pname:handleType must: be defined as an NT handle or a global share
-    handle.
+    handle
 ****
 
 include::{generated}/validity/structs/VkFenceGetWin32HandleInfoKHR.txt[]
@@ -1567,21 +1567,21 @@ properties of the defined external fence handle types.
   * [[VUID-VkFenceGetFdInfoKHR-handleType-01453]]
     pname:handleType must: have been included in
     slink:VkExportFenceCreateInfo::pname:handleTypes when pname:fence's
-    current payload was created.
+    current payload was created
   * [[VUID-VkFenceGetFdInfoKHR-handleType-01454]]
     If pname:handleType refers to a handle type with copy payload
     transference semantics, pname:fence must: be signaled, or have an
     associated <<synchronization-fences-signaling,fence signal operation>>
-    pending execution.
+    pending execution
   * [[VUID-VkFenceGetFdInfoKHR-fence-01455]]
     pname:fence must: not currently have its payload replaced by an imported
     payload as described below in
     <<synchronization-fences-importing,Importing Fence Payloads>> unless
     that imported payload's handle type was included in
     slink:VkExternalFenceProperties::pname:exportFromImportedHandleTypes for
-    pname:handleType.
+    pname:handleType
   * [[VUID-VkFenceGetFdInfoKHR-handleType-01456]]
-    pname:handleType must: be defined as a POSIX file descriptor handle.
+    pname:handleType must: be defined as a POSIX file descriptor handle
 ****
 
 include::{generated}/validity/structs/VkFenceGetFdInfoKHR.txt[]
@@ -2029,28 +2029,28 @@ The handle types supported by pname:handleType are:
   * [[VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457]]
     pname:handleType must: be a value included in the
     <<synchronization-fence-handletypes-win32, Handle Types Supported by
-    VkImportFenceWin32HandleInfoKHR>> table.
+    VkImportFenceWin32HandleInfoKHR>> table
   * [[VUID-VkImportFenceWin32HandleInfoKHR-handleType-01459]]
     If pname:handleType is not
     ename:VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT, pname:name must:
-    be `NULL`.
+    be `NULL`
   * [[VUID-VkImportFenceWin32HandleInfoKHR-handleType-01460]]
     If pname:handleType is not `0` and pname:handle is `NULL`, pname:name
     must: name a valid synchronization primitive of the type specified by
-    pname:handleType.
+    pname:handleType
   * [[VUID-VkImportFenceWin32HandleInfoKHR-handleType-01461]]
     If pname:handleType is not `0` and pname:name is `NULL`, pname:handle
-    must: be a valid handle of the type specified by pname:handleType.
+    must: be a valid handle of the type specified by pname:handleType
   * [[VUID-VkImportFenceWin32HandleInfoKHR-handle-01462]]
-    If pname:handle is not `NULL`, pname:name must be `NULL`.
+    If pname:handle is not `NULL`, pname:name must be `NULL`
   * [[VUID-VkImportFenceWin32HandleInfoKHR-handle-01539]]
     If pname:handle is not `NULL`, it must: obey any requirements listed for
     pname:handleType in <<external-fence-handle-types-compatibility,external
-    fence handle types compatibility>>.
+    fence handle types compatibility>>
   * [[VUID-VkImportFenceWin32HandleInfoKHR-name-01540]]
     If pname:name is not `NULL`, it must: obey any requirements listed for
     pname:handleType in <<external-fence-handle-types-compatibility,external
-    fence handle types compatibility>>.
+    fence handle types compatibility>>
 ****
 
 include::{generated}/validity/structs/VkImportFenceWin32HandleInfoKHR.txt[]
@@ -2120,11 +2120,11 @@ The handle types supported by pname:handleType are:
   * [[VUID-VkImportFenceFdInfoKHR-handleType-01464]]
     pname:handleType must: be a value included in the
     <<synchronization-fence-handletypes-fd, Handle Types Supported by
-    VkImportFenceFdInfoKHR>> table.
+    VkImportFenceFdInfoKHR>> table
   * [[VUID-VkImportFenceFdInfoKHR-fd-01541]]
     pname:fd must: obey any requirements listed for pname:handleType in
     <<external-fence-handle-types-compatibility,external fence handle types
-    compatibility>>.
+    compatibility>>
 ****
 
 If pname:handleType is ename:VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT, the
@@ -2337,7 +2337,7 @@ include::{generated}/validity/structs/VkSemaphoreTypeCreateInfo.txt[]
     ename:VK_SEMAPHORE_TYPE_TIMELINE
   * [[VUID-VkSemaphoreTypeCreateInfo-semaphoreType-03279]]
     If pname:semaphoreType is ename:VK_SEMAPHORE_TYPE_BINARY,
-    pname:initialValue must: be zero.
+    pname:initialValue must: be zero
 ****
 
 If no sname:VkSemaphoreTypeCreateInfo structure is included in the
@@ -2405,7 +2405,7 @@ endif::VK_KHR_external_semaphore[]
 ****
   * [[VUID-VkExportSemaphoreCreateInfo-handleTypes-01124]]
     The bits in pname:handleTypes must: be supported and compatible, as
-    reported by slink:VkExternalSemaphoreProperties.
+    reported by slink:VkExternalSemaphoreProperties
 ****
 
 include::{generated}/validity/structs/VkExportSemaphoreCreateInfo.txt[]
@@ -2472,7 +2472,7 @@ code:GENERIC_ALL
     ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT or
     ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT,
     sname:VkExportSemaphoreWin32HandleInfoKHR must: not be included in the
-    pname:pNext chain of slink:VkSemaphoreCreateInfo.
+    pname:pNext chain of slink:VkSemaphoreCreateInfo
 ****
 
 include::{generated}/validity/structs/VkExportSemaphoreWin32HandleInfoKHR.txt[]
@@ -2527,31 +2527,31 @@ properties of the defined external semaphore handle types.
   * [[VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01126]]
     pname:handleType must: have been included in
     slink:VkExportSemaphoreCreateInfo::pname:handleTypes when the
-    pname:semaphore's current payload was created.
+    pname:semaphore's current payload was created
   * [[VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01127]]
     If pname:handleType is defined as an NT handle,
     flink:vkGetSemaphoreWin32HandleKHR must: be called no more than once for
-    each valid unique combination of pname:semaphore and pname:handleType.
+    each valid unique combination of pname:semaphore and pname:handleType
   * [[VUID-VkSemaphoreGetWin32HandleInfoKHR-semaphore-01128]]
     pname:semaphore must: not currently have its payload replaced by an
     imported payload as described below in
     <<synchronization-semaphores-importing,Importing Semaphore Payloads>>
     unless that imported payload's handle type was included in
     slink:VkExternalSemaphoreProperties::pname:exportFromImportedHandleTypes
-    for pname:handleType.
+    for pname:handleType
   * [[VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01129]]
     If pname:handleType refers to a handle type with copy payload
     transference semantics, as defined below in
     <<synchronization-semaphores-importing,Importing Semaphore Payloads>>,
-    there must: be no queue waiting on pname:semaphore.
+    there must: be no queue waiting on pname:semaphore
   * [[VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01130]]
     If pname:handleType refers to a handle type with copy payload
     transference semantics, pname:semaphore must: be signaled, or have an
     associated <<synchronization-semaphores-signaling,semaphore signal
-    operation>> pending execution.
+    operation>> pending execution
   * [[VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01131]]
     pname:handleType must: be defined as an NT handle or a global share
-    handle.
+    handle
 ****
 
 include::{generated}/validity/structs/VkSemaphoreGetWin32HandleInfoKHR.txt[]
@@ -2622,37 +2622,37 @@ properties of the defined external semaphore handle types.
   * [[VUID-VkSemaphoreGetFdInfoKHR-handleType-01132]]
     pname:handleType must: have been included in
     slink:VkExportSemaphoreCreateInfo::pname:handleTypes when
-    pname:semaphore's current payload was created.
+    pname:semaphore's current payload was created
   * [[VUID-VkSemaphoreGetFdInfoKHR-semaphore-01133]]
     pname:semaphore must: not currently have its payload replaced by an
     imported payload as described below in
     <<synchronization-semaphores-importing,Importing Semaphore Payloads>>
     unless that imported payload's handle type was included in
     slink:VkExternalSemaphoreProperties::pname:exportFromImportedHandleTypes
-    for pname:handleType.
+    for pname:handleType
   * [[VUID-VkSemaphoreGetFdInfoKHR-handleType-01134]]
     If pname:handleType refers to a handle type with copy payload
     transference semantics, as defined below in
     <<synchronization-semaphores-importing,Importing Semaphore Payloads>>,
-    there must: be no queue waiting on pname:semaphore.
+    there must: be no queue waiting on pname:semaphore
   * [[VUID-VkSemaphoreGetFdInfoKHR-handleType-01135]]
     If pname:handleType refers to a handle type with copy payload
     transference semantics, pname:semaphore must: be signaled, or have an
     associated <<synchronization-semaphores-signaling,semaphore signal
-    operation>> pending execution.
+    operation>> pending execution
   * [[VUID-VkSemaphoreGetFdInfoKHR-handleType-01136]]
     pname:handleType must: be defined as a POSIX file descriptor handle.
 ifdef::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
   * [[VUID-VkSemaphoreGetFdInfoKHR-handleType-03253]]
     If pname:handleType refers to a handle type with copy payload
     transference semantics, pname:semaphore must: have been created with a
-    elink:VkSemaphoreType of ename:VK_SEMAPHORE_TYPE_BINARY.
+    elink:VkSemaphoreType of ename:VK_SEMAPHORE_TYPE_BINARY
   * [[VUID-VkSemaphoreGetFdInfoKHR-handleType-03254]]
     If pname:handleType refers to a handle type with copy payload
     transference semantics, pname:semaphore must: have an associated
     semaphore signal operation that has been submitted for execution and any
     semaphore signal operations on which it depends (if any) must: have also
-    been submitted for execution.
+    been submitted for execution
 endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
 ****
 
@@ -3100,7 +3100,7 @@ endif::VK_KHR_timeline_semaphore[]
     value of the semaphore or the value of any outstanding semaphore wait or
     signal operation on pname:semaphore by more than
     <<limits-maxTimelineSemaphoreValueDifference,
-    pname:maxTimelineSemaphoreValueDifference>>.
+    pname:maxTimelineSemaphoreValueDifference>>
 ****
 
 include::{generated}/validity/structs/VkSemaphoreSignalInfo.txt[]
@@ -3352,31 +3352,31 @@ The handle types supported by pname:handleType are:
   * [[VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01140]]
     pname:handleType must: be a value included in the
     <<synchronization-semaphore-handletypes-win32,Handle Types Supported by
-    VkImportSemaphoreWin32HandleInfoKHR>> table.
+    VkImportSemaphoreWin32HandleInfoKHR>> table
   * [[VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01466]]
     If pname:handleType is not
     ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT or
     ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT, pname:name
-    must: be `NULL`.
+    must: be `NULL`
   * [[VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01467]]
     If pname:handleType is not `0` and pname:handle is `NULL`, pname:name
     must: name a valid synchronization primitive of the type specified by
-    pname:handleType.
+    pname:handleType
   * [[VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01468]]
     If pname:handleType is not `0` and pname:name is `NULL`, pname:handle
-    must: be a valid handle of the type specified by pname:handleType.
+    must: be a valid handle of the type specified by pname:handleType
   * [[VUID-VkImportSemaphoreWin32HandleInfoKHR-handle-01469]]
-    If pname:handle is not `NULL`, pname:name must be `NULL`.
+    If pname:handle is not `NULL`, pname:name must be `NULL`
   * [[VUID-VkImportSemaphoreWin32HandleInfoKHR-handle-01542]]
     If pname:handle is not `NULL`, it must: obey any requirements listed for
     pname:handleType in
     <<external-semaphore-handle-types-compatibility,external semaphore
-    handle types compatibility>>.
+    handle types compatibility>>
   * [[VUID-VkImportSemaphoreWin32HandleInfoKHR-name-01543]]
     If pname:name is not `NULL`, it must: obey any requirements listed for
     pname:handleType in
     <<external-semaphore-handle-types-compatibility,external semaphore
-    handle types compatibility>>.
+    handle types compatibility>>
   * [[VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-03261]]
     If pname:handleType is
     ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT or
@@ -3390,12 +3390,12 @@ ifdef::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT, the
     slink:VkSemaphoreTypeCreateInfo::pname:semaphoreType field must: match
     that of the semaphore from which pname:handle or pname:name was
-    exported.
+    exported
   * [[VUID-VkImportSemaphoreWin32HandleInfoKHR-flags-03322]]
     If pname:flags contains ename:VK_SEMAPHORE_IMPORT_TEMPORARY_BIT, the
     slink:VkSemaphoreTypeCreateInfo::pname:semaphoreType field of the
     semaphore from which pname:handle or pname:name was exported must: not
-    be ename:VK_SEMAPHORE_TYPE_TIMELINE.
+    be ename:VK_SEMAPHORE_TYPE_TIMELINE
 endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
 ****
 
@@ -3469,11 +3469,11 @@ The handle types supported by pname:handleType are:
   * [[VUID-VkImportSemaphoreFdInfoKHR-handleType-01143]]
     pname:handleType must: be a value included in the
     <<synchronization-semaphore-handletypes-fd,Handle Types Supported by
-    VkImportSemaphoreFdInfoKHR>> table.
+    VkImportSemaphoreFdInfoKHR>> table
   * [[VUID-VkImportSemaphoreFdInfoKHR-fd-01544]]
     pname:fd must: obey any requirements listed for pname:handleType in
     <<external-semaphore-handle-types-compatibility,external semaphore
-    handle types compatibility>>.
+    handle types compatibility>>
   * [[VUID-VkImportSemaphoreFdInfoKHR-handleType-03263]]
     If pname:handleType is
     ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT, the
@@ -3484,12 +3484,12 @@ ifdef::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
     If pname:handleType is
     ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT, the
     slink:VkSemaphoreTypeCreateInfo::pname:semaphoreType field must: match
-    that of the semaphore from which pname:fd was exported.
+    that of the semaphore from which pname:fd was exported
   * [[VUID-VkImportSemaphoreFdInfoKHR-flags-03323]]
     If pname:flags contains ename:VK_SEMAPHORE_IMPORT_TEMPORARY_BIT, the
     slink:VkSemaphoreTypeCreateInfo::pname:semaphoreType field of the
     semaphore from which pname:fd was exported must: not be
-    ename:VK_SEMAPHORE_TYPE_TIMELINE.
+    ename:VK_SEMAPHORE_TYPE_TIMELINE
 endif::VK_VERSION_1_2,VK_KHR_timeline_semaphore[]
 ****
 
@@ -3780,7 +3780,7 @@ signal operation occurs, and no execution dependency is generated.
 ifdef::VK_VERSION_1_1,VK_KHR_device_group[]
   * [[VUID-vkCmdSetEvent-commandBuffer-01152]]
     pname:commandBuffer's current device mask must: include exactly one
-    physical device.
+    physical device
 endif::VK_VERSION_1_1,VK_KHR_device_group[]
 ifdef::VK_NV_mesh_shader[]
   * [[VUID-vkCmdSetEvent-stageMask-02107]]
@@ -3849,7 +3849,7 @@ event unsignal operation occurs, and no execution dependency is generated.
 ifdef::VK_VERSION_1_1,VK_KHR_device_group[]
   * [[VUID-vkCmdResetEvent-commandBuffer-01157]]
     pname:commandBuffer's current device mask must: include exactly one
-    physical device.
+    physical device
 endif::VK_VERSION_1_1,VK_KHR_device_group[]
 ifdef::VK_NV_mesh_shader[]
   * [[VUID-vkCmdResetEvent-stageMask-02109]]
@@ -4007,21 +4007,21 @@ semaphore).
     structure that was used to create the sname:VkCommandPool that
     pname:commandBuffer was allocated from, as specified in the
     <<synchronization-pipeline-stages-supported, table of supported pipeline
-    stages>>.
+    stages>>
   * [[VUID-vkCmdWaitEvents-pMemoryBarriers-01165]]
     Each element of pname:pMemoryBarriers, pname:pBufferMemoryBarriers or
     pname:pImageMemoryBarriers must: not have any access flag included in
     its pname:srcAccessMask member if that bit is not supported by any of
     the pipeline stages in pname:srcStageMask, as specified in the
     <<synchronization-access-types-supported, table of supported access
-    types>>.
+    types>>
   * [[VUID-vkCmdWaitEvents-pMemoryBarriers-01166]]
     Each element of pname:pMemoryBarriers, pname:pBufferMemoryBarriers or
     pname:pImageMemoryBarriers must: not have any access flag included in
     its pname:dstAccessMask member if that bit is not supported by any of
     the pipeline stages in pname:dstStageMask, as specified in the
     <<synchronization-access-types-supported, table of supported access
-    types>>.
+    types>>
   * [[VUID-vkCmdWaitEvents-srcQueueFamilyIndex-02803]]
     The pname:srcQueueFamilyIndex and pname:dstQueueFamilyIndex members of
     any element of pname:pBufferMemoryBarriers or pname:pImageMemoryBarriers
@@ -4029,7 +4029,7 @@ semaphore).
 ifdef::VK_VERSION_1_1,VK_KHR_device_group[]
   * [[VUID-vkCmdWaitEvents-commandBuffer-01167]]
     pname:commandBuffer's current device mask must: include exactly one
-    physical device.
+    physical device
 endif::VK_VERSION_1_1,VK_KHR_device_group[]
 ifdef::VK_NV_mesh_shader[]
   * [[VUID-vkCmdWaitEvents-srcStageMask-02111]]
@@ -4588,7 +4588,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_external_memory[]
     and pname:dstQueueFamilyIndex is ename:VK_QUEUE_FAMILY_IGNORED, the
     other must: be ename:VK_QUEUE_FAMILY_IGNORED or a special queue family
     reserved for external memory ownership transfers, as described in
-    <<synchronization-queue-transfers>>.
+    <<synchronization-queue-transfers>>
 endif::VK_VERSION_1_1,VK_KHR_external_memory[]
 ifndef::VK_VERSION_1_1,VK_KHR_external_memory[]
   * [[VUID-VkBufferMemoryBarrier-buffer-01192]]
@@ -4609,13 +4609,13 @@ ifdef::VK_VERSION_1_1,VK_KHR_external_memory[]
     ename:VK_SHARING_MODE_EXCLUSIVE and pname:srcQueueFamilyIndex is not
     ename:VK_QUEUE_FAMILY_IGNORED, it must: be a valid queue family or a
     special queue family reserved for external memory transfers, as
-    described in <<synchronization-queue-transfers>>.
+    described in <<synchronization-queue-transfers>>
   * [[VUID-VkBufferMemoryBarrier-buffer-01765]]
     If pname:buffer was created with a sharing mode of
     ename:VK_SHARING_MODE_EXCLUSIVE and pname:dstQueueFamilyIndex is not
     ename:VK_QUEUE_FAMILY_IGNORED, it must: be a valid queue family or a
     special queue family reserved for external memory transfers, as
-    described in <<synchronization-queue-transfers>>.
+    described in <<synchronization-queue-transfers>>
 endif::VK_VERSION_1_1,VK_KHR_external_memory[]
   * [[VUID-VkBufferMemoryBarrier-buffer-01196]]
     If pname:buffer was created with a sharing mode of
@@ -4770,7 +4770,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_external_memory[]
     and pname:dstQueueFamilyIndex is ename:VK_QUEUE_FAMILY_IGNORED, the
     other must: be ename:VK_QUEUE_FAMILY_IGNORED or a special queue family
     reserved for external memory transfers, as described in
-    <<synchronization-queue-transfers>>.
+    <<synchronization-queue-transfers>>
 endif::VK_VERSION_1_1,VK_KHR_external_memory[]
 ifndef::VK_VERSION_1_1,VK_KHR_external_memory[]
   * [[VUID-VkImageMemoryBarrier-image-01200]]
@@ -4778,26 +4778,26 @@ ifndef::VK_VERSION_1_1,VK_KHR_external_memory[]
     ename:VK_SHARING_MODE_EXCLUSIVE, pname:srcQueueFamilyIndex and
     pname:dstQueueFamilyIndex must: either both be
     ename:VK_QUEUE_FAMILY_IGNORED, or both be a valid queue family (see
-    <<devsandqueues-queueprops>>).
+    <<devsandqueues-queueprops>>)
 endif::VK_VERSION_1_1,VK_KHR_external_memory[]
 ifdef::VK_VERSION_1_1,VK_KHR_external_memory[]
   * [[VUID-VkImageMemoryBarrier-image-01201]]
     If pname:image was created with a sharing mode of
     ename:VK_SHARING_MODE_EXCLUSIVE and pname:srcQueueFamilyIndex is
     ename:VK_QUEUE_FAMILY_IGNORED, pname:dstQueueFamilyIndex must: also be
-    ename:VK_QUEUE_FAMILY_IGNORED.
+    ename:VK_QUEUE_FAMILY_IGNORED
   * [[VUID-VkImageMemoryBarrier-image-01767]]
     If pname:image was created with a sharing mode of
     ename:VK_SHARING_MODE_EXCLUSIVE and pname:srcQueueFamilyIndex is not
     ename:VK_QUEUE_FAMILY_IGNORED, it must: be a valid queue family or a
     special queue family reserved for external memory transfers, as
-    described in <<synchronization-queue-transfers>>.
+    described in <<synchronization-queue-transfers>>
   * [[VUID-VkImageMemoryBarrier-image-01768]]
     If pname:image was created with a sharing mode of
     ename:VK_SHARING_MODE_EXCLUSIVE and pname:dstQueueFamilyIndex is not
     ename:VK_QUEUE_FAMILY_IGNORED, it must: be a valid queue family or a
     special queue family reserved for external memory transfers, as
-    described in <<synchronization-queue-transfers>>.
+    described in <<synchronization-queue-transfers>>
 endif::VK_VERSION_1_1,VK_KHR_external_memory[]
   * [[VUID-VkImageMemoryBarrier-image-01205]]
     If pname:image was created with a sharing mode of

--- a/scripts/deperiodize_vuids.py
+++ b/scripts/deperiodize_vuids.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+
+# Removes periods after Valid Usage sentence in the spec
+#
+# Usage:
+# cd <root of Vulkan-Docs repo>
+# ./scripts/deperiodize_vuids.py
+
+import os,re
+
+def deperiodizeFile(filename):
+    print('    Deperiodizing = %s' % filename)
+
+    with open(filename, 'r', encoding='utf8', newline='\n') as f:
+        data = f.read()
+
+    # Remove periods from VUs
+    data = re.sub( r'(  \* \[\[VUID\-[\s\S]+?)\.?(?=(\n  \* \[\[VUID\-)|(\n\*\*\*\*)|(\nendif))', r'\g<1>', data )
+
+    with open(filename, 'w', encoding='utf8', newline='\n') as f:
+        data = f.write(data)
+
+def deperiodizeFolder(folder):
+    print('  Parsing = %s' % folder)
+    for root, subdirs, files in os.walk(folder):
+        for file in files:
+            if file.endswith(".txt"):
+                file_path = os.path.join(root, file)
+                deperiodizeFile(file_path)
+        for subdir in subdirs:
+            sub_folder = os.path.join(root, subdir)
+            deperiodizeFolder(sub_folder)
+
+if __name__ == '__main__':
+    deperiodizeFolder(os.getcwd() + '/chapters')
+    deperiodizeFolder(os.getcwd() + '/appendices')


### PR DESCRIPTION
For consistency, remove periods at the end of every VU.

Automated script:

```
#!/usr/bin/python3

import os,re

def periodizeFile(filename):
    print('    Periodizing = %s' % filename)

    with open(filename, 'r', encoding='utf8', newline='\n') as f:
        data = f.read()

    # Remove periods from VUs
    data = re.sub( r'(  \* \[\[VUID\-[\s\S]+?)\.?(?=(\n  \* \[\[VUID\-)|(\n\*\*\*\*)|(\nendif))', r'\g<1>', data )

    with open(filename, 'w', encoding='utf8', newline='\n') as f:
        data = f.write(data)

def periodizeFolder(folder):
    print('  Parsing = %s' % folder)
    for root, subdirs, files in os.walk(folder):
        for file in files:
            if file.endswith(".txt"):
                file_path = os.path.join(root, file)
                periodizeFile(file_path)
        for subdir in subdirs:
            sub_folder = os.path.join(root, subdir)
            periodizeFolder(sub_folder)

if __name__ == '__main__':
    periodizeFolder(os.getcwd() + '/chapters')
    periodizeFolder(os.getcwd() + '/appendices')
```