### PR TITLE
Remove dead CSS

### DIFF
--- a/config/khronos.css
+++ b/config/khronos.css
@@ -724,9 +724,4 @@ li > p > a[id^="VUID-"]:before { content: "\00A7"; font-size: 1em; display: bloc
 
 li > p:hover > a[id^="VUID-"], li > p > a[id^="VUID-"]:hover { visibility: visible; }
 
-li > p > a[id^="VUID-"].link { color: black; text-decoration: none; }
-
-/* TODO: not quite sure what these two do */
-li > p > a[id^="VUID-"].link:hover { color: black; }
-
 .vuid { color: gray; font-family: monospace; }


### PR DESCRIPTION
Does not work. Probably meant `:link`.

The browser defaults are fine anyway. Typically the VUID link handle is blue, and gets black on mouse hover.