### PR TITLE
Remove redundant transient image VU

### DIFF
--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -1270,11 +1270,6 @@ endif::VK_EXT_fragment_density_map[]
     If pname:flags contains ename:VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT or
     ename:VK_IMAGE_CREATE_SPARSE_ALIASED_BIT, it must: also contain
     ename:VK_IMAGE_CREATE_SPARSE_BINDING_BIT
-  * [[VUID-VkImageCreateInfo-None-01925]]
-    If any of the bits ename:VK_IMAGE_CREATE_SPARSE_BINDING_BIT,
-    ename:VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT, or
-    ename:VK_IMAGE_CREATE_SPARSE_ALIASED_BIT are set,
-    ename:VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT must: not also be set
 ifdef::VK_VERSION_1_1[]
   * [[VUID-VkImageCreateInfo-flags-01890]]
     If the protected memory feature is not enabled, pname:flags must: not


### PR DESCRIPTION
Redundant to `VUID-VkImageCreateInfo-usage-00963`, which says:

> If `usage` includes `VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT`, then bits other than `VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT`, `VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT`, and `VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT` **must** not be set