### PR TITLE
Add missing handle comment for some VkObjectType values

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -9758,7 +9758,7 @@ typedef void <name>CAMetalLayer</name>;
             <enum extends="VkStructureType" extnumber="157" offset="3"          name="VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO"/>
             <enum extends="VkStructureType" extnumber="157" offset="4"          name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES"/>
             <enum extends="VkStructureType" extnumber="157" offset="5"          name="VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES"/>
-            <enum extends="VkObjectType"    extnumber="157" offset="0"          name="VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION"/>
+            <enum extends="VkObjectType"    extnumber="157" offset="0"          name="VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION" comment="VkSamplerYcbcrConversion"/>
             <enum extends="VkFormat"        extnumber="157" offset="0"          name="VK_FORMAT_G8B8G8R8_422_UNORM"/>
             <enum extends="VkFormat"        extnumber="157" offset="1"          name="VK_FORMAT_B8G8R8G8_422_UNORM"/>
             <enum extends="VkFormat"        extnumber="157" offset="2"          name="VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM"/>
@@ -9820,7 +9820,7 @@ typedef void <name>CAMetalLayer</name>;
         </require>
         <require comment="Promoted from VK_KHR_descriptor_update_template">
             <enum extends="VkStructureType" extnumber="86"  offset="0"          name="VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO"/>
-            <enum extends="VkObjectType"    extnumber="86"  offset="0"          name="VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE"/>
+            <enum extends="VkObjectType"    extnumber="86"  offset="0"          name="VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE" comment="VkDescriptorUpdateTemplate"/>
             <command name="vkCreateDescriptorUpdateTemplate"/>
             <command name="vkDestroyDescriptorUpdateTemplate"/>
             <command name="vkUpdateDescriptorSetWithTemplate"/>
@@ -11980,7 +11980,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum bitpos="22" extends="VkAccessFlagBits"                name="VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR"/>
                 <enum offset="0"  extends="VkQueryType" extnumber="166"     name="VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR"/>
                 <enum offset="0"  extends="VkQueryType"                     name="VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR"/>
-                <enum offset="0"  extends="VkObjectType" extnumber="166"    name="VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR"/>
+                <enum offset="0"  extends="VkObjectType" extnumber="166"    name="VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR" comment="VkAccelerationStructureKHR"/>
                 <enum offset="0"  extends="VkDebugReportObjectTypeEXT" extnumber="166" name="VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT"/>
                 <enum offset="0"  extends="VkIndexType" extnumber="166"     name="VK_INDEX_TYPE_NONE_KHR"/>
                 <enum offset="0"  extends="VkGeometryTypeKHR"               name="VK_GEOMETRY_TYPE_INSTANCES_KHR"/>
@@ -12858,7 +12858,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PERFORMANCE_OVERRIDE_INFO_INTEL"/>
                 <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL"/>
                 <enum offset="0" extends="VkQueryType"                  name="VK_QUERY_TYPE_PERFORMANCE_QUERY_INTEL"/>
-                <enum offset="0" extends="VkObjectType"                 name="VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL"/>
+                <enum offset="0" extends="VkObjectType"                 name="VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL" comment="VkPerformanceConfigurationINTEL"/>
                 <type name="VkPerformanceConfigurationTypeINTEL"/>
                 <type name="VkQueryPoolSamplingModeINTEL"/>
                 <type name="VkPerformanceOverrideTypeINTEL"/>
@@ -13449,7 +13449,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="3"                                             name="VK_KHR_DEFERRED_HOST_OPERATIONS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_deferred_host_operations&quot;"   name="VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEFERRED_OPERATION_INFO_KHR"/>
-                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR"/>
+                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR" comment="VkDeferredOperationKHR"/>
                 <type name="VkDeferredOperationKHR"/>
                 <type name="VkDeferredOperationInfoKHR"/>
                 <command name="vkCreateDeferredOperationKHR"/>
@@ -13753,7 +13753,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO_EXT"/>
                 <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PRIVATE_DATA_SLOT_CREATE_INFO_EXT"/>
-                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT"/>
+                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT" comment="VkPrivateDataSlotEXT"/>
                 <type name="VkPhysicalDevicePrivateDataFeaturesEXT"/>
                 <type name="VkDevicePrivateDataCreateInfoEXT"/>
                 <type name="VkPrivateDataSlotCreateInfoEXT"/>


### PR DESCRIPTION
For most VkObjectType values there's a comment with the matching handle name. Since they are the most elegant way to get the object type for a handle, I plan to use these comments to generate parts of Wine's vulkan code.

This PR adds comments to VkObjectType values that previously didn't have any.