### PR TITLE
Fix language around device extensions implemented by layers

### DIFF
--- a/chapters/devsandqueues.txt
+++ b/chapters/devsandqueues.txt
@@ -1044,9 +1044,9 @@ flink:vkGetPhysicalDeviceFeatures.
 
 After verifying and enabling the extensions the sname:VkDevice object is
 created and returned to the application.
-If a requested extension is only supported by a layer, both the layer and
-the extension need to be specified at fname:vkCreateInstance time for the
-creation to succeed.
+If a requested extension is only supported by a layer, the layer needs to
+be specified at fname:vkCreateInstance time and the extension at
+fname:vkCreateDevice time for the creation to succeed.
 
 Multiple logical devices can: be created from the same physical device.
 Logical device creation may: fail due to lack of device-specific resources


### PR DESCRIPTION
Device extensions implemented by layers require the *layer* to be specified at `vkCreateInstance` time, while the *extension* needs to be specified at `vkCreateDevice` time.