### PR TITLE
Remove noautovalidity from pNexts in vk.xml

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -3163,7 +3163,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDebugUtilsMessengerCallbackDataEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                                                        <name>pNext</name></member>
+            <member>const <type>void</type>*                                                                        <name>pNext</name></member>
             <member optional="true"><type>VkDebugUtilsMessengerCallbackDataFlagsEXT</type>                          <name>flags</name></member>
             <member optional="true" len="null-terminated">const <type>char</type>*                                  <name>pMessageIdName</name></member>
             <member optional="true"><type>int32_t</type>                                                            <name>messageIdNumber</name></member>

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -1891,7 +1891,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                          <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>deviceGeneratedCommands</name></member>
         </type>
         <type category="struct" name="VkDevicePrivateDataCreateInfoEXT" allowduplicate="true" structextends="VkDeviceCreateInfo">
@@ -1911,7 +1911,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*            <name>pNext</name></member>
             <member><type>uint32_t</type>         <name>maxGraphicsShaderGroupCount</name></member>
             <member><type>uint32_t</type>         <name>maxIndirectSequenceCount</name></member>
             <member><type>uint32_t</type>         <name>maxIndirectCommandsTokenCount</name></member>
@@ -2352,7 +2352,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>multiview</name><comment>Multiple views in a renderpass</comment></member>
             <member><type>VkBool32</type>                         <name>multiviewGeometryShader</name><comment>Multiple views in a renderpass w/ geometry shader</comment></member>
             <member><type>VkBool32</type>                         <name>multiviewTessellationShader</name><comment>Multiple views in a renderpass w/ tessellation shader</comment></member>
@@ -2367,7 +2367,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMultiviewPropertiesKHR"                  alias="VkPhysicalDeviceMultiviewProperties"/>
         <type category="struct" name="VkRenderPassMultiviewCreateInfo" structextends="VkRenderPassCreateInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO"><type>VkStructureType</type>        <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member>const <type>void</type>*                            <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>               <name>subpassCount</name></member>
             <member len="subpassCount">const <type>uint32_t</type>*     <name>pViewMasks</name></member>
             <member optional="true"><type>uint32_t</type>               <name>dependencyCount</name></member>
@@ -2663,7 +2663,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>perViewPositionAllComponents</name></member>
         </type>
         <type category="struct" name="VkInputAttachmentAspectReference">
@@ -2722,12 +2722,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSharedPresentSurfaceCapabilitiesKHR" returnedonly="true" structextends="VkSurfaceCapabilities2KHR">
             <member values="VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>void</type>*                             <name>pNext</name></member>
             <member optional="true"><type>VkImageUsageFlags</type> <name>sharedPresentSupportedUsageFlags</name><comment>Supported image usage flags if swapchain created using a shared present mode</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDevice16BitStorageFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>storageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock</comment></member>
             <member><type>VkBool32</type>                         <name>uniformAndStorageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock and Block</comment></member>
             <member><type>VkBool32</type>                         <name>storagePushConstant16</name><comment>16-bit integer/floating-point variables supported in PushConstant</comment></member>
@@ -2843,13 +2843,13 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkImagePlaneMemoryRequirementsInfoKHR"                   alias="VkImagePlaneMemoryRequirementsInfo"/>
         <type category="struct" name="VkPhysicalDeviceSamplerYcbcrConversionFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>samplerYcbcrConversion</name><comment>Sampler color conversion supported</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR"       alias="VkPhysicalDeviceSamplerYcbcrConversionFeatures"/>
         <type category="struct" name="VkSamplerYcbcrConversionImageFormatProperties" returnedonly="true" structextends="VkImageFormatProperties2">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>combinedImageSamplerDescriptorCount</name></member>
         </type>
         <type category="struct" name="VkSamplerYcbcrConversionImageFormatPropertiesKHR"        alias="VkSamplerYcbcrConversionImageFormatProperties"/>
@@ -2957,12 +2957,12 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkSamplerReductionModeCreateInfoEXT" alias="VkSamplerReductionModeCreateInfo"/>
         <type category="struct" name="VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>advancedBlendCoherentOperations</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>advancedBlendMaxColorAttachments</name></member>
             <member><type>VkBool32</type>                         <name>advancedBlendIndependentBlend</name></member>
             <member><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedSrcColor</name></member>
@@ -3046,13 +3046,13 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkDescriptorSetLayoutSupportKHR"                         alias="VkDescriptorSetLayoutSupport"/>
         <type category="struct" name="VkPhysicalDeviceShaderDrawParametersFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>shaderDrawParameters</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderDrawParameterFeatures"             alias="VkPhysicalDeviceShaderDrawParametersFeatures"/>
         <type category="struct" name="VkPhysicalDeviceShaderFloat16Int8Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>shaderFloat16</name><comment>16-bit floats (halfs) in shaders</comment></member>
             <member><type>VkBool32</type>                         <name>shaderInt8</name><comment>8-bit integers in shaders</comment></member>
         </type>
