### PR TITLE
Make chunked html permalinkable

### DIFF
--- a/config/chunkindex/chunked.js
+++ b/config/chunkindex/chunked.js
@@ -128,19 +128,9 @@ function searchKeyDown(e) {
   }
 }
 
-document.addEventListener("DOMContentLoaded", function(event) {
-  // get the chapter name from the current URL
-  var chap = window.location.pathname.replace(/.*\//, '');
-
-  var toc = document.getElementById("toc");
-
-  // Scroll the sidebar to the appropriate chapter
-  if(chap != "") {
-    scrollChapter(toc, chap);
-    toc.scrollTop -= 96;
-  }
-
+function initSearchbox() {
   // add anchor links to code blocks
+  // TODO: doesn't really belong here, and single-page could use this too
   var blocks = document.getElementsByClassName("listingblock")
 
   for(var i=0; i < blocks.length; i++) {
@@ -154,10 +144,11 @@ document.addEventListener("DOMContentLoaded", function(event) {
     }
   }
 
+  // actual searchbox init
   results = document.getElementById('results');
   searchbox = document.getElementById('searchbox');
 
-  loadJS("lunr.js", function() {
+  loadJS("lunr.js?v=2.3.8", function() {
     loadJS(searchindexurl, function() {
       searchengine = lunr.Index.load(searchindex);
 
@@ -167,4 +158,4 @@ document.addEventListener("DOMContentLoaded", function(event) {
       searchbox.addEventListener('input', searchInput, false);
     }, true);
   }, true);
-});
+}

--- a/config/chunkindex/generate-index.rb
+++ b/config/chunkindex/generate-index.rb
@@ -23,7 +23,7 @@ ARGV.each do |file|
     if line =~ /div id="([vV][kK][^"]*)"/ then
       id = $1
 
-      data << { :id => File.basename(file) + "#" + id, :title => id, :body => id }
+      data << { :id => "#" + id, :title => id, :body => id }
     end
 
     if line =~ /h[0-9]\s*id="([^"]*)"/ then
@@ -44,7 +44,7 @@ ARGV.each do |file|
         text = "#{curext.strip} - #{text}"
       end
 
-      curdata = { :id => File.basename(file) + "#" + id, :title => text, :body => "" }
+      curdata = { :id => "#" + id, :title => text, :body => "" }
     elsif curdata != nil then
       curdata[:body] += " " + text
     end

--- a/config/loadable_html/extension.rb
+++ b/config/loadable_html/extension.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 The Khronos Group Inc.
+# Copyright (c) 2016-2020 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,21 +12,32 @@ class MakeHtmlLoadable < Extensions::Postprocessor
 
     if document.attr? 'stem'
 
-      loading_msg = '<div id="loading_msg"><p>Loading&hellip; please wait.</p></div>'
+      logo_bug_white = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH5AYdEwQiw14QHwAAAhpJREFUaN7tWO1xgzAMfc5lADpBGYFO0GxQOkHpBE03YANGyAiQCegGJBMkG5AN1D/KHSXGXxinufO74/gBSHrSk2wMRERERESEABHVpEbxH20PnRQaJ7Wj3YT0SHwQWMTR3MSsTB0JIS4AGs1rG4fcvGme7332gS5bu9BVXVtyaAB8ATgDOPL9PHh+sbSX6/xx5f0QYGMvHofbhROQuspHzJTUVfOpJIhhdc5CiLPCTgqgAPAxsvOkq4CwCDblkr8CyBRZU+HA1xHAjxDiIPGTs0wvQoh3X43b0TLoiWjHQd80+NzAN0R0onA4EVHpa9Gq6H7oZxG5c/A3RKymEE+V1nEcNtycB9nU4YxmAK73Z75nBo3/KWt4l13hGK2sAR37bcv++wlfpYmh3qK8ssmRcjAlX6nknUynb36nkgyRWvmtRfDZKOhyYmJtJT5OAzstf5tPBcbPhsroJkkYzvvNKHhV1TpJZlWoVAsprxnTW2yDCdQqMqrdTRrYLwxknsikaZrRrQPpwqLCXhaxrcJBPtFw2j8qTo73X9IpEjsbjZrISJMYPz/uBiROjr1TBJGPJLDSsA90MuqCycdgV/pnHbCQUTj5TIyuSkVi5iYwQQiMFpPxipw7Bl8jNAZESse9VDj5eBq/i8ln5ZmD7Sma9tznHlXoH1I+jjKaPX1WC3DYP6x8LGXkRT7rhTh8G5zcNYiIiIh4ePwCG/5IoFeZaBUAAAAASUVORK5CYII='
+      loading_msg = '<div id="loading_msg">Loading <img alt="" class="loading_spinner" decoding="sync" src="' + logo_bug_white + '" /></div>'
       noJS_class = 'class="noJS"'
 
       loaded_script = '
 <style>
     #loading_msg {
-        width: 100%;
-        margin-left: auto;
-        margin-right: auto;
-        margin-top: 1ex;
-        margin-bottom: 1ex;
-        max-width: 62.5em;
-        position: relative;
-        padding-left: 1.5em;
-        padding-right: 1.5em;
+        position: fixed;
+        top: 0;
+        left: 50vw;
+        transform: translateX(-50%);
+        z-index: 1;
+        padding: 0.5em;
+        color: white;
+        background-color: #A41E22;
+        font-size: larger;
+    }
+    .loading_spinner {
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        animation: spin 1s linear infinite;
+    }
+    @keyframes spin {
+        0% {transform: rotateY(0deg);}
+        100% {transform: rotateY(360deg);}
     }
 
     html.noJS #loading_msg {display: none !important;}
@@ -47,7 +58,7 @@ class MakeHtmlLoadable < Extensions::Postprocessor
 
       output.sub! /(<html lang="en")/, '\1' + " " + noJS_class + " "
       output.sub! /(?=<\/head>)/, loaded_script
-      output.sub! /(?=<div id="content")/, loading_msg + "\n"
+      output.sub! /(<body.*?>)/, '\1' + "\n" + loading_msg
     end
     output
   end

--- a/scripts/motherchunker.py
+++ b/scripts/motherchunker.py
@@ -184,28 +184,28 @@ function locationHashChanged(){{
         var xhr = new XMLHttpRequest();
         xhr.onload = function() {{
             console.assert(xhr.readyState == 4, "readyState of XMLHttpRequest is not DONE on load event");
-            if( xhr.status == 200 ){{
-                //hideContent(); // TODO: hide the previous contents or not, that is the question
-                document.getElementById("content").innerHTML = xhr.response;
-                showContent();
-                hideLoadingMsg();
+            console.assert(xhr.status == 200 || window.location.protocol == "file:", "HTTP status is not 200 on load event");
 
-                if( hash != "" ){{
-                    document.getElementById(hash).scrollIntoView();
-                    var chapter_n = parseInt(page.substr(4));
-                    document.getElementById("toc").getElementsByClassName("sectlevel1")[0].children[chapter_n].scrollIntoView({{block: "center"}});
-                }}
-                else{{
-                    window.scrollTo(0,0);
-                }}
+            //hideContent(); // keep the previous contents on so there is no page blink
+            document.getElementById("content").innerHTML = xhr.response;
+            showContent();
+            hideLoadingMsg();
 
-                if( current_page === undefined ) initSearchbox(); // TODO: should be async call?
-                current_page = page;
+            if( hash != "" ){{
+                document.getElementById(hash).scrollIntoView();
+                var chapter_n = parseInt(page.substr(4));
+                document.getElementById("toc").getElementsByClassName("sectlevel1")[0].children[chapter_n].scrollIntoView({{block: "center"}});
             }}
-            else panic( "HTTP code " + xhr.status );
+            else{{
+                window.scrollTo(0,0);
+            }}
+
+            if( current_page === undefined ) initSearchbox(); // TODO: should be async call?
+            current_page = page;
         }};
         xhr.onerror = function() {{
-            if( window.location.protocol == "file:" && xhr.status == 0 ) panic( "<code>file://</code> protocol used; this website is not suitable for offline viewing" );
+            // file protocol does not send any status codes; have to assume it failed for security reasons
+            if( window.location.protocol == "file:" ) panic( "<code>file://</code> protocol used; this website is not suitable for offline viewing" );
             else panic( "request error; HTTP code " + xhr.status );
         }};
         xhr.onabort = function() {{ panic( "request aborted" ); }};

--- a/scripts/motherchunker.py
+++ b/scripts/motherchunker.py
@@ -1,0 +1,251 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2016-2020 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Makes a smart chunked spec that dynamically loads the right chapter page
+# based on what # anchor is in the URL
+#
+# Usage:
+# cd <root of Vulkan-Docs repo>
+# ./scripts/motherchunker.py ./gen/out/html/vkspec.html ./gen/out/chunked/vkspec.html
+
+import os,sys,re
+from html.parser import HTMLParser
+
+# Produces a map between html id anchor and a html file it will be in
+class IdHTMLParser(HTMLParser):
+    def __init__(self):
+        HTMLParser.__init__(self, convert_charrefs=True)
+
+        self.current_section = 0
+
+        self.id_map = [('', 'chap0.html')]
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'div' and ('class', 'sect1') in attrs:
+            self.current_section += 1
+
+        html_id = next((attr[1] for attr in attrs if attr[0] == 'id'), None)
+
+        if html_id is not None:
+            self.id_map.append((html_id, 'chap' + str(self.current_section) + '.html'))
+
+    # only actually triggers if there is explicitly '/' there at the end
+    def handle_startendtag(self, tag, attrs):
+        self.handle_starttag(tag, attrs)
+
+    def unknown_decl(self, data):
+        print( 'WARNING: unregognized syntax at {}!'.format(self.getpos()) )
+
+# Produces a template and the chunks the template loads into itself
+# plus some select modifications, like adding the searchbox
+class ChunkerHTMLParser(HTMLParser):
+    def __init__(self, additional_headers):
+        HTMLParser.__init__(self, convert_charrefs=False)
+
+        self.SELFCLOSING_TAGS = ['meta', 'link', 'br', 'col', 'wbr']
+        self.PLACEHOLDER_CONTENTS = \
+'''
+<noscript>
+    <p>The chunked specification requires JavaScript. Please enable JavaScript for this page, or consider using the <a href="../html/vkspec.html">single-page</a> specification.</p>
+</noscript>
+'''
+        self.PREAMBLE_TOC_ENTRY = '\n<li><a href="#preamble">0. Preamble</a></li>'
+        self.SEARCHBOX = \
+'''<div class="searchbox">
+    <label for="searchbox">Search: </label>
+    <input id="searchbox" type="text" disabled="disabled" value="Loading Search Data" />
+    <div id="resultsdiv"><ol id="results"></ol></div>
+</div>'''
+        self.additional_headers = additional_headers
+
+        self.current_section = 0
+        self.header_tag_level = None
+        self.content_tag_level = None
+        self.tag_stack = []
+
+        self.html_template = []
+        self.chunks = [] # For perf reasons, each chunk will be an array of strings to later be joined
+
+    def handle_starttag(self, tag, attrs):
+        # Track which section we are in to write to appropriate chunk
+        if tag == 'div' and ('class', 'sect1') in attrs:
+            self.current_section += 1
+            self.chunks.append([])
+
+        # Append "chunked" to the class of the <html> tag
+        if tag == 'html':
+            tag_text = '<html'
+            class_found = False
+            for (attr_name, attr_value) in attrs:
+                if attr_name == 'class':
+                    class_found = True
+                    attr_value += ' chunked'
+                tag_text += ' ' + attr_name + '="' + attr_value + '"'
+            if not class_found: tag_text += ' class="chunked"'
+            tag_text += '>'
+            self.html_template.append(tag_text)
+        # Add everything before first section to template, and everything after it to appropriate chunk
+        elif self.content_tag_level is None: self.html_template.append(self.get_starttag_text())
+        else: self.chunks[self.current_section].append(self.get_starttag_text())
+
+        # Add Preamble to the TOC
+        if tag == 'ul' and ('class', 'sectlevel1') in attrs:
+            self.html_template.append(self.PREAMBLE_TOC_ENTRY)
+
+        # Track whether we are in the common section of the html, or already in the first chunk
+        if tag == 'div' and ('id', 'content') in attrs:
+            if self.content_tag_level is not None: sys.exit( 'ERROR: second "content" tag encountered!' )
+            self.content_tag_level = len(self.tag_stack)
+            self.chunks.append([])
+
+        # Track whether we are in the header section of the spec (also includes the sidebar)
+        if tag == 'div' and ('id', 'header') in attrs:
+            self.header_tag_level = len(self.tag_stack)
+
+        if tag not in self.SELFCLOSING_TAGS: self.tag_stack.append(tag)
+
+    def handle_endtag(self, tag):
+        opened_tag = self.tag_stack.pop()
+        if tag != opened_tag: sys.exit( 'ERROR: closing tag <{}> at {} did not match opened tag <{}> !'.format(tag, self.getpos(), opened_tag) )
+
+        if self.content_tag_level is not None and len(self.tag_stack) == self.content_tag_level:
+            if tag != 'div': sys.exit( 'ERROR: expected <div> as a closing tag of content!' )
+            self.content_tag_level = None
+
+            # Add contents that will be in the contents container before any chunk loads
+            self.html_template.append(self.PLACEHOLDER_CONTENTS)
+
+        if tag == 'head': self.html_template.append(self.additional_headers)
+
+        # Add searchbox to the sidebar
+        if self.header_tag_level is not None and len(self.tag_stack) == self.header_tag_level:
+            self.html_template.append(self.SEARCHBOX)
+            self.header_tag_level = None
+
+        # Add everything after last section to template, and everything before it to appropriate chunk
+        if self.content_tag_level is None: self.html_template.append('</' + tag + '>')
+        else: self.chunks[self.current_section].append('</' + tag + '>')
+
+    # Write the rest of the html elements to either template or chunk as appropriate
+    def handle_startendtag(self, tag, attrs): # only actually triggers if there is explicitly '/' there at the end (usually in SVG)
+        if self.content_tag_level is None: self.html_template.append(self.get_starttag_text())
+        else: self.chunks[self.current_section].append(self.get_starttag_text())
+    def handle_data(self, data):
+        if self.content_tag_level is None: self.html_template.append(data)
+        else: self.chunks[self.current_section].append(data)
+    def handle_comment(self, data):
+        self.handle_data( '<!--' + data + '-->' )
+    def handle_decl(self, decl):
+        self.handle_data( '<!' + decl + '>' )
+    def handle_entityref(self, name):
+        self.handle_data( '&' + name + ';' )
+    def handle_charref(self, name):
+        self.handle_data( '&#' + name + ';' )
+    def unknown_decl(self, data):
+        print( 'WARNING: unregognized syntax at {}!'.format(self.getpos()) )
+        self.handle_data( data )
+
+def makeChunked(in_file, out_file):
+    try:
+        with open(in_file, 'r', encoding='utf8') as f: data = f.read()
+    except FileNotFoundError:
+        print('Error: File %s does not exist.' % in_file)
+        sys.exit(2)
+
+    id_parser = IdHTMLParser()
+    id_parser.feed(data)
+
+    redirect_script = \
+'''<script>
+var id_map = {{{}}};
+
+var current_page;
+
+function panic( reason ){{
+    console.error("Page load failed! Reason: " + reason);
+    document.getElementById("content").innerHTML = "<p>Page failed to load (reason: " + reason + ").</p>";
+    showContent();
+    hideLoadingMsg();
+    current_page = undefined;
+}}
+
+function locationHashChanged(){{
+    var hash = location.hash;
+    if( !hash ) hash = "";
+    if( hash.startsWith("#") ) hash = hash.substring(1);
+
+    var page = id_map[hash];
+    if( page !== undefined && page != current_page ){{
+        showLoadingMsg();
+
+        var xhr = new XMLHttpRequest();
+        xhr.onload = function() {{
+            console.assert(xhr.readyState == 4, "readyState of XMLHttpRequest is not DONE on load event");
+            if( xhr.status == 200 ){{
+                //hideContent(); // TODO: hide the previous contents or not, that is the question
+                document.getElementById("content").innerHTML = xhr.response;
+                showContent();
+                hideLoadingMsg();
+
+                if( hash != "" ){{
+                    document.getElementById(hash).scrollIntoView();
+                    var chapter_n = parseInt(page.substr(4));
+                    document.getElementById("toc").getElementsByClassName("sectlevel1")[0].children[chapter_n].scrollIntoView({{block: "center"}});
+                }}
+                else{{
+                    window.scrollTo(0,0);
+                }}
+
+                if( current_page === undefined ) initSearchbox(); // TODO: should be async call?
+                current_page = page;
+            }}
+            else panic( "HTTP code " + xhr.status );
+        }};
+        xhr.onerror = function() {{
+            if( window.location.protocol == "file:" && xhr.status == 0 ) panic( "<code>file://</code> protocol used; this website is not suitable for offline viewing" );
+            else panic( "request error; HTTP code " + xhr.status );
+        }};
+        xhr.onabort = function() {{ panic( "request aborted" ); }};
+        xhr.ontimeout = function() {{ panic( "request timed out" );  }};
+
+        xhr.open("GET", page + "?v=" + document.title.replace(/[^0-9.]/g, ''));
+        xhr.timeout = 5000; //ms
+        xhr.send();
+    }}
+}}
+
+window.onhashchange = locationHashChanged;
+window.addEventListener("load", locationHashChanged);
+</script>'''
+
+    redirect_map = ['"{}":"{}"'.format(html_id, page) for html_id, page in id_parser.id_map]
+    redirect_map = ','.join(redirect_map)
+    redirect_script = redirect_script.format(redirect_map)
+
+    searchbox_script = \
+'''
+<link href="chunked.css?v=4" rel="stylesheet">
+<script>var searchindexurl = 'search.index.js?v=2.3.8&spec=' + (document.title.replace(/[^0-9.]/g, ''));</script>
+<script src="chunked.js?v=5"></script>
+'''
+
+    additional_headers = redirect_script + searchbox_script
+    chunker_parser = ChunkerHTMLParser(additional_headers)
+    chunker_parser.feed(data)
+
+    with open(out_file, 'w', encoding='utf8') as f: f.write(''.join(chunker_parser.html_template))
+
+    out_dir = os.path.dirname(out_file)
+    for section, chunk in enumerate(chunker_parser.chunks):
+        chunk_file = os.path.join(out_dir, 'chap' + str(section) + '.html')
+        with open(chunk_file, 'w', encoding='utf8') as f: f.write(''.join(chunk))
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print('Error: .py requires two arguments.')
+        print('Usage: .py file.html file.html')
+        sys.exit(1)
+    makeChunked(sys.argv[1], sys.argv[2])

--- a/scripts/motherchunker.py
+++ b/scripts/motherchunker.py
@@ -192,9 +192,12 @@ function locationHashChanged(){{
             hideLoadingMsg();
 
             if( hash != "" ){{
-                document.getElementById(hash).scrollIntoView();
+                // scroll to chapter in the TOC
                 var chapter_n = parseInt(page.substr(4));
                 document.getElementById("toc").getElementsByClassName("sectlevel1")[0].children[chapter_n].scrollIntoView({{block: "center"}});
+
+                // scroll to contents (also should undo the above if TOC is not a sidebar)
+                document.getElementById(hash).scrollIntoView();
             }}
             else{{
                 window.scrollTo(0,0);


### PR DESCRIPTION
Make chunked html permalinkable. I.e. so it accepts any anchor in `vkspec.html#vkHash` as if it was single-page spec.

Demo: http://vulkan.hys.cz/chunked_smart/vkspec.html#VkInstanceCreateInfo

TODO:
- [x] Do not load page when already on the correct chapter
- [x] Make links in the spec point to `vkspec.html` instead of `chap*.html` (might as well rewrite the chunker, ugh...)
- [x] Check that script is not triggered by external links
- [x] Rename index.html to something less indexy
- [x] Deal with the searchbox
- [x] Handle JavaScript\HTTP errors
- [x] Scroll to appropriate part in the TOC too
  - [x] Broken on mobile where the toc is on top; fix
- [ ] Make refpages link to this version (@oddhack wants to take care of it)
- [x] Gracefully handle disabled JavaScript
- [x] Reintroduce injecting Preamble into the TOC, or make it part of every chapter.
- [x] Properly integrate the "loadable" (#702) script
- [x] Searchbox feels to be loaded prematurely on first page load
- [x] Use the `?` for versioning browser cache
- [x] Make loading message\page less obtrusive (no blink)
- [x] <s>Deal with offline viewing (`file://`)</s>, or fail gracefully with specific error message
  - [ ] Make a fallback for offline viewing
- [ ] Restore link handles to code listings (perhaps best done outside this PR to include single-page)
- Soliciting feedback
- ?