### PR TITLE
Add VK_EXT_directfb_surface

### DIFF
--- a/include/vulkan/vulkan.h
+++ b/include/vulkan/vulkan.h
@@ -71,6 +71,12 @@
 #endif
 
 
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+#include <directfb.h>
+#include "vulkan_directfb.h"
+#endif
+
+
 #ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>

--- a/scripts/genvk.py
+++ b/scripts/genvk.py
@@ -293,6 +293,7 @@ def makeGenOpts(args):
                                                                      ] ],
         [ 'vulkan_xcb.h',         [ 'VK_KHR_xcb_surface'          ], commonSuppressExtensions ],
         [ 'vulkan_xlib.h',        [ 'VK_KHR_xlib_surface'         ], commonSuppressExtensions ],
+        [ 'vulkan_directfb.h',    [ 'VK_EXT_directfb_surface'     ], commonSuppressExtensions ],
         [ 'vulkan_xlib_xrandr.h', [ 'VK_EXT_acquire_xlib_display' ], commonSuppressExtensions ],
         [ 'vulkan_metal.h',       [ 'VK_EXT_metal_surface'        ], commonSuppressExtensions ],
         [ 'vulkan_beta.h',        betaRequireExtensions,             betaSuppressExtensions ],

--- a/xml/Makefile
+++ b/xml/Makefile
@@ -56,6 +56,7 @@ PLATFORM_HEADERS = \
     $(VULKAN)/vulkan_win32.h \
     $(VULKAN)/vulkan_xcb.h \
     $(VULKAN)/vulkan_xlib.h \
+    $(VULKAN)/vulkan_directfb.h \
     $(VULKAN)/vulkan_xlib_xrandr.h \
     $(VULKAN)/vulkan_metal.h \
     $(VULKAN)/vulkan_beta.h

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -23,6 +23,7 @@ server.
         <platform name="xlib_xrandr" protect="VK_USE_PLATFORM_XLIB_XRANDR_EXT" comment="X Window System, Xlib client library, XRandR extension"/>
         <platform name="xcb" protect="VK_USE_PLATFORM_XCB_KHR" comment="X Window System, Xcb client library"/>
         <platform name="wayland" protect="VK_USE_PLATFORM_WAYLAND_KHR" comment="Wayland display server protocol"/>
+        <platform name="directfb" protect="VK_USE_PLATFORM_DIRECTFB_EXT" comment="DirectFB library"/>
         <platform name="android" protect="VK_USE_PLATFORM_ANDROID_KHR" comment="Android OS"/>
         <platform name="win32" protect="VK_USE_PLATFORM_WIN32_KHR" comment="Microsoft Win32 API (also refers to Win64 apps)"/>
         <platform name="vi" protect="VK_USE_PLATFORM_VI_NN" comment="Nintendo Vi"/>
@@ -77,6 +78,7 @@ server.
         <type category="include" name="wayland-client.h"/>
         <type category="include" name="windows.h"/>
         <type category="include" name="xcb/xcb.h"/>
+        <type category="include" name="directfb.h"/>
         <type category="include" name="zircon/types.h"/>
         <type category="include" name="ggp_c/vulkan_types.h"/>
             <comment>
@@ -112,6 +114,8 @@ server.
         <type requires="xcb/xcb.h" name="xcb_connection_t"/>
         <type requires="xcb/xcb.h" name="xcb_visualid_t"/>
         <type requires="xcb/xcb.h" name="xcb_window_t"/>
+        <type requires="directfb.h" name="IDirectFB"/>
+        <type requires="directfb.h" name="IDirectFBSurface"/>
         <type requires="zircon/types.h" name="zx_handle_t"/>
         <type requires="ggp_c/vulkan_types.h" name="GgpStreamDescriptor"/>
         <type requires="ggp_c/vulkan_types.h" name="GgpFrameToken"/>
@@ -272,6 +276,7 @@ typedef void <name>CAMetalLayer</name>;
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkWin32SurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXlibSurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXcbSurfaceCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDirectFBSurfaceCreateFlagsEXT</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkIOSSurfaceCreateFlagsMVK</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMacOSSurfaceCreateFlagsMVK</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMetalSurfaceCreateFlagsEXT</name>;</type>
@@ -1727,6 +1732,13 @@ typedef void <name>CAMetalLayer</name>;
             <member optional="true"><type>VkXcbSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>xcb_connection_t</type>*                <name>connection</name></member>
             <member><type>xcb_window_t</type>                     <name>window</name></member>
+        </type>
+        <type category="struct" name="VkDirectFBSurfaceCreateInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkDirectFBSurfaceCreateFlagsEXT</type>   <name>flags</name></member>
+            <member noautovalidity="true"><type>IDirectFB</type>*                       <name>dfb</name></member>
+            <member noautovalidity="true"><type>IDirectFBSurface</type>*                <name>surface</name></member>
         </type>
         <type category="struct" name="VkImagePipeSurfaceCreateInfoFUCHSIA">
             <member values="VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA"><type>VkStructureType</type> <name>sType</name></member>
@@ -7322,6 +7334,19 @@ typedef void <name>CAMetalLayer</name>;
             <param><type>uint32_t</type> <name>queueFamilyIndex</name></param>
             <param><type>xcb_connection_t</type>* <name>connection</name></param>
             <param><type>xcb_visualid_t</type> <name>visual_id</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateDirectFBSurfaceEXT</name></proto>
+            <param><type>VkInstance</type> <name>instance</name></param>
+            <param>const <type>VkDirectFBSurfaceCreateInfoEXT</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkSurfaceKHR</type>* <name>pSurface</name></param>
+        </command>
+        <command>
+            <proto><type>VkBool32</type> <name>vkGetPhysicalDeviceDirectFBPresentationSupportEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>uint32_t</type> <name>queueFamilyIndex</name></param>
+            <param><type>IDirectFB</type>* <name>dfb</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkCreateImagePipeSurfaceFUCHSIA</name></proto>
@@ -13666,6 +13691,17 @@ typedef void <name>CAMetalLayer</name>;
             <require>
                 <enum value="0"                                             name="VK_NV_EXTENSION_346_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_extension_346&quot;"       name="VK_NV_EXTENSION_346_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_directfb_surface" number="347" type="instance" requires="VK_KHR_surface" platform="directfb" supported="vulkan" author="EXT" contact="Nicolas Caramelli @caramelli">
+            <require>
+                <enum value="1"                                             name="VK_EXT_DIRECTFB_SURFACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_directfb_surface&quot;"           name="VK_EXT_DIRECTFB_SURFACE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT"/>
+                <type name="VkDirectFBSurfaceCreateFlagsEXT"/>
+                <type name="VkDirectFBSurfaceCreateInfoEXT"/>
+                <command name="vkCreateDirectFBSurfaceEXT"/>
+                <command name="vkGetPhysicalDeviceDirectFBPresentationSupportEXT"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
DirectFB interfaces was largely widespread in the GNU/Linux embedded world and the VK_EXT_directfb_surface extension allows rendering via DirectFB on such platform.

A screenshot with simple Vulkan examples running with the VK_EXT_directfb_surface extension is available on the HiGFXback project:

https://github.com/caramelli/higfxback/wiki/DirectFB#vulkan-rendering

And the yagears project provides sample code to use this VK_EXT_directfb_surface extension:

https://github.com/caramelli/yagears

Nicolas Caramelli