@@ -3082,7 +3082,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceFloatControlsPropertiesKHR"              alias="VkPhysicalDeviceFloatControlsProperties"/>
         <type category="struct" name="VkPhysicalDeviceHostQueryResetFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>hostQueryReset</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceHostQueryResetFeaturesEXT"               alias="VkPhysicalDeviceHostQueryResetFeatures"/>
@@ -3242,7 +3242,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>shaderInputAttachmentArrayDynamicIndexing</name></member>
             <member><type>VkBool32</type>               <name>shaderUniformTexelBufferArrayDynamicIndexing</name></member>
             <member><type>VkBool32</type>               <name>shaderStorageTexelBufferArrayDynamicIndexing</name></member>
@@ -3267,7 +3267,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingFeaturesEXT"           alias="VkPhysicalDeviceDescriptorIndexingFeatures"/>
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>void</type>*                  <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>maxUpdateAfterBindDescriptorsInAllPools</name></member>
             <member><type>VkBool32</type>               <name>shaderUniformBufferArrayNonUniformIndexingNative</name></member>
             <member><type>VkBool32</type>               <name>shaderSampledImageArrayNonUniformIndexingNative</name></member>
@@ -3315,7 +3315,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkDescriptorSetVariableDescriptorCountLayoutSupportEXT"  alias="VkDescriptorSetVariableDescriptorCountLayoutSupport"/>
         <type category="struct" name="VkAttachmentDescription2">
             <member values="VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true">const <type>void</type>*            <name>pNext</name></member>
+            <member>const <type>void</type>*                                  <name>pNext</name></member>
             <member optional="true"><type>VkAttachmentDescriptionFlags</type> <name>flags</name></member>
             <member><type>VkFormat</type>                                     <name>format</name></member>
             <member><type>VkSampleCountFlagBits</type>                        <name>samples</name></member>
@@ -3329,7 +3329,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkAttachmentDescription2KHR"                             alias="VkAttachmentDescription2"/>
         <type category="struct" name="VkAttachmentReference2">
             <member values="VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member>const <type>void</type>*                       <name>pNext</name></member>
             <member><type>uint32_t</type>                          <name>attachment</name></member>
             <member><type>VkImageLayout</type>                     <name>layout</name></member>
             <member noautovalidity="true"><type>VkImageAspectFlags</type> <name>aspectMask</name></member>
@@ -3337,7 +3337,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkAttachmentReference2KHR"                               alias="VkAttachmentReference2"/>
         <type category="struct" name="VkSubpassDescription2">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true">const <type>void</type>*                           <name>pNext</name></member>
+            <member>const <type>void</type>*                                                 <name>pNext</name></member>
             <member optional="true"><type>VkSubpassDescriptionFlags</type>                   <name>flags</name></member>
             <member><type>VkPipelineBindPoint</type>                                         <name>pipelineBindPoint</name></member>
             <member><type>uint32_t</type>                                                    <name>viewMask</name></member>
@@ -3353,7 +3353,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkSubpassDescription2KHR"                                alias="VkSubpassDescription2"/>
         <type category="struct" name="VkSubpassDependency2">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member>const <type>void</type>*                       <name>pNext</name></member>
             <member><type>uint32_t</type>                          <name>srcSubpass</name></member>
             <member><type>uint32_t</type>                          <name>dstSubpass</name></member>
             <member><type>VkPipelineStageFlags</type>              <name>srcStageMask</name></member>
@@ -3501,7 +3501,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDevice8BitStorageFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>storageBuffer8BitAccess</name><comment>8-bit integer variables supported in StorageBuffer</comment></member>
             <member><type>VkBool32</type>                         <name>uniformAndStorageBuffer8BitAccess</name><comment>8-bit integer variables supported in StorageBuffer and Uniform</comment></member>
             <member><type>VkBool32</type>                         <name>storagePushConstant8</name><comment>8-bit integer variables supported in PushConstant</comment></member>
@@ -3509,13 +3509,13 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDevice8BitStorageFeaturesKHR"                  alias="VkPhysicalDevice8BitStorageFeatures"/>
         <type category="struct" name="VkPhysicalDeviceConditionalRenderingFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>conditionalRendering</name></member>
             <member><type>VkBool32</type>                           <name>inheritedConditionalRendering</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkanMemoryModelFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>vulkanMemoryModel</name></member>
             <member><type>VkBool32</type>                         <name>vulkanMemoryModelDeviceScope</name></member>
             <member><type>VkBool32</type>                         <name>vulkanMemoryModelAvailabilityVisibilityChains</name></member>
