### PR TITLE
Fix example code for VkPushConstantRange

### DIFF
--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -1876,15 +1876,15 @@ const VkDescriptorSetLayout layouts[] = { layout1, layout2 };
 const VkPushConstantRange ranges[] =
 {
     {
-        VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,    // stageFlags
-        0,                                      // offset
-        4                                       // size
+        VK_SHADER_STAGE_VERTEX_BIT,    // stageFlags
+        0,                             // offset
+        4                              // size
     },
 
     {
-        VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,  // stageFlags
-        4,                                      // offset
-        4                                       // size
+        VK_SHADER_STAGE_FRAGMENT_BIT,  // stageFlags
+        4,                             // offset
+        4                              // size
     },
 };
 


### PR DESCRIPTION
VkPushConstantRange takes ShaderStageFlags not PipelineStageFlags.