### PR TITLE
Add specification for VK_EXT_directfb_surface extension

### DIFF
--- a/appendices/VK_EXT_directfb_surface.txt
+++ b/appendices/VK_EXT_directfb_surface.txt
@@ -1,0 +1,29 @@
+// Copyright (c) 2014-2020 Khronos Group.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_directfb_surface.txt[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2020-06-16
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Nicolas Caramelli
+
+=== Description
+
+The `VK_EXT_directfb_surface` extension is an instance extension.
+It provides a mechanism to create a slink:VkSurfaceKHR object (defined by
+the `<<VK_KHR_surface>>` extension) that refers to a DirectFB
+code:IDirectFBSurface, as well as a query to determine support for rendering
+via DirectFB.
+
+include::{generated}/interfaces/VK_EXT_directfb_surface.txt[]
+
+=== Version History
+
+ * Revision 1, 2020-06-16 (Nicolas Caramelli)
+   - Initial version

--- a/appendices/boilerplate.txt
+++ b/appendices/boilerplate.txt
@@ -288,6 +288,9 @@ endif::VK_NV_win32_keyed_mutex[]
                                      | Microsoft Windows      | `vulkan_win32.h`         | `<windows.h>`                  | dname:VK_USE_PLATFORM_WIN32_KHR
 | `<<VK_KHR_xcb_surface>>`           | X11 Xcb                | `vulkan_xcb.h`           | `<xcb/xcb.h>`                  | dname:VK_USE_PLATFORM_XCB_KHR
 | `<<VK_KHR_xlib_surface>>`          | X11 Xlib               | `vulkan_xlib.h`          | `<X11/Xlib.h>`                 | dname:VK_USE_PLATFORM_XLIB_KHR
+ifdef::VK_EXT_directfb_surface[]
+| `<<VK_EXT_directfb_surface>>`      | DirectFB               | `vulkan_directfb.h`      | `<directfb.h>`                 | dname:VK_USE_PLATFORM_DIRECTFB_EXT
+endif::VK_EXT_directfb_surface[]
 ifdef::VK_EXT_acquire_xlib_display[]
 | `<<VK_EXT_acquire_xlib_display>>`  | X11 XRAndR             | `vulkan_xlib_xrandr.h`   | `<X11/Xlib.h>`,
                                                                                            `<X11/extensions{wbro}/Xrandr.h>`    | dname:VK_USE_PLATFORM_XLIB_XRANDR_EXT

--- a/chapters/VK_EXT_directfb_surface/platformCreateSurface_directfb.txt
+++ b/chapters/VK_EXT_directfb_surface/platformCreateSurface_directfb.txt
@@ -40,6 +40,12 @@ include::{generated}/api/structs/VkDirectFBSurfaceCreateInfoEXT.txt[]
   * pname:dfb is a pointer to the code:IDirectFB main interface of DirectFB.
   * pname:surface is a pointer to a code:IDirectFBSurface surface interface.
 
+.Valid Usage
+****
+  * pname:dfb must: point to a valid DirectFB code:IDirectFB
+  * pname:surface must: point to a valid DirectFB code:IDirectFBSurface
+****
+
 include::{generated}/validity/structs/VkDirectFBSurfaceCreateInfoEXT.txt[]
 --
 

