### PR TITLE
Fix typo in protected submit VU

### DIFF
--- a/chapters/cmdbuffers.txt
+++ b/chapters/cmdbuffers.txt
@@ -1247,8 +1247,8 @@ ifdef::VK_VERSION_1_1[]
   * [[VUID-VkSubmitInfo-pNext-04120]]
     If the pname:pNext chain of this structure does not include a
     sname:VkProtectedSubmitInfo structure with pname:protectedSubmit set to
-    ename:VK_TRUE, then each element of the command buffer of the
-    pname:pCommandBuffers array must: be an unprotected command buffer
+    ename:VK_TRUE, then each element of the pname:pCommandBuffers array
+    must: be an unprotected command buffer
 endif::VK_VERSION_1_1[]
 ****
 


### PR DESCRIPTION
ex #1284: probably a typo.
All elements of unprotected command buffer are required to be unprotected, I think.