### PR TITLE
Fix paranthesis mistake in chapters/textures.txt

### DIFF
--- a/chapters/textures.txt
+++ b/chapters/textures.txt
@@ -2645,7 +2645,7 @@ The sum [eq]#{tau}~2Daniso~# is defined using the single isotropic
      \frac{1}{N}\sum_{i=1}^{N}
      {\tau_{2D}\left (
        u \left ( x - \frac{1}{2} + \frac{i}{N+1} , y \right ),
-         \left ( v \left (x-\frac{1}{2}+\frac{i}{N+1} \right ), y
+         \left ( v \left (x-\frac{1}{2}+\frac{i}{N+1}, y \right ),
 \right )
      \right )},
      & \text{when}\  \rho_{x} > \rho_{y} \\


### PR DESCRIPTION
The ```y``` coordinate is outside the ```v``` function's parantesis the the top formula regarding anisotropic filtering.