--- a/chapters/VK_EXT_directfb_surface/platformCreateSurface_directfb.txt
+++ b/chapters/VK_EXT_directfb_surface/platformCreateSurface_directfb.txt
@@ -1,0 +1,55 @@
+// Copyright (c) 2014-2020 Khronos Group.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[platformCreateSurface_directfb,platformCreateSurface_directfb]]
+
+=== DirectFB Platform
+
+[open,refpage='vkCreateDirectFBSurfaceEXT',desc='Create a slink:VkSurfaceKHR object for a DirectFB surface',type='protos']
+--
+
+To create a sname:VkSurfaceKHR object for a DirectFB surface, call:
+
+include::{generated}/api/protos/vkCreateDirectFBSurfaceEXT.txt[]
+
+  * pname:instance is the instance to associate the surface with.
+  * pname:pCreateInfo is a pointer to a sname:VkDirectFBSurfaceCreateInfoEXT
+    structure containing parameters affecting the creation of the surface
+    object.
+  * pname:pAllocator is the allocator used for host memory allocated for the
+    surface object when there is no more specific allocator available (see
+    <<memory-allocation,Memory Allocation>>).
+  * pname:pSurface is a pointer to a slink:VkSurfaceKHR handle in which the
+    created surface object is returned.
+
+include::{generated}/validity/protos/vkCreateDirectFBSurfaceEXT.txt[]
+--
+
+[open,refpage='VkDirectFBSurfaceCreateInfoEXT',desc='Structure specifying parameters of a newly created DirectFB surface object',type='structs']
+--
+
+The sname:VkDirectFBSurfaceCreateInfoEXT structure is defined as:
+
+include::{generated}/api/structs/VkDirectFBSurfaceCreateInfoEXT.txt[]
+
+  * pname:sType is the type of this structure.
+  * pname:pNext is `NULL` or a pointer to a structure extending this
+    structure.
+  * pname:flags is reserved for future use.
+  * pname:dfb is a pointer to the code:IDirectFB main interface of DirectFB.
+  * pname:surface is a pointer to a code:IDirectFBSurface surface interface.
+
+include::{generated}/validity/structs/VkDirectFBSurfaceCreateInfoEXT.txt[]
+--
+
+With DirectFB, pname:minImageExtent, pname:maxImageExtent, and
+pname:currentExtent must: always equal the surface size.
+
+[open,refpage='VkDirectFBSurfaceCreateFlagsEXT',desc='Reserved for future use',type='flags']
+--
+include::{generated}/api/flags/VkDirectFBSurfaceCreateFlagsEXT.txt[]
+
+tname:VkDirectFBSurfaceCreateFlagsEXT is a bitmask type for setting a mask,
+but is currently reserved for future use.
+--

--- a/chapters/VK_EXT_directfb_surface/platformQuerySupport_directfb.txt
+++ b/chapters/VK_EXT_directfb_surface/platformQuerySupport_directfb.txt
@@ -20,5 +20,13 @@ include::{generated}/api/protos/vkGetPhysicalDeviceDirectFBPresentationSupportEX
 
 This platform-specific function can: be called prior to creating a surface.
 
+.Valid Usage
+****
+  * pname:queueFamilyIndex must: be less than
+    pname:pQueueFamilyPropertyCount returned by
+    fname:vkGetPhysicalDeviceQueueFamilyProperties for the given
+    pname:physicalDevice
+****
+
 include::{generated}/validity/protos/vkGetPhysicalDeviceDirectFBPresentationSupportEXT.txt[]
 --

--- a/chapters/VK_EXT_directfb_surface/platformQuerySupport_directfb.txt
+++ b/chapters/VK_EXT_directfb_surface/platformQuerySupport_directfb.txt
@@ -1,0 +1,24 @@
+// Copyright (c) 2014-2020 Khronos Group.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[platformQuerySupport_directfb,platformQuerySupport_directfb]]
+
+=== DirectFB Platform
+
+[open,refpage='vkGetPhysicalDeviceDirectFBPresentationSupportEXT',desc='Query physical device for presentation with DirectFB',type='protos']
+--
+
+To determine whether a queue family of a physical device supports
+presentation with DirectFB library, call:
+
+include::{generated}/api/protos/vkGetPhysicalDeviceDirectFBPresentationSupportEXT.txt[]
+
+  * pname:physicalDevice is the physical device.
+  * pname:queueFamilyIndex is the queue family index.
+  * pname:dfb is a pointer to the code:IDirectFB main interface of DirectFB.
+
+This platform-specific function can: be called prior to creating a surface.
+
+include::{generated}/validity/protos/vkGetPhysicalDeviceDirectFBPresentationSupportEXT.txt[]
+--

--- a/chapters/VK_KHR_surface/wsi.txt
+++ b/chapters/VK_KHR_surface/wsi.txt
@@ -110,6 +110,10 @@ ifdef::VK_KHR_xlib_surface[]
 include::{chapters}/VK_KHR_xlib_surface/platformCreateSurface_xlib.txt[]
 endif::VK_KHR_xlib_surface[]
 
