### PR TITLE
Remove allocation VU for a well defined case

### DIFF
--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -1051,10 +1051,6 @@ ifdef::VK_AMD_device_coherent_memory[]
     identify a memory type supporting
     ename:VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD
 endif::VK_AMD_device_coherent_memory[]
-  * [[VUID-vkAllocateMemory-maxMemoryAllocationCount-04101]]
-    There must: be less than
-    sname:VkPhysicalDeviceLimits::pname:maxMemoryAllocationCount device
-    memory allocations currently allocated on the device.
 ****
 
 include::{generated}/validity/protos/vkAllocateMemory.txt[]

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -33,14 +33,6 @@ include::{generated}/api/protos/vkCreateSampler.txt[]
   * pname:pSampler is a pointer to a slink:VkSampler handle in which the
     resulting sampler object is returned.
 
-.Valid Usage
-****
-  * [[VUID-vkCreateSampler-maxSamplerAllocationCount-04110]]
-    There must: be less than
-    sname:VkPhysicalDeviceLimits::pname:maxSamplerAllocationCount VkSampler
-    objects currently created on the device.
-****
-
 include::{generated}/validity/protos/vkCreateSampler.txt[]
 --
 


### PR DESCRIPTION
Remove the `maxMemoryAllocationCount` and `maxSamplerAllocationCount` VUs. The cases are well defined:

> If a call to `vkAllocateMemory` would cause the total number of allocations to exceed these limits, such a call will fail and **must** return `VK_ERROR_TOO_MANY_OBJECTS`.

> If `maxSamplerAllocationCount` is exceeded, `vkCreateSampler` will return `VK_ERROR_TOO_MANY_OBJECTS`.