@@ -3546,7 +3546,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>vertexAttributeInstanceRateDivisor</name></member>
             <member><type>VkBool32</type>                           <name>vertexAttributeInstanceRateZeroDivisor</name></member>
         </type>
@@ -3585,7 +3585,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceASTCDecodeFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>decodeModeSharedExponent</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTransformFeedbackFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
@@ -3616,7 +3616,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                          <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>representativeFragmentTest</name></member>
         </type>
         <type category="struct" name="VkPipelineRepresentativeFragmentTestStateCreateInfoNV" structextends="VkGraphicsPipelineCreateInfo">
@@ -4015,13 +4015,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceMemoryBudgetPropertiesEXT" structextends="VkPhysicalDeviceMemoryProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                       <name>heapBudget</name>[<enum>VK_MAX_MEMORY_HEAPS</enum>]</member>
             <member><type>VkDeviceSize</type>                       <name>heapUsage</name>[<enum>VK_MAX_MEMORY_HEAPS</enum>]</member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMemoryPriorityFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>memoryPriority</name></member>
         </type>
         <type category="struct" name="VkMemoryPriorityAllocateInfoEXT" structextends="VkMemoryAllocateInfo">
@@ -4031,7 +4031,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceBufferDeviceAddressFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddress</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddressCaptureReplay</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddressMultiDevice</name></member>
@@ -4039,7 +4039,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceBufferDeviceAddressFeaturesKHR"          alias="VkPhysicalDeviceBufferDeviceAddressFeatures"/>
         <type category="struct" name="VkPhysicalDeviceBufferDeviceAddressFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddress</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddressCaptureReplay</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddressMultiDevice</name></member>
@@ -4136,12 +4136,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceYcbcrImageArraysFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>ycbcrImageArrays</name></member>
         </type>
         <type category="struct" name="VkImageViewHandleInfoNVX">
             <member values="VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member>const <type>void</type>*                         <name>pNext</name></member>
             <member><type>VkImageView</type>                         <name>imageView</name></member>
             <member><type>VkDescriptorType</type>                    <name>descriptorType</name></member>
             <member optional="true"><type>VkSampler</type>           <name>sampler</name></member>
@@ -4185,7 +4185,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDevicePerformanceQueryFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>performanceCounterQueryPools</name><comment>performance counters supported in query pools</comment></member>
             <member><type>VkBool32</type>                         <name>performanceCounterMultipleQueryPools</name><comment>performance counters from multiple query pools can be accessed in the same primary command buffer</comment></member>        </type>
         <type category="struct" name="VkPhysicalDevicePerformanceQueryPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
@@ -4195,7 +4195,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPerformanceCounterKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                             <name>pNext</name></member> <!-- Pointer to next structure -->
+            <member>const <type>void</type>*                        <name>pNext</name></member> <!-- Pointer to next structure -->
             <member><type>VkPerformanceCounterUnitKHR</type>        <name>unit</name></member>
             <member><type>VkPerformanceCounterScopeKHR</type>       <name>scope</name></member>
             <member><type>VkPerformanceCounterStorageKHR</type>     <name>storage</name></member>
@@ -4242,7 +4242,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceCoverageReductionModeFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                          <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>coverageReductionMode</name></member>
         </type>
         <type category="struct" name="VkPipelineCoverageReductionStateCreateInfoNV" structextends="VkPipelineMultisampleStateCreateInfo">
@@ -4316,7 +4316,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceIndexTypeUint8FeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>indexTypeUint8</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderSMBuiltinsPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
@@ -4327,7 +4327,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderSMBuiltinsFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                          <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>shaderSMBuiltins</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
@@ -4339,19 +4339,19 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                          <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>separateDepthStencilLayouts</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR"  alias="VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"/>
         <type category="struct" name="VkAttachmentReferenceStencilLayout" structextends="VkAttachmentReference2">
             <member values="VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_STENCIL_LAYOUT"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                          <name>pNext</name></member>
             <member><type>VkImageLayout</type>                  <name>stencilLayout</name></member>
         </type>
         <type category="struct" name="VkAttachmentReferenceStencilLayoutKHR"                   alias="VkAttachmentReferenceStencilLayout"/>
         <type category="struct" name="VkAttachmentDescriptionStencilLayout" structextends="VkAttachmentDescription2">
             <member values="VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                          <name>pNext</name></member>
             <member><type>VkImageLayout</type>                  <name>stencilInitialLayout</name></member>
             <member><type>VkImageLayout</type>                  <name>stencilFinalLayout</name></member>
         </type>