+ifdef::VK_EXT_directfb_surface[]
+include::{chapters}/VK_EXT_directfb_surface/platformCreateSurface_directfb.txt[]
+endif::VK_EXT_directfb_surface[]
+
 ifdef::VK_FUCHSIA_imagepipe_surface[]
 include::{chapters}/VK_FUCHSIA_imagepipe_surface/platformCreateSurface_imagepipe.txt[]
 endif::VK_FUCHSIA_imagepipe_surface[]
@@ -248,6 +252,10 @@ endif::VK_KHR_xcb_surface[]
 ifdef::VK_KHR_xlib_surface[]
 include::{chapters}/VK_KHR_xlib_surface/platformQuerySupport_xlib.txt[]
 endif::VK_KHR_xlib_surface[]
+
+ifdef::VK_EXT_directfb_surface[]
+include::{chapters}/VK_EXT_directfb_surface/platformQuerySupport_directfb.txt[]
+endif::VK_EXT_directfb_surface[]
 
 ifdef::VK_FUCHSIA_imagepipe_surface[]
 include::{chapters}/VK_FUCHSIA_imagepipe_surface/platformQuerySupport_imagepipe.txt[]

--- a/include/vulkan/vulkan.h
+++ b/include/vulkan/vulkan.h
@@ -61,6 +61,12 @@
 #endif
 
 
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+#include <directfb.h>
+#include "vulkan_directfb.h"
+#endif
+
+
 #ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>

--- a/scripts/genvk.py
+++ b/scripts/genvk.py
@@ -294,6 +294,7 @@ def makeGenOpts(args):
                                                                      ] ],
         [ 'vulkan_xcb.h',         [ 'VK_KHR_xcb_surface'          ], commonSuppressExtensions ],
         [ 'vulkan_xlib.h',        [ 'VK_KHR_xlib_surface'         ], commonSuppressExtensions ],
+        [ 'vulkan_directfb.h',    [ 'VK_EXT_directfb_surface'     ], commonSuppressExtensions ],
         [ 'vulkan_xlib_xrandr.h', [ 'VK_EXT_acquire_xlib_display' ], commonSuppressExtensions ],
         [ 'vulkan_metal.h',       [ 'VK_EXT_metal_surface'        ], commonSuppressExtensions ],
         [ 'vulkan_beta.h',        betaRequireExtensions,             betaSuppressExtensions ],

--- a/xml/Makefile
+++ b/xml/Makefile
@@ -56,6 +56,7 @@ PLATFORM_HEADERS = \
     $(VULKAN)/vulkan_win32.h \
     $(VULKAN)/vulkan_xcb.h \
     $(VULKAN)/vulkan_xlib.h \
+    $(VULKAN)/vulkan_directfb.h \
     $(VULKAN)/vulkan_xlib_xrandr.h \
     $(VULKAN)/vulkan_metal.h \
     $(VULKAN)/vulkan_beta.h

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -23,6 +23,7 @@ server.
         <platform name="xlib_xrandr" protect="VK_USE_PLATFORM_XLIB_XRANDR_EXT" comment="X Window System, Xlib client library, XRandR extension"/>
         <platform name="xcb" protect="VK_USE_PLATFORM_XCB_KHR" comment="X Window System, Xcb client library"/>
         <platform name="wayland" protect="VK_USE_PLATFORM_WAYLAND_KHR" comment="Wayland display server protocol"/>
+        <platform name="directfb" protect="VK_USE_PLATFORM_DIRECTFB_EXT" comment="DirectFB library"/>
         <platform name="android" protect="VK_USE_PLATFORM_ANDROID_KHR" comment="Android OS"/>
         <platform name="win32" protect="VK_USE_PLATFORM_WIN32_KHR" comment="Microsoft Win32 API (also refers to Win64 apps)"/>
         <platform name="vi" protect="VK_USE_PLATFORM_VI_NN" comment="Nintendo Vi"/>
@@ -77,6 +78,7 @@ server.
         <type category="include" name="wayland-client.h"/>
         <type category="include" name="windows.h"/>
         <type category="include" name="xcb/xcb.h"/>
+        <type category="include" name="directfb.h"/>
         <type category="include" name="zircon/types.h"/>
         <type category="include" name="ggp_c/vulkan_types.h"/>
             <comment>
@@ -112,6 +114,8 @@ server.
         <type requires="xcb/xcb.h" name="xcb_connection_t"/>
         <type requires="xcb/xcb.h" name="xcb_visualid_t"/>
         <type requires="xcb/xcb.h" name="xcb_window_t"/>
+        <type requires="directfb.h" name="IDirectFB"/>
+        <type requires="directfb.h" name="IDirectFBSurface"/>
         <type requires="zircon/types.h" name="zx_handle_t"/>
         <type requires="ggp_c/vulkan_types.h" name="GgpStreamDescriptor"/>
         <type requires="ggp_c/vulkan_types.h" name="GgpFrameToken"/>
@@ -272,6 +276,7 @@ typedef void <name>CAMetalLayer</name>;
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkWin32SurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXlibSurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXcbSurfaceCreateFlagsKHR</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDirectFBSurfaceCreateFlagsEXT</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkIOSSurfaceCreateFlagsMVK</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMacOSSurfaceCreateFlagsMVK</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMetalSurfaceCreateFlagsEXT</name>;</type>
@@ -1727,6 +1732,13 @@ typedef void <name>CAMetalLayer</name>;
             <member optional="true"><type>VkXcbSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>xcb_connection_t</type>*                <name>connection</name></member>
             <member><type>xcb_window_t</type>                     <name>window</name></member>
+        </type>
+        <type category="struct" name="VkDirectFBSurfaceCreateInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkDirectFBSurfaceCreateFlagsEXT</type>   <name>flags</name></member>
+            <member noautovalidity="true"><type>IDirectFB</type>*                       <name>dfb</name></member>
+            <member noautovalidity="true"><type>IDirectFBSurface</type>*                <name>surface</name></member>
         </type>
         <type category="struct" name="VkImagePipeSurfaceCreateInfoFUCHSIA">
             <member values="VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA"><type>VkStructureType</type> <name>sType</name></member>
@@ -7322,6 +7334,19 @@ typedef void <name>CAMetalLayer</name>;
             <param><type>uint32_t</type> <name>queueFamilyIndex</name></param>
             <param><type>xcb_connection_t</type>* <name>connection</name></param>
             <param><type>xcb_visualid_t</type> <name>visual_id</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateDirectFBSurfaceEXT</name></proto>
+            <param><type>VkInstance</type> <name>instance</name></param>
+            <param>const <type>VkDirectFBSurfaceCreateInfoEXT</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkSurfaceKHR</type>* <name>pSurface</name></param>
+        </command>
+        <command>
+            <proto><type>VkBool32</type> <name>vkGetPhysicalDeviceDirectFBPresentationSupportEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>uint32_t</type> <name>queueFamilyIndex</name></param>
+            <param><type>IDirectFB</type>* <name>dfb</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkCreateImagePipeSurfaceFUCHSIA</name></proto>
@@ -13668,10 +13693,15 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_NV_extension_346&quot;"       name="VK_NV_EXTENSION_346_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_347" number="347" author="EXT" contact="Nicolas Caramelli @caramelli" supported="disabled">
+        <extension name="VK_EXT_directfb_surface" number="347" type="instance" requires="VK_KHR_surface" platform="directfb" supported="vulkan" author="EXT" contact="Nicolas Caramelli @caramelli">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_347_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_347&quot;"              name="VK_EXT_EXTENSION_347_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_EXT_DIRECTFB_SURFACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_directfb_surface&quot;"           name="VK_EXT_DIRECTFB_SURFACE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT"/>
+                <type name="VkDirectFBSurfaceCreateFlagsEXT"/>
+                <type name="VkDirectFBSurfaceCreateInfoEXT"/>
+                <command name="vkCreateDirectFBSurfaceEXT"/>
+                <command name="vkGetPhysicalDeviceDirectFBPresentationSupportEXT"/>
             </require>
         </extension>
     </extensions>

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -13668,5 +13668,11 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_NV_extension_346&quot;"       name="VK_NV_EXTENSION_346_EXTENSION_NAME"/>
             </require>
         </extension>
+        <extension name="VK_EXT_extension_347" number="347" author="EXT" contact="Nicolas Caramelli @caramelli" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_347_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_347&quot;"              name="VK_EXT_EXTENSION_347_EXTENSION_NAME"/>
+            </require>
+        </extension>
     </extensions>
 </registry>


### PR DESCRIPTION
I don't know what to define in the .Valid usage section for the number associated with the VUID, so this section is missing.

Nicolas Caramelli