@@ -4405,17 +4405,17 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>shaderDemoteToHelperInvocation</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>texelBufferAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                       <name>storageTexelBufferOffsetAlignmentBytes</name></member>
             <member><type>VkBool32</type>                           <name>storageTexelBufferOffsetSingleTexelAlignment</name></member>
             <member><type>VkDeviceSize</type>                       <name>uniformTexelBufferOffsetAlignmentBytes</name></member>
@@ -4454,7 +4454,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkDeviceMemoryOpaqueCaptureAddressInfoKHR"               alias="VkDeviceMemoryOpaqueCaptureAddressInfo"/>
         <type category="struct" name="VkPhysicalDeviceLineRasterizationFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>rectangularLines</name></member>
             <member><type>VkBool32</type>                           <name>bresenhamLines</name></member>
             <member><type>VkBool32</type>                           <name>smoothLines</name></member>
@@ -4477,12 +4477,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>* <name>pNext</name></member>
+            <member><type>void</type>*                                                            <name>pNext</name></member>
             <member><type>VkBool32</type>                                                         <name>pipelineCreationCacheControl</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan11Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>storageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock</comment></member>
             <member><type>VkBool32</type>                         <name>uniformAndStorageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock and Block</comment></member>
             <member><type>VkBool32</type>                         <name>storagePushConstant16</name><comment>16-bit integer/floating-point variables supported in PushConstant</comment></member>
@@ -4498,7 +4498,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan11Properties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint8_t</type>                          <name>deviceUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
             <member><type>uint8_t</type>                          <name>driverUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
             <member><type>uint8_t</type>                          <name>deviceLUID</name>[<enum>VK_LUID_SIZE</enum>]</member>
@@ -4517,7 +4517,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan12Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>samplerMirrorClampToEdge</name></member>
             <member><type>VkBool32</type>                         <name>drawIndirectCount</name></member>
             <member><type>VkBool32</type>                         <name>storageBuffer8BitAccess</name><comment>8-bit integer variables supported in StorageBuffer</comment></member>
@@ -4568,7 +4568,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan12Properties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkDriverId</type>                       <name>driverID</name></member>
             <member><type>char</type>                             <name>driverName</name>[<enum>VK_MAX_DRIVER_NAME_SIZE</enum>]</member>
             <member><type>char</type>                             <name>driverInfo</name>[<enum>VK_MAX_DRIVER_INFO_SIZE</enum>]</member>
@@ -4629,7 +4629,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceCoherentMemoryFeaturesAMD" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>deviceCoherentMemory</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceToolPropertiesEXT" returnedonly="true">
@@ -4649,12 +4649,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                                                                   <name>pNext</name></member>
+            <member><type>void</type>*                                                                                         <name>pNext</name></member>
             <member><type>uint32_t</type>                                                                                      <name>maxCustomBorderColorSamplers</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>customBorderColors</name></member>
             <member><type>VkBool32</type>                           <name>customBorderColorWithoutFormat</name></member>
         </type>
@@ -4813,7 +4813,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceExtendedDynamicStateFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>extendedDynamicState</name></member>
         </type>
         <type category="struct" name="VkRenderPassTransformBeginInfoQCOM" structextends="VkRenderPassBeginInfo">
@@ -4829,7 +4829,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceDiagnosticsConfigFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>void</type>*                          <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>diagnosticsConfig</name></member>
         </type>
         <type category="struct" name="VkDeviceDiagnosticsConfigCreateInfoNV" structextends="VkDeviceCreateInfo">
@@ -4839,20 +4839,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceRobustness2FeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>robustBufferAccess2</name></member>
             <member><type>VkBool32</type>                           <name>robustImageAccess2</name></member>
             <member><type>VkBool32</type>                           <name>nullDescriptor</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRobustness2PropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                       <name>robustStorageBufferAccessSizeAlignment</name></member>
             <member><type>VkDeviceSize</type>                       <name>robustUniformBufferAccessSizeAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceImageRobustnessFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>robustImageAccess</name></member>
         </type>
     </types>


### PR DESCRIPTION
ex #1284

diff:
![diff1](https://user-images.githubusercontent.com/3791331/88870094-c7b61800-d214-11ea-8fd0-44d7b6a7cb7c.png)
![diff2](https://user-images.githubusercontent.com/3791331/88870102-cbe23580-d214-11ea-82f8-810b945b12b2.png)
![diff3](https://user-images.githubusercontent.com/3791331/88870109-cf75bc80-d214-11ea-898d-6eec8247072f.png)
![diff4](https://user-images.githubusercontent.com/3791331/88870111-d3094380-d214-11ea-87d9-6db21441da00.png)
