### PR TITLE
pNext pointers not marked as optional in vk.xml

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -652,11 +652,11 @@ typedef void <name>CAMetalLayer</name>;
             <comment>Struct types</comment>
         <type category="struct" name="VkBaseOutStructure">
             <member><type>VkStructureType</type> <name>sType</name></member>
-            <member>struct <type>VkBaseOutStructure</type>* <name>pNext</name></member>
+            <member optional="true">struct <type>VkBaseOutStructure</type>* <name>pNext</name></member>
         </type>
         <type category="struct" name="VkBaseInStructure">
             <member><type>VkStructureType</type> <name>sType</name></member>
-            <member>const struct <type>VkBaseInStructure</type>* <name>pNext</name></member>
+            <member optional="true">const struct <type>VkBaseInStructure</type>* <name>pNext</name></member>
         </type>
         <type category="struct" name="VkOffset2D">
             <member><type>int32_t</type>        <name>x</name></member>
@@ -722,7 +722,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkApplicationInfo">
             <member values="VK_STRUCTURE_TYPE_APPLICATION_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*     <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*     <name>pNext</name></member>
             <member optional="true" len="null-terminated">const <type>char</type>*     <name>pApplicationName</name></member>
             <member><type>uint32_t</type>        <name>applicationVersion</name></member>
             <member optional="true" len="null-terminated">const <type>char</type>*     <name>pEngineName</name></member>
@@ -739,7 +739,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDeviceQueueCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*     <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*     <name>pNext</name></member>
             <member optional="true"><type>VkDeviceQueueCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>        <name>queueFamilyIndex</name></member>
             <member><type>uint32_t</type>        <name>queueCount</name></member>
@@ -747,7 +747,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*     <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*     <name>pNext</name></member>
             <member optional="true"><type>VkDeviceCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>        <name>queueCreateInfoCount</name></member>
             <member len="queueCreateInfoCount">const <type>VkDeviceQueueCreateInfo</type>* <name>pQueueCreateInfos</name></member>
@@ -759,7 +759,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkInstanceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*     <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*     <name>pNext</name></member>
             <member optional="true"><type>VkInstanceCreateFlags</type>  <name>flags</name></member>
             <member optional="true">const <type>VkApplicationInfo</type>* <name>pApplicationInfo</name></member>
             <member optional="true"><type>uint32_t</type>               <name>enabledLayerCount</name></member>
@@ -781,7 +781,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkDeviceSize</type>           <name>allocationSize</name><comment>Size of memory allocation</comment></member>
             <member><type>uint32_t</type>               <name>memoryTypeIndex</name><comment>Index of the of the memory type to allocate from</comment></member>
         </type>
@@ -812,7 +812,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkMappedMemoryRange">
             <member values="VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkDeviceMemory</type>         <name>memory</name><comment>Mapped memory object</comment></member>
             <member><type>VkDeviceSize</type>           <name>offset</name><comment>Offset within the memory object where the range starts</comment></member>
             <member><type>VkDeviceSize</type>           <name>size</name><comment>Size of the range within the memory object</comment></member>
@@ -841,7 +841,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkWriteDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member noautovalidity="true"><type>VkDescriptorSet</type>        <name>dstSet</name><comment>Destination descriptor set</comment></member>
             <member><type>uint32_t</type>               <name>dstBinding</name><comment>Binding within the destination descriptor set to write</comment></member>
             <member><type>uint32_t</type>               <name>dstArrayElement</name><comment>Array element within the destination binding to write</comment></member>
@@ -853,7 +853,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCopyDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkDescriptorSet</type>        <name>srcSet</name><comment>Source descriptor set</comment></member>
             <member><type>uint32_t</type>               <name>srcBinding</name><comment>Binding within the source descriptor set to copy from</comment></member>
             <member><type>uint32_t</type>               <name>srcArrayElement</name><comment>Array element within the source binding to copy from</comment></member>
@@ -864,7 +864,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkBufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkBufferCreateFlags</type>    <name>flags</name><comment>Buffer creation flags</comment></member>
             <member><type>VkDeviceSize</type>           <name>size</name><comment>Specified in bytes</comment></member>
             <member><type>VkBufferUsageFlags</type>     <name>usage</name><comment>Buffer usage flags</comment></member>
@@ -874,7 +874,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkBufferViewCreateInfo">
             <member values="VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkBufferViewCreateFlags</type><name>flags</name></member>
             <member><type>VkBuffer</type>               <name>buffer</name></member>
             <member><type>VkFormat</type>               <name>format</name><comment>Optionally specifies format of elements</comment></member>
@@ -901,13 +901,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkMemoryBarrier">
             <member values="VK_STRUCTURE_TYPE_MEMORY_BARRIER"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name><comment>Memory accesses from the source of the dependency to synchronize</comment></member>
             <member optional="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name><comment>Memory accesses from the destination of the dependency to synchronize</comment></member>
         </type>
         <type category="struct" name="VkBufferMemoryBarrier">
             <member values="VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member noautovalidity="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name><comment>Memory accesses from the source of the dependency to synchronize</comment></member>
             <member noautovalidity="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name><comment>Memory accesses from the destination of the dependency to synchronize</comment></member>
             <member><type>uint32_t</type>               <name>srcQueueFamilyIndex</name><comment>Queue family to transition ownership from</comment></member>
@@ -918,7 +918,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImageMemoryBarrier">
             <member values="VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member noautovalidity="true"><type>VkAccessFlags</type>          <name>srcAccessMask</name><comment>Memory accesses from the source of the dependency to synchronize</comment></member>
             <member noautovalidity="true"><type>VkAccessFlags</type>          <name>dstAccessMask</name><comment>Memory accesses from the destination of the dependency to synchronize</comment></member>
             <member><type>VkImageLayout</type>          <name>oldLayout</name><comment>Current layout of the image</comment></member>
@@ -930,7 +930,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkImageCreateFlags</type>     <name>flags</name><comment>Image creation flags</comment></member>
             <member><type>VkImageType</type>            <name>imageType</name></member>
             <member><type>VkFormat</type>               <name>format</name></member>
@@ -954,7 +954,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImageViewCreateInfo">
             <member values="VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkImageViewCreateFlags</type> <name>flags</name></member>
             <member><type>VkImage</type>                <name>image</name></member>
             <member><type>VkImageViewType</type>        <name>viewType</name></member>
@@ -999,7 +999,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkBindSparseInfo">
             <member values="VK_STRUCTURE_TYPE_BIND_SPARSE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>               <name>waitSemaphoreCount</name></member>
             <member len="waitSemaphoreCount">const <type>VkSemaphore</type>*     <name>pWaitSemaphores</name></member>
             <member optional="true"><type>uint32_t</type>               <name>bufferBindCount</name></member>
@@ -1041,7 +1041,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkShaderModuleCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkShaderModuleCreateFlags</type> <name>flags</name></member>
             <member><type>size_t</type>                 <name>codeSize</name><comment>Specified in bytes</comment></member>
             <member len="latexmath:[\textrm{codeSize} \over 4]" altlen="codeSize / 4">const <type>uint32_t</type>*            <name>pCode</name><comment>Binary code of size codeSize</comment></member>
@@ -1055,7 +1055,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDescriptorSetLayoutCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkDescriptorSetLayoutCreateFlags</type>    <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>               <name>bindingCount</name><comment>Number of bindings in the descriptor set layout</comment></member>
             <member len="bindingCount">const <type>VkDescriptorSetLayoutBinding</type>* <name>pBindings</name><comment>Array of descriptor set layout bindings</comment></member>
@@ -1066,7 +1066,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDescriptorPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkDescriptorPoolCreateFlags</type>  <name>flags</name></member>
             <member><type>uint32_t</type>               <name>maxSets</name></member>
             <member><type>uint32_t</type>               <name>poolSizeCount</name></member>
@@ -1074,7 +1074,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDescriptorSetAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkDescriptorPool</type>       <name>descriptorPool</name></member>
             <member><type>uint32_t</type>               <name>descriptorSetCount</name></member>
             <member len="descriptorSetCount">const <type>VkDescriptorSetLayout</type>* <name>pSetLayouts</name></member>
@@ -1092,7 +1092,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineShaderStageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineShaderStageCreateFlags</type>    <name>flags</name></member>
             <member><type>VkShaderStageFlagBits</type>  <name>stage</name><comment>Shader stage</comment></member>
             <member><type>VkShaderModule</type>         <name>module</name><comment>Module containing entry point</comment></member>
@@ -1101,7 +1101,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkComputePipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member><type>VkPipelineShaderStageCreateInfo</type> <name>stage</name></member>
             <member><type>VkPipelineLayout</type>       <name>layout</name><comment>Interface layout of the pipeline</comment></member>
@@ -1121,7 +1121,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineVertexInputStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineVertexInputStateCreateFlags</type>    <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>               <name>vertexBindingDescriptionCount</name><comment>number of bindings</comment></member>
             <member len="vertexBindingDescriptionCount">const <type>VkVertexInputBindingDescription</type>* <name>pVertexBindingDescriptions</name></member>
@@ -1130,20 +1130,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineInputAssemblyStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineInputAssemblyStateCreateFlags</type>    <name>flags</name></member>
             <member><type>VkPrimitiveTopology</type>    <name>topology</name></member>
             <member><type>VkBool32</type>               <name>primitiveRestartEnable</name></member>
         </type>
         <type category="struct" name="VkPipelineTessellationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineTessellationStateCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>               <name>patchControlPoints</name></member>
         </type>
         <type category="struct" name="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineViewportStateCreateFlags</type>    <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>               <name>viewportCount</name></member>
             <member noautovalidity="true" optional="true" len="viewportCount">const <type>VkViewport</type>*      <name>pViewports</name></member>
@@ -1152,7 +1152,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member optional="true"><type>VkPipelineRasterizationStateCreateFlags</type>    <name>flags</name></member>
             <member><type>VkBool32</type>               <name>depthClampEnable</name></member>
             <member><type>VkBool32</type>               <name>rasterizerDiscardEnable</name></member>
@@ -1167,7 +1167,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineMultisampleStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineMultisampleStateCreateFlags</type>    <name>flags</name></member>
             <member><type>VkSampleCountFlagBits</type>  <name>rasterizationSamples</name><comment>Number of samples used for rasterization</comment></member>
             <member><type>VkBool32</type>               <name>sampleShadingEnable</name><comment>optional (GL45)</comment></member>
@@ -1188,7 +1188,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineColorBlendStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineColorBlendStateCreateFlags</type>    <name>flags</name></member>
             <member><type>VkBool32</type>               <name>logicOpEnable</name></member>
             <member noautovalidity="true"><type>VkLogicOp</type>              <name>logicOp</name></member>
@@ -1198,7 +1198,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineDynamicStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineDynamicStateCreateFlags</type>    <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>               <name>dynamicStateCount</name></member>
             <member len="dynamicStateCount">const <type>VkDynamicState</type>*  <name>pDynamicStates</name></member>
@@ -1214,7 +1214,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineDepthStencilStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineDepthStencilStateCreateFlags</type>    <name>flags</name></member>
             <member><type>VkBool32</type>               <name>depthTestEnable</name></member>
             <member><type>VkBool32</type>               <name>depthWriteEnable</name></member>
@@ -1228,7 +1228,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member><type>uint32_t</type>               <name>stageCount</name></member>
             <member len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
@@ -1249,7 +1249,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineCacheCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCacheCreateFlags</type>    <name>flags</name></member>
             <member optional="true"><type>size_t</type>                 <name>initialDataSize</name><comment>Size of initial data to populate cache, in bytes</comment></member>
             <member len="initialDataSize">const <type>void</type>*            <name>pInitialData</name><comment>Initial data to populate cache</comment></member>
@@ -1261,7 +1261,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineLayoutCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineLayoutCreateFlags</type>    <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>               <name>setLayoutCount</name><comment>Number of descriptor sets interfaced by the pipeline</comment></member>
             <member len="setLayoutCount">const <type>VkDescriptorSetLayout</type>* <name>pSetLayouts</name><comment>Array of setCount number of descriptor set layout objects defining the layout of the</comment></member>
@@ -1270,7 +1270,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSamplerCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkSamplerCreateFlags</type>   <name>flags</name></member>
             <member><type>VkFilter</type>               <name>magFilter</name><comment>Filter mode for magnification</comment></member>
             <member><type>VkFilter</type>               <name>minFilter</name><comment>Filter mode for minifiation</comment></member>
@@ -1290,20 +1290,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCommandPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkCommandPoolCreateFlags</type>   <name>flags</name><comment>Command pool creation flags</comment></member>
             <member><type>uint32_t</type>               <name>queueFamilyIndex</name></member>
         </type>
         <type category="struct" name="VkCommandBufferAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkCommandPool</type>          <name>commandPool</name></member>
             <member><type>VkCommandBufferLevel</type>   <name>level</name></member>
             <member><type>uint32_t</type>               <name>commandBufferCount</name></member>
         </type>
         <type category="struct" name="VkCommandBufferInheritanceInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true" noautovalidity="true"><type>VkRenderPass</type>    <name>renderPass</name><comment>Render pass for secondary command buffers</comment></member>
             <member><type>uint32_t</type>               <name>subpass</name></member>
             <member optional="true" noautovalidity="true"><type>VkFramebuffer</type>   <name>framebuffer</name><comment>Framebuffer for secondary command buffers</comment></member>
@@ -1313,13 +1313,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCommandBufferBeginInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkCommandBufferUsageFlags</type>  <name>flags</name><comment>Command buffer usage flags</comment></member>
             <member optional="true" noautovalidity="true">const <type>VkCommandBufferInheritanceInfo</type>*       <name>pInheritanceInfo</name><comment>Pointer to inheritance info for secondary command buffers</comment></member>
         </type>
         <type category="struct" name="VkRenderPassBeginInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkRenderPass</type>           <name>renderPass</name></member>
             <member><type>VkFramebuffer</type>          <name>framebuffer</name></member>
             <member><type>VkRect2D</type>               <name>renderArea</name></member>
@@ -1382,7 +1382,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkRenderPassCreateInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkRenderPassCreateFlags</type> <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>   <name>attachmentCount</name></member>
             <member len="attachmentCount">const <type>VkAttachmentDescription</type>* <name>pAttachments</name></member>
@@ -1393,12 +1393,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkEventCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EVENT_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkEventCreateFlags</type>     <name>flags</name><comment>Event creation flags</comment></member>
         </type>
         <type category="struct" name="VkFenceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_FENCE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkFenceCreateFlags</type>     <name>flags</name><comment>Fence creation flags</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFeatures">
@@ -1584,12 +1584,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSemaphoreCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkSemaphoreCreateFlags</type> <name>flags</name><comment>Semaphore creation flags</comment></member>
         </type>
         <type category="struct" name="VkQueryPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkQueryPoolCreateFlags</type> <name>flags</name></member>
             <member><type>VkQueryType</type>            <name>queryType</name></member>
             <member><type>uint32_t</type>               <name>queryCount</name></member>
@@ -1597,7 +1597,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkFramebufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkFramebufferCreateFlags</type>    <name>flags</name></member>
             <member><type>VkRenderPass</type>           <name>renderPass</name></member>
             <member optional="true"><type>uint32_t</type>               <name>attachmentCount</name></member>
@@ -1626,7 +1626,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_SUBMIT_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>       <name>waitSemaphoreCount</name></member>
             <member len="waitSemaphoreCount">const <type>VkSemaphore</type>*     <name>pWaitSemaphores</name></member>
             <member len="waitSemaphoreCount">const <type>VkPipelineStageFlags</type>*           <name>pWaitDstStageMask</name></member>
@@ -1659,7 +1659,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDisplayModeCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkDisplayModeCreateFlagsKHR</type>      <name>flags</name></member>
             <member><type>VkDisplayModeParametersKHR</type>       <name>parameters</name><comment>The parameters this mode uses.</comment></member>
         </type>
@@ -1676,7 +1676,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDisplaySurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkDisplaySurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member><type>VkDisplayModeKHR</type>                 <name>displayMode</name><comment>The mode to use when displaying this surface</comment></member>
             <member><type>uint32_t</type>                         <name>planeIndex</name><comment>The plane on which this surface appears.  Must be between 0 and the value returned by vkGetPhysicalDeviceDisplayPlanePropertiesKHR() in pPropertyCount.</comment></member>
@@ -1688,7 +1688,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDisplayPresentInfoKHR" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkRect2D</type>                         <name>srcRect</name><comment>Rectangle within the presentable image to read pixel data from when presenting to the display.</comment></member>
             <member><type>VkRect2D</type>                         <name>dstRect</name><comment>Rectangle within the current display mode's visible region to display srcRectangle in.</comment></member>
             <member><type>VkBool32</type>                         <name>persistent</name><comment>For smart displays, use buffered mode.  If the display properties member "persistentMode" is VK_FALSE, this member must always be VK_FALSE.</comment></member>
@@ -1707,60 +1707,60 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkAndroidSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                    <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                    <name>pNext</name></member>
             <member optional="true"><type>VkAndroidSurfaceCreateFlagsKHR</type> <name>flags</name></member>
             <member noautovalidity="true">struct <type>ANativeWindow</type>*    <name>window</name></member>
         </type>
         <type category="struct" name="VkViSurfaceCreateInfoNN">
             <member values="VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkViSurfaceCreateFlagsNN</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>void</type>*                            <name>window</name></member>
         </type>
         <type category="struct" name="VkWaylandSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkWaylandSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true">struct <type>wl_display</type>*               <name>display</name></member>
             <member noautovalidity="true">struct <type>wl_surface</type>*               <name>surface</name></member>
         </type>
         <type category="struct" name="VkWin32SurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkWin32SurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member><type>HINSTANCE</type>                        <name>hinstance</name></member>
             <member><type>HWND</type>                             <name>hwnd</name></member>
         </type>
         <type category="struct" name="VkXlibSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkXlibSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>Display</type>*                         <name>dpy</name></member>
             <member><type>Window</type>                           <name>window</name></member>
         </type>
         <type category="struct" name="VkXcbSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkXcbSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>xcb_connection_t</type>*                <name>connection</name></member>
             <member><type>xcb_window_t</type>                     <name>window</name></member>
         </type>
         <type category="struct" name="VkDirectFBSurfaceCreateInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkDirectFBSurfaceCreateFlagsEXT</type>   <name>flags</name></member>
             <member noautovalidity="true"><type>IDirectFB</type>*                       <name>dfb</name></member>
             <member noautovalidity="true"><type>IDirectFBSurface</type>*                <name>surface</name></member>
         </type>
         <type category="struct" name="VkImagePipeSurfaceCreateInfoFUCHSIA">
             <member values="VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkImagePipeSurfaceCreateFlagsFUCHSIA</type>   <name>flags</name></member>
             <member><type>zx_handle_t</type>                      <name>imagePipeHandle</name></member>
         </type>
         <type category="struct" name="VkStreamDescriptorSurfaceCreateInfoGGP">
             <member values="VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkStreamDescriptorSurfaceCreateFlagsGGP</type> <name>flags</name></member>
             <member><type>GgpStreamDescriptor</type>              <name>streamDescriptor</name></member>
         </type>
@@ -1770,7 +1770,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSwapchainCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkSwapchainCreateFlagsKHR</type>        <name>flags</name></member>
             <member><type>VkSurfaceKHR</type>                     <name>surface</name><comment>The swapchain's target surface</comment></member>
             <member><type>uint32_t</type>                         <name>minImageCount</name><comment>Minimum number of presentation images the application needs</comment></member>
@@ -1790,7 +1790,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*  <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*  <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreCount</name><comment>Number of semaphores to wait for before presenting</comment></member>
             <member len="waitSemaphoreCount">const <type>VkSemaphore</type>* <name>pWaitSemaphores</name><comment>Semaphores to wait for before presenting</comment></member>
             <member><type>uint32_t</type>                         <name>swapchainCount</name><comment>Number of swapchains to present in this call</comment></member>
@@ -1800,20 +1800,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDebugReportCallbackCreateInfoEXT" structextends="VkInstanceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkDebugReportFlagsEXT</type>            <name>flags</name><comment>Indicates which events call this callback</comment></member>
             <member><type>PFN_vkDebugReportCallbackEXT</type>     <name>pfnCallback</name><comment>Function pointer of a callback function</comment></member>
             <member optional="true"><type>void</type>*            <name>pUserData</name><comment>User data provided to callback function</comment></member>
         </type>
         <type category="struct" name="VkValidationFlagsEXT" structextends="VkInstanceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT"><type>VkStructureType</type>                  <name>sType</name><comment>Must be VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT</comment></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>disabledValidationCheckCount</name><comment>Number of validation checks to disable</comment></member>
             <member len="disabledValidationCheckCount">const <type>VkValidationCheckEXT</type>* <name>pDisabledValidationChecks</name><comment>Validation checks to disable</comment></member>
         </type>
         <type category="struct" name="VkValidationFeaturesEXT" structextends="VkInstanceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT"><type>VkStructureType</type>  <name>sType</name><comment>Must be VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT</comment></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>                         <name>enabledValidationFeatureCount</name><comment>Number of validation features to enable</comment></member>
             <member len="enabledValidationFeatureCount">const <type>VkValidationFeatureEnableEXT</type>* <name>pEnabledValidationFeatures</name><comment>Validation features to enable</comment></member>
             <member optional="true"><type>uint32_t</type>                         <name>disabledValidationFeatureCount</name><comment>Number of validation features to disable</comment></member>
@@ -1821,19 +1821,19 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineRasterizationStateRasterizationOrderAMD" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkRasterizationOrderAMD</type>          <name>rasterizationOrder</name><comment>Rasterization order to use for the pipeline</comment></member>
         </type>
         <type category="struct" name="VkDebugMarkerObjectNameInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDebugReportObjectTypeEXT</type>       <name>objectType</name><comment>The type of the object</comment></member>
             <member><type>uint64_t</type>                         <name>object</name><comment>The handle of the object, cast to uint64_t</comment></member>
             <member len="null-terminated">const <type>char</type>* <name>pObjectName</name><comment>Name to apply to the object</comment></member>
         </type>
         <type category="struct" name="VkDebugMarkerObjectTagInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDebugReportObjectTypeEXT</type>       <name>objectType</name><comment>The type of the object</comment></member>
             <member><type>uint64_t</type>                         <name>object</name><comment>The handle of the object, cast to uint64_t</comment></member>
             <member><type>uint64_t</type>                         <name>tagName</name><comment>The name of the tag to set on the object</comment></member>
@@ -1842,23 +1842,23 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDebugMarkerMarkerInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member len="null-terminated">const <type>char</type>* <name>pMarkerName</name><comment>Name of the debug marker</comment></member>
             <member optional="true"><type>float</type>            <name>color</name>[4]<comment>Optional color for debug marker</comment></member>
         </type>
         <type category="struct" name="VkDedicatedAllocationImageCreateInfoNV" structextends="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>dedicatedAllocation</name><comment>Whether this image uses a dedicated allocation</comment></member>
         </type>
         <type category="struct" name="VkDedicatedAllocationBufferCreateInfoNV" structextends="VkBufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>dedicatedAllocation</name><comment>Whether this buffer uses a dedicated allocation</comment></member>
         </type>
         <type category="struct" name="VkDedicatedAllocationMemoryAllocateInfoNV" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkImage</type>          <name>image</name><comment>Image that this allocation will be bound to</comment></member>
             <member optional="true"><type>VkBuffer</type>         <name>buffer</name><comment>Buffer that this allocation will be bound to</comment></member>
         </type>
@@ -1870,29 +1870,29 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkExternalMemoryImageCreateInfoNV" structextends="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagsNV</type> <name>handleTypes</name></member>
         </type>
         <type category="struct" name="VkExportMemoryAllocateInfoNV" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagsNV</type> <name>handleTypes</name></member>
         </type>
         <type category="struct" name="VkImportMemoryWin32HandleInfoNV" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagsNV</type> <name>handleType</name></member>
             <member optional="true"><type>HANDLE</type>                           <name>handle</name></member>
         </type>
         <type category="struct" name="VkExportMemoryWin32HandleInfoNV" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true">const <type>SECURITY_ATTRIBUTES</type>*       <name>pAttributes</name></member>
             <member optional="true"><type>DWORD</type>                            <name>dwAccess</name></member>
         </type>
         <type category="struct" name="VkWin32KeyedMutexAcquireReleaseInfoNV" structextends="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>                         <name>acquireCount</name></member>
             <member len="acquireCount">const <type>VkDeviceMemory</type>*            <name>pAcquireSyncs</name></member>
             <member len="acquireCount">const <type>uint64_t</type>*                  <name>pAcquireKeys</name></member>
@@ -1903,27 +1903,27 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>deviceGeneratedCommands</name></member>
         </type>
         <type category="struct" name="VkDevicePrivateDataCreateInfoEXT" allowduplicate="true" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                               <name>privateDataSlotRequestCount</name></member>
         </type>
         <type category="struct" name="VkPrivateDataSlotCreateInfoEXT">
             <member values="VK_STRUCTURE_TYPE_PRIVATE_DATA_SLOT_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member><type>VkPrivateDataSlotCreateFlagsEXT</type>        <name>flags</name></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePrivateDataFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                                  <name>pNext</name></member>
             <member><type>VkBool32</type>                               <name>privateData</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>uint32_t</type>         <name>maxGraphicsShaderGroupCount</name></member>
             <member><type>uint32_t</type>         <name>maxIndirectSequenceCount</name></member>
             <member><type>uint32_t</type>         <name>maxIndirectCommandsTokenCount</name></member>
@@ -1936,7 +1936,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkGraphicsShaderGroupCreateInfoNV">
             <member values="VK_STRUCTURE_TYPE_GRAPHICS_SHADER_GROUP_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                <name>pNext</name></member>
             <member><type>uint32_t</type>                                                   <name>stageCount</name></member>
             <member len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>*    <name>pStages</name></member>
             <member noautovalidity="true" optional="true">const <type>VkPipelineVertexInputStateCreateInfo</type>*                <name>pVertexInputState</name></member>
@@ -1944,7 +1944,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkGraphicsPipelineShaderGroupsCreateInfoNV" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_SHADER_GROUPS_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                <name>pNext</name></member>
             <member><type>uint32_t</type>                                                   <name>groupCount</name></member>
             <member len="groupCount">const <type>VkGraphicsShaderGroupCreateInfoNV</type>*  <name>pGroups</name></member>
             <member optional="true"><type>uint32_t</type>                                   <name>pipelineCount</name></member>
@@ -1972,7 +1972,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkIndirectCommandsLayoutTokenNV">
             <member values="VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_TOKEN_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                    <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                    <name>pNext</name></member>
             <member><type>VkIndirectCommandsTokenTypeNV</type>  <name>tokenType</name></member>
             <member><type>uint32_t</type>                       <name>stream</name></member>
             <member><type>uint32_t</type>                       <name>offset</name></member>
@@ -1989,7 +1989,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkIndirectCommandsLayoutCreateInfoNV">
             <member values="VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                             <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                             <name>pNext</name></member>
             <member><type>VkIndirectCommandsLayoutUsageFlagsNV</type>    <name>flags</name></member>
             <member><type>VkPipelineBindPoint</type>                     <name>pipelineBindPoint</name></member>
             <member><type>uint32_t</type>                                <name>tokenCount</name></member>
@@ -1999,7 +1999,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkGeneratedCommandsInfoNV">
             <member values="VK_STRUCTURE_TYPE_GENERATED_COMMANDS_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
             <member><type>VkPipelineBindPoint</type>                <name>pipelineBindPoint</name></member>
             <member><type>VkPipeline</type>                         <name>pipeline</name></member>
             <member><type>VkIndirectCommandsLayoutNV</type>         <name>indirectCommandsLayout</name></member>
@@ -2016,7 +2016,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkGeneratedCommandsMemoryRequirementsInfoNV">
             <member values="VK_STRUCTURE_TYPE_GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                 <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                 <name>pNext</name></member>
             <member><type>VkPipelineBindPoint</type>         <name>pipelineBindPoint</name></member>
             <member><type>VkPipeline</type>                  <name>pipeline</name></member>
             <member><type>VkIndirectCommandsLayoutNV</type>  <name>indirectCommandsLayout</name></member>
@@ -2024,31 +2024,31 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceFeatures2" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkPhysicalDeviceFeatures</type>         <name>features</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFeatures2KHR"                            alias="VkPhysicalDeviceFeatures2"/>
         <type category="struct" name="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkPhysicalDeviceProperties</type>       <name>properties</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceProperties2KHR"                          alias="VkPhysicalDeviceProperties2"/>
         <type category="struct" name="VkFormatProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkFormatProperties</type>               <name>formatProperties</name></member>
         </type>
         <type category="struct" name="VkFormatProperties2KHR"                                  alias="VkFormatProperties2"/>
         <type category="struct" name="VkImageFormatProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkImageFormatProperties</type>          <name>imageFormatProperties</name></member>
         </type>
         <type category="struct" name="VkImageFormatProperties2KHR"                             alias="VkImageFormatProperties2"/>
         <type category="struct" name="VkPhysicalDeviceImageFormatInfo2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkFormat</type>                         <name>format</name></member>
             <member><type>VkImageType</type>                      <name>type</name></member>
             <member><type>VkImageTiling</type>                    <name>tiling</name></member>
@@ -2058,25 +2058,25 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceImageFormatInfo2KHR"                     alias="VkPhysicalDeviceImageFormatInfo2"/>
         <type category="struct" name="VkQueueFamilyProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkQueueFamilyProperties</type>          <name>queueFamilyProperties</name></member>
         </type>
         <type category="struct" name="VkQueueFamilyProperties2KHR"                             alias="VkQueueFamilyProperties2"/>
         <type category="struct" name="VkPhysicalDeviceMemoryProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkPhysicalDeviceMemoryProperties</type> <name>memoryProperties</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMemoryProperties2KHR"                    alias="VkPhysicalDeviceMemoryProperties2"/>
         <type category="struct" name="VkSparseImageFormatProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkSparseImageFormatProperties</type>    <name>properties</name></member>
         </type>
         <type category="struct" name="VkSparseImageFormatProperties2KHR"                       alias="VkSparseImageFormatProperties2"/>
         <type category="struct" name="VkPhysicalDeviceSparseImageFormatInfo2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkFormat</type>                         <name>format</name></member>
             <member><type>VkImageType</type>                      <name>type</name></member>
             <member><type>VkSampleCountFlagBits</type>            <name>samples</name></member>
@@ -2086,7 +2086,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceSparseImageFormatInfo2KHR"               alias="VkPhysicalDeviceSparseImageFormatInfo2"/>
         <type category="struct" name="VkPhysicalDevicePushDescriptorPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>maxPushDescriptors</name></member>
         </type>
         <type category="struct" name="VkConformanceVersion">
@@ -2098,7 +2098,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkConformanceVersionKHR"                                 alias="VkConformanceVersion"/>
         <type category="struct" name="VkPhysicalDeviceDriverProperties" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkDriverId</type>                       <name>driverID</name></member>
             <member><type>char</type>                             <name>driverName</name>[<enum>VK_MAX_DRIVER_NAME_SIZE</enum>]</member>
             <member><type>char</type>                             <name>driverInfo</name>[<enum>VK_MAX_DRIVER_INFO_SIZE</enum>]</member>
@@ -2107,7 +2107,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDriverPropertiesKHR"                     alias="VkPhysicalDeviceDriverProperties"/>
         <type category="struct" name="VkPresentRegionsKHR" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>swapchainCount</name><comment>Copy of VkPresentInfoKHR::swapchainCount</comment></member>
             <member len="swapchainCount" optional="true">const <type>VkPresentRegionKHR</type>*   <name>pRegions</name><comment>The regions that have changed</comment></member>
         </type>
@@ -2122,7 +2122,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceVariablePointersFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>variablePointersStorageBuffer</name></member>
             <member><type>VkBool32</type>                         <name>variablePointers</name></member>
         </type>
@@ -2137,19 +2137,19 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkExternalMemoryPropertiesKHR"                           alias="VkExternalMemoryProperties"/>
         <type category="struct" name="VkPhysicalDeviceExternalImageFormatInfo"  structextends="VkPhysicalDeviceImageFormatInfo2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExternalImageFormatInfoKHR"              alias="VkPhysicalDeviceExternalImageFormatInfo"/>
         <type category="struct" name="VkExternalImageFormatProperties" returnedonly="true" structextends="VkImageFormatProperties2">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkExternalMemoryProperties</type> <name>externalMemoryProperties</name></member>
         </type>
         <type category="struct" name="VkExternalImageFormatPropertiesKHR"                      alias="VkExternalImageFormatProperties"/>
         <type category="struct" name="VkPhysicalDeviceExternalBufferInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkBufferCreateFlags</type> <name>flags</name></member>
             <member><type>VkBufferUsageFlags</type>               <name>usage</name></member>
             <member><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
@@ -2157,13 +2157,13 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceExternalBufferInfoKHR"                   alias="VkPhysicalDeviceExternalBufferInfo"/>
         <type category="struct" name="VkExternalBufferProperties" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkExternalMemoryProperties</type>    <name>externalMemoryProperties</name></member>
         </type>
         <type category="struct" name="VkExternalBufferPropertiesKHR"                           alias="VkExternalBufferProperties"/>
         <type category="struct" name="VkPhysicalDeviceIDProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint8_t</type>                          <name>deviceUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
             <member><type>uint8_t</type>                          <name>driverUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
             <member><type>uint8_t</type>                          <name>deviceLUID</name>[<enum>VK_LUID_SIZE</enum>]</member>
@@ -2173,67 +2173,67 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceIDPropertiesKHR"                         alias="VkPhysicalDeviceIDProperties"/>
         <type category="struct" name="VkExternalMemoryImageCreateInfo" structextends="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlags</type> <name>handleTypes</name></member>
         </type>
         <type category="struct" name="VkExternalMemoryImageCreateInfoKHR"                      alias="VkExternalMemoryImageCreateInfo"/>
         <type category="struct" name="VkExternalMemoryBufferCreateInfo" structextends="VkBufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlags</type> <name>handleTypes</name></member>
         </type>
         <type category="struct" name="VkExternalMemoryBufferCreateInfoKHR"                     alias="VkExternalMemoryBufferCreateInfo"/>
         <type category="struct" name="VkExportMemoryAllocateInfo" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlags</type> <name>handleTypes</name></member>
         </type>
         <type category="struct" name="VkExportMemoryAllocateInfoKHR"                           alias="VkExportMemoryAllocateInfo"/>
         <type category="struct" name="VkImportMemoryWin32HandleInfoKHR" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
             <member optional="true"><type>HANDLE</type>           <name>handle</name></member>
             <member optional="true"><type>LPCWSTR</type>          <name>name</name></member>
         </type>
         <type category="struct" name="VkExportMemoryWin32HandleInfoKHR" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true">const <type>SECURITY_ATTRIBUTES</type>* <name>pAttributes</name></member>
             <member><type>DWORD</type>                            <name>dwAccess</name></member>
             <member><type>LPCWSTR</type>                          <name>name</name></member>
         </type>
         <type category="struct" name="VkMemoryWin32HandlePropertiesKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>memoryTypeBits</name></member>
         </type>
         <type category="struct" name="VkMemoryGetWin32HandleInfoKHR">
             <member values="VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
             <member><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkImportMemoryFdInfoKHR" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
             <member><type>int</type>                              <name>fd</name></member>
         </type>
         <type category="struct" name="VkMemoryFdPropertiesKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>memoryTypeBits</name></member>
         </type>
         <type category="struct" name="VkMemoryGetFdInfoKHR">
             <member values="VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
             <member><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkWin32KeyedMutexAcquireReleaseInfoKHR" structextends="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>acquireCount</name></member>
             <member len="acquireCount">const <type>VkDeviceMemory</type>* <name>pAcquireSyncs</name></member>
             <member len="acquireCount">const <type>uint64_t</type>* <name>pAcquireKeys</name></member>
@@ -2244,13 +2244,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceExternalSemaphoreInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkExternalSemaphoreHandleTypeFlagBits</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExternalSemaphoreInfoKHR"                alias="VkPhysicalDeviceExternalSemaphoreInfo"/>
         <type category="struct" name="VkExternalSemaphoreProperties" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkExternalSemaphoreHandleTypeFlags</type> <name>exportFromImportedHandleTypes</name></member>
             <member><type>VkExternalSemaphoreHandleTypeFlags</type> <name>compatibleHandleTypes</name></member>
             <member optional="true"><type>VkExternalSemaphoreFeatureFlags</type> <name>externalSemaphoreFeatures</name></member>
@@ -2258,13 +2258,13 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkExternalSemaphorePropertiesKHR"                        alias="VkExternalSemaphoreProperties"/>
         <type category="struct" name="VkExportSemaphoreCreateInfo" structextends="VkSemaphoreCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalSemaphoreHandleTypeFlags</type> <name>handleTypes</name></member>
         </type>
         <type category="struct" name="VkExportSemaphoreCreateInfoKHR"                          alias="VkExportSemaphoreCreateInfo"/>
         <type category="struct" name="VkImportSemaphoreWin32HandleInfoKHR">
             <member values="VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member externsync="true"><type>VkSemaphore</type>    <name>semaphore</name></member>
             <member optional="true"><type>VkSemaphoreImportFlags</type> <name>flags</name></member>
             <member optional="true"><type>VkExternalSemaphoreHandleTypeFlagBits</type> <name>handleType</name></member>
@@ -2273,14 +2273,14 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkExportSemaphoreWin32HandleInfoKHR" structextends="VkSemaphoreCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true">const <type>SECURITY_ATTRIBUTES</type>*       <name>pAttributes</name></member>
             <member><type>DWORD</type>                            <name>dwAccess</name></member>
             <member><type>LPCWSTR</type>                          <name>name</name></member>
         </type>
         <type category="struct" name="VkD3D12FenceSubmitInfoKHR" structextends="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreValuesCount</name></member>
             <member optional="true" len="waitSemaphoreValuesCount">const <type>uint64_t</type>* <name>pWaitSemaphoreValues</name></member>
             <member optional="true"><type>uint32_t</type>         <name>signalSemaphoreValuesCount</name></member>
@@ -2288,13 +2288,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSemaphoreGetWin32HandleInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkSemaphore</type>                      <name>semaphore</name></member>
             <member><type>VkExternalSemaphoreHandleTypeFlagBits</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkImportSemaphoreFdInfoKHR">
             <member values="VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member externsync="true"><type>VkSemaphore</type>    <name>semaphore</name></member>
             <member optional="true"><type>VkSemaphoreImportFlags</type> <name>flags</name></member>
             <member><type>VkExternalSemaphoreHandleTypeFlagBits</type> <name>handleType</name></member>
@@ -2302,19 +2302,19 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSemaphoreGetFdInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkSemaphore</type>                      <name>semaphore</name></member>
             <member><type>VkExternalSemaphoreHandleTypeFlagBits</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExternalFenceInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkExternalFenceHandleTypeFlagBits</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExternalFenceInfoKHR"                    alias="VkPhysicalDeviceExternalFenceInfo"/>
         <type category="struct" name="VkExternalFenceProperties" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkExternalFenceHandleTypeFlags</type> <name>exportFromImportedHandleTypes</name></member>
             <member><type>VkExternalFenceHandleTypeFlags</type> <name>compatibleHandleTypes</name></member>
             <member optional="true"><type>VkExternalFenceFeatureFlags</type> <name>externalFenceFeatures</name></member>
@@ -2322,13 +2322,13 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkExternalFencePropertiesKHR"                            alias="VkExternalFenceProperties"/>
         <type category="struct" name="VkExportFenceCreateInfo" structextends="VkFenceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalFenceHandleTypeFlags</type> <name>handleTypes</name></member>
         </type>
         <type category="struct" name="VkExportFenceCreateInfoKHR"                              alias="VkExportFenceCreateInfo"/>
         <type category="struct" name="VkImportFenceWin32HandleInfoKHR">
             <member values="VK_STRUCTURE_TYPE_IMPORT_FENCE_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                        <name>pNext</name></member>
             <member externsync="true"><type>VkFence</type>                          <name>fence</name></member>
             <member optional="true"><type>VkFenceImportFlags</type>              <name>flags</name></member>
             <member optional="true"><type>VkExternalFenceHandleTypeFlagBits</type>  <name>handleType</name></member>
@@ -2337,20 +2337,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkExportFenceWin32HandleInfoKHR" structextends="VkFenceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                <name>pNext</name></member>
             <member optional="true">const <type>SECURITY_ATTRIBUTES</type>* <name>pAttributes</name></member>
             <member><type>DWORD</type>                                      <name>dwAccess</name></member>
             <member><type>LPCWSTR</type>                                    <name>name</name></member>
         </type>
         <type category="struct" name="VkFenceGetWin32HandleInfoKHR">
             <member values="VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member><type>VkFence</type>                                <name>fence</name></member>
             <member><type>VkExternalFenceHandleTypeFlagBits</type>   <name>handleType</name></member>
         </type>
         <type category="struct" name="VkImportFenceFdInfoKHR">
             <member values="VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member externsync="true"><type>VkFence</type>              <name>fence</name></member>
             <member optional="true"><type>VkFenceImportFlags</type>  <name>flags</name></member>
             <member><type>VkExternalFenceHandleTypeFlagBits</type>   <name>handleType</name></member>
@@ -2358,13 +2358,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkFenceGetFdInfoKHR">
             <member values="VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member><type>VkFence</type>                                <name>fence</name></member>
             <member><type>VkExternalFenceHandleTypeFlagBits</type>   <name>handleType</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>multiview</name><comment>Multiple views in a renderpass</comment></member>
             <member><type>VkBool32</type>                         <name>multiviewGeometryShader</name><comment>Multiple views in a renderpass w/ geometry shader</comment></member>
             <member><type>VkBool32</type>                         <name>multiviewTessellationShader</name><comment>Multiple views in a renderpass w/ tessellation shader</comment></member>
@@ -2372,14 +2372,14 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMultiviewFeaturesKHR"                    alias="VkPhysicalDeviceMultiviewFeatures"/>
         <type category="struct" name="VkPhysicalDeviceMultiviewProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment></member>
             <member><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewPropertiesKHR"                  alias="VkPhysicalDeviceMultiviewProperties"/>
         <type category="struct" name="VkRenderPassMultiviewCreateInfo" structextends="VkRenderPassCreateInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO"><type>VkStructureType</type>        <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>               <name>subpassCount</name></member>
             <member len="subpassCount">const <type>uint32_t</type>*     <name>pViewMasks</name></member>
             <member optional="true"><type>uint32_t</type>               <name>dependencyCount</name></member>
@@ -2390,7 +2390,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkRenderPassMultiviewCreateInfoKHR"                      alias="VkRenderPassMultiviewCreateInfo"/>
         <type category="struct" name="VkSurfaceCapabilities2EXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>minImageCount</name><comment>Supported minimum number of images for the surface</comment></member>
             <member><type>uint32_t</type>                         <name>maxImageCount</name><comment>Supported maximum number of images for the surface, 0 for unlimited</comment></member>
             <member><type>VkExtent2D</type>                       <name>currentExtent</name><comment>Current image width and height for the surface, (0, 0) if undefined</comment></member>
@@ -2405,27 +2405,27 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDisplayPowerInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_POWER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDisplayPowerStateEXT</type>           <name>powerState</name></member>
         </type>
         <type category="struct" name="VkDeviceEventInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceEventTypeEXT</type>             <name>deviceEvent</name></member>
         </type>
         <type category="struct" name="VkDisplayEventInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDisplayEventTypeEXT</type>            <name>displayEvent</name></member>
         </type>
         <type category="struct" name="VkSwapchainCounterCreateInfoEXT" structextends="VkSwapchainCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkSurfaceCounterFlagsEXT</type>         <name>surfaceCounters</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceGroupProperties" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>physicalDeviceCount</name></member>
             <member><type>VkPhysicalDevice</type>                 <name>physicalDevices</name>[<enum>VK_MAX_DEVICE_GROUP_SIZE</enum>]</member>
             <member><type>VkBool32</type>                         <name>subsetAllocation</name></member>
@@ -2433,14 +2433,14 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceGroupPropertiesKHR"                      alias="VkPhysicalDeviceGroupProperties"/>
         <type category="struct" name="VkMemoryAllocateFlagsInfo" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkMemoryAllocateFlags</type> <name>flags</name></member>
             <member><type>uint32_t</type>                         <name>deviceMask</name></member>
         </type>
         <type category="struct" name="VkMemoryAllocateFlagsInfoKHR"                            alias="VkMemoryAllocateFlagsInfo"/>
         <type category="struct" name="VkBindBufferMemoryInfo">
             <member values="VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkBuffer</type>                         <name>buffer</name></member>
             <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
             <member><type>VkDeviceSize</type>                     <name>memoryOffset</name></member>
@@ -2448,14 +2448,14 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkBindBufferMemoryInfoKHR"                               alias="VkBindBufferMemoryInfo"/>
         <type category="struct" name="VkBindBufferMemoryDeviceGroupInfo" structextends="VkBindBufferMemoryInfo">
             <member values="VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>deviceIndexCount</name></member>
             <member len="deviceIndexCount">const <type>uint32_t</type>*  <name>pDeviceIndices</name></member>
         </type>
         <type category="struct" name="VkBindBufferMemoryDeviceGroupInfoKHR"                    alias="VkBindBufferMemoryDeviceGroupInfo"/>
         <type category="struct" name="VkBindImageMemoryInfo">
             <member values="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkImage</type>                          <name>image</name></member>
             <member noautovalidity="true"><type>VkDeviceMemory</type>                   <name>memory</name></member>
             <member><type>VkDeviceSize</type>                     <name>memoryOffset</name></member>
@@ -2463,7 +2463,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkBindImageMemoryInfoKHR"                                alias="VkBindImageMemoryInfo"/>
         <type category="struct" name="VkBindImageMemoryDeviceGroupInfo" structextends="VkBindImageMemoryInfo">
             <member values="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>deviceIndexCount</name></member>
             <member len="deviceIndexCount">const <type>uint32_t</type>*  <name>pDeviceIndices</name></member>
             <member optional="true"><type>uint32_t</type>         <name>splitInstanceBindRegionCount</name></member>
@@ -2472,7 +2472,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkBindImageMemoryDeviceGroupInfoKHR"                     alias="VkBindImageMemoryDeviceGroupInfo"/>
         <type category="struct" name="VkDeviceGroupRenderPassBeginInfo" structextends="VkRenderPassBeginInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>deviceMask</name></member>
             <member optional="true"><type>uint32_t</type>         <name>deviceRenderAreaCount</name></member>
             <member len="deviceRenderAreaCount">const <type>VkRect2D</type>*  <name>pDeviceRenderAreas</name></member>
@@ -2480,13 +2480,13 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkDeviceGroupRenderPassBeginInfoKHR"                     alias="VkDeviceGroupRenderPassBeginInfo"/>
         <type category="struct" name="VkDeviceGroupCommandBufferBeginInfo" structextends="VkCommandBufferBeginInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>deviceMask</name></member>
         </type>
         <type category="struct" name="VkDeviceGroupCommandBufferBeginInfoKHR"                  alias="VkDeviceGroupCommandBufferBeginInfo"/>
         <type category="struct" name="VkDeviceGroupSubmitInfo" structextends="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreCount</name></member>
             <member len="waitSemaphoreCount">const <type>uint32_t</type>*    <name>pWaitSemaphoreDeviceIndices</name></member>
             <member optional="true"><type>uint32_t</type>         <name>commandBufferCount</name></member>
@@ -2497,31 +2497,31 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkDeviceGroupSubmitInfoKHR"                              alias="VkDeviceGroupSubmitInfo"/>
         <type category="struct" name="VkDeviceGroupBindSparseInfo" structextends="VkBindSparseInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>resourceDeviceIndex</name></member>
             <member><type>uint32_t</type>                         <name>memoryDeviceIndex</name></member>
         </type>
         <type category="struct" name="VkDeviceGroupBindSparseInfoKHR"                          alias="VkDeviceGroupBindSparseInfo"/>
         <type category="struct" name="VkDeviceGroupPresentCapabilitiesKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>presentMask</name>[<enum>VK_MAX_DEVICE_GROUP_SIZE</enum>]</member>
             <member><type>VkDeviceGroupPresentModeFlagsKHR</type> <name>modes</name></member>
         </type>
         <type category="struct" name="VkImageSwapchainCreateInfoKHR" structextends="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkSwapchainKHR</type>   <name>swapchain</name></member>
         </type>
         <type category="struct" name="VkBindImageMemorySwapchainInfoKHR" structextends="VkBindImageMemoryInfo">
             <member values="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member externsync="true"><type>VkSwapchainKHR</type> <name>swapchain</name></member>
             <member><type>uint32_t</type>                         <name>imageIndex</name></member>
         </type>
         <type category="struct" name="VkAcquireNextImageInfoKHR">
             <member values="VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member externsync="true"><type>VkSwapchainKHR</type> <name>swapchain</name></member>
             <member><type>uint64_t</type>                         <name>timeout</name></member>
             <member optional="true" externsync="true"><type>VkSemaphore</type> <name>semaphore</name></member>
@@ -2530,21 +2530,21 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDeviceGroupPresentInfoKHR" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>swapchainCount</name></member>
             <member len="swapchainCount">const <type>uint32_t</type>* <name>pDeviceMasks</name></member>
             <member><type>VkDeviceGroupPresentModeFlagBitsKHR</type> <name>mode</name></member>
         </type>
         <type category="struct" name="VkDeviceGroupDeviceCreateInfo" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>                         <name>physicalDeviceCount</name></member>
             <member len="physicalDeviceCount">const <type>VkPhysicalDevice</type>*  <name>pPhysicalDevices</name></member>
         </type>
         <type category="struct" name="VkDeviceGroupDeviceCreateInfoKHR"                        alias="VkDeviceGroupDeviceCreateInfo"/>
         <type category="struct" name="VkDeviceGroupSwapchainCreateInfoKHR" structextends="VkSwapchainCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceGroupPresentModeFlagsKHR</type>                         <name>modes</name></member>
         </type>
         <type category="struct" name="VkDescriptorUpdateTemplateEntry">
@@ -2558,7 +2558,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkDescriptorUpdateTemplateEntryKHR"                      alias="VkDescriptorUpdateTemplateEntry"/>
         <type category="struct" name="VkDescriptorUpdateTemplateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                               <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                               <name>pNext</name></member>
             <member optional="true"><type>VkDescriptorUpdateTemplateCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>                 <name>descriptorUpdateEntryCount</name><comment>Number of descriptor update entries to use for the update template</comment></member>
             <member len="descriptorUpdateEntryCount">const <type>VkDescriptorUpdateTemplateEntry</type>* <name>pDescriptorUpdateEntries</name><comment>Descriptor update entries for the template</comment></member>
@@ -2576,7 +2576,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkHdrMetadataEXT">
                 <comment>Display primary in chromaticity coordinates</comment>
             <member values="VK_STRUCTURE_TYPE_HDR_METADATA_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*    <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
                 <comment> From SMPTE 2086</comment>
             <member noautovalidity="true"><type>VkXYColorEXT</type>   <name>displayPrimaryRed</name><comment>Display primary's Red</comment></member>
             <member noautovalidity="true"><type>VkXYColorEXT</type>   <name>displayPrimaryGreen</name><comment>Display primary's Green</comment></member>
@@ -2590,12 +2590,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDisplayNativeHdrSurfaceCapabilitiesAMD" returnedonly="true" structextends="VkSurfaceCapabilities2KHR">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*          <name>pNext</name></member>
+            <member optional="true"><type>void</type>*          <name>pNext</name></member>
             <member><type>VkBool32</type>       <name>localDimmingSupport</name></member>
         </type>
         <type category="struct" name="VkSwapchainDisplayNativeHdrCreateInfoAMD" structextends="VkSwapchainCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*    <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>       <name>localDimmingEnable</name></member>
         </type>
         <type category="struct" name="VkRefreshCycleDurationGOOGLE" returnedonly="true">
@@ -2610,7 +2610,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPresentTimesInfoGOOGLE" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>swapchainCount</name><comment>Copy of VkPresentInfoKHR::swapchainCount</comment></member>
             <member len="swapchainCount" optional="true">const <type>VkPresentTimeGOOGLE</type>*   <name>pTimes</name><comment>The earliest times to present images</comment></member>
         </type>
@@ -2620,19 +2620,19 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkIOSSurfaceCreateInfoMVK">
             <member values="VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                    <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                    <name>pNext</name></member>
             <member optional="true"><type>VkIOSSurfaceCreateFlagsMVK</type>     <name>flags</name></member>
             <member noautovalidity="true">const <type>void</type>*                                    <name>pView</name></member>
         </type>
         <type category="struct" name="VkMacOSSurfaceCreateInfoMVK">
             <member values="VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                    <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                    <name>pNext</name></member>
             <member optional="true"><type>VkMacOSSurfaceCreateFlagsMVK</type>   <name>flags</name></member>
             <member noautovalidity="true">const <type>void</type>*                                    <name>pView</name></member>
         </type>
         <type category="struct" name="VkMetalSurfaceCreateInfoEXT">
             <member values="VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                    <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                    <name>pNext</name></member>
             <member optional="true"><type>VkMetalSurfaceCreateFlagsEXT</type>   <name>flags</name></member>
             <member noautovalidity="true">const <type>CAMetalLayer</type>*      <name>pLayer</name></member>
         </type>
@@ -2642,7 +2642,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineViewportWScalingStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>viewportWScalingEnable</name></member>
             <member><type>uint32_t</type>               <name>viewportCount</name></member>
             <member noautovalidity="true" optional="true" len="viewportCount">const <type>VkViewportWScalingNV</type>*      <name>pViewportWScalings</name></member>
@@ -2655,19 +2655,19 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineViewportSwizzleStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineViewportSwizzleStateCreateFlagsNV</type>    <name>flags</name></member>
             <member><type>uint32_t</type>               <name>viewportCount</name></member>
             <member len="viewportCount">const <type>VkViewportSwizzleNV</type>*      <name>pViewportSwizzles</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDiscardRectanglePropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>maxDiscardRectangles</name><comment>max number of active discard rectangles</comment></member>
         </type>
         <type category="struct" name="VkPipelineDiscardRectangleStateCreateInfoEXT" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                       <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                       <name>pNext</name></member>
             <member optional="true"><type>VkPipelineDiscardRectangleStateCreateFlagsEXT</type>     <name>flags</name></member>
             <member><type>VkDiscardRectangleModeEXT</type>                                         <name>discardRectangleMode</name></member>
             <member optional="true"><type>uint32_t</type>                                          <name>discardRectangleCount</name></member>
@@ -2675,7 +2675,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>perViewPositionAllComponents</name></member>
         </type>
         <type category="struct" name="VkInputAttachmentAspectReference">
@@ -2686,60 +2686,60 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkInputAttachmentAspectReferenceKHR"                     alias="VkInputAttachmentAspectReference"/>
         <type category="struct" name="VkRenderPassInputAttachmentAspectCreateInfo" structextends="VkRenderPassCreateInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                     <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
             <member><type>uint32_t</type>                        <name>aspectReferenceCount</name></member>
             <member len="aspectReferenceCount">const <type>VkInputAttachmentAspectReference</type>* <name>pAspectReferences</name></member>
         </type>
         <type category="struct" name="VkRenderPassInputAttachmentAspectCreateInfoKHR"          alias="VkRenderPassInputAttachmentAspectCreateInfo"/>
         <type category="struct" name="VkPhysicalDeviceSurfaceInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkSurfaceKHR</type> <name>surface</name></member>
         </type>
         <type category="struct" name="VkSurfaceCapabilities2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*   <name>pNext</name></member>
+            <member optional="true"><type>void</type>*   <name>pNext</name></member>
             <member><type>VkSurfaceCapabilitiesKHR</type> <name>surfaceCapabilities</name></member>
         </type>
         <type category="struct" name="VkSurfaceFormat2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkSurfaceFormatKHR</type> <name>surfaceFormat</name></member>
         </type>
         <type category="struct" name="VkDisplayProperties2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkDisplayPropertiesKHR</type> <name>displayProperties</name></member>
         </type>
         <type category="struct" name="VkDisplayPlaneProperties2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkDisplayPlanePropertiesKHR</type> <name>displayPlaneProperties</name></member>
         </type>
         <type category="struct" name="VkDisplayModeProperties2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkDisplayModePropertiesKHR</type> <name>displayModeProperties</name></member>
         </type>
         <type category="struct" name="VkDisplayPlaneInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_PLANE_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member externsync="true"><type>VkDisplayModeKHR</type> <name>mode</name></member>
             <member><type>uint32_t</type> <name>planeIndex</name></member>
         </type>
         <type category="struct" name="VkDisplayPlaneCapabilities2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_PLANE_CAPABILITIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkDisplayPlaneCapabilitiesKHR</type> <name>capabilities</name></member>
         </type>
         <type category="struct" name="VkSharedPresentSurfaceCapabilitiesKHR" returnedonly="true" structextends="VkSurfaceCapabilities2KHR">
             <member values="VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member optional="true"><type>VkImageUsageFlags</type> <name>sharedPresentSupportedUsageFlags</name><comment>Supported image usage flags if swapchain created using a shared present mode</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDevice16BitStorageFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>storageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock</comment></member>
             <member><type>VkBool32</type>                         <name>uniformAndStorageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock and Block</comment></member>
             <member><type>VkBool32</type>                         <name>storagePushConstant16</name><comment>16-bit integer/floating-point variables supported in PushConstant</comment></member>
@@ -2748,7 +2748,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDevice16BitStorageFeaturesKHR"                 alias="VkPhysicalDevice16BitStorageFeatures"/>
         <type category="struct" name="VkPhysicalDeviceSubgroupProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                   <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                   <name>pNext</name></member>
             <member noautovalidity="true"><type>uint32_t</type>                      <name>subgroupSize</name><comment>The size of a subgroup for this queue.</comment></member>
             <member noautovalidity="true"><type>VkShaderStageFlags</type>            <name>supportedStages</name><comment>Bitfield of what shader stages support subgroup operations</comment></member>
             <member noautovalidity="true"><type>VkSubgroupFeatureFlags</type>        <name>supportedOperations</name><comment>Bitfield of what subgroup operations are supported.</comment></member>
@@ -2756,81 +2756,81 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
              <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-             <member><type>void</type>*                          <name>pNext</name></member>
+             <member optional="true"><type>void</type>*                          <name>pNext</name></member>
              <member noautovalidity="true"><type>VkBool32</type> <name>shaderSubgroupExtendedTypes</name><comment>Flag to specify whether subgroup operations with extended types are supported</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR"  alias="VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"/>
         <type category="struct" name="VkBufferMemoryRequirementsInfo2">
             <member values="VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                          <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                          <name>pNext</name></member>
             <member><type>VkBuffer</type>                                                             <name>buffer</name></member>
         </type>
         <type category="struct" name="VkBufferMemoryRequirementsInfo2KHR"                      alias="VkBufferMemoryRequirementsInfo2"/>
         <type category="struct" name="VkImageMemoryRequirementsInfo2">
             <member values="VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                          <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                          <name>pNext</name></member>
             <member><type>VkImage</type>                                                              <name>image</name></member>
         </type>
         <type category="struct" name="VkImageMemoryRequirementsInfo2KHR"                       alias="VkImageMemoryRequirementsInfo2"/>
         <type category="struct" name="VkImageSparseMemoryRequirementsInfo2">
             <member values="VK_STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                          <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                          <name>pNext</name></member>
             <member><type>VkImage</type>                                                              <name>image</name></member>
         </type>
         <type category="struct" name="VkImageSparseMemoryRequirementsInfo2KHR"                 alias="VkImageSparseMemoryRequirementsInfo2"/>
         <type category="struct" name="VkMemoryRequirements2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkMemoryRequirements</type>                                                 <name>memoryRequirements</name></member>
         </type>
         <type category="struct" name="VkMemoryRequirements2KHR"                                alias="VkMemoryRequirements2"/>
         <type category="struct" name="VkSparseImageMemoryRequirements2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                                       <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                                       <name>pNext</name></member>
             <member><type>VkSparseImageMemoryRequirements</type>                                      <name>memoryRequirements</name></member>
         </type>
         <type category="struct" name="VkSparseImageMemoryRequirements2KHR"                     alias="VkSparseImageMemoryRequirements2"/>
         <type category="struct" name="VkPhysicalDevicePointClippingProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkPointClippingBehavior</type>      <name>pointClippingBehavior</name></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePointClippingPropertiesKHR"              alias="VkPhysicalDevicePointClippingProperties"/>
         <type category="struct" name="VkMemoryDedicatedRequirements" returnedonly="true" structextends="VkMemoryRequirements2">
             <member values="VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>prefersDedicatedAllocation</name></member>
             <member><type>VkBool32</type>                         <name>requiresDedicatedAllocation</name></member>
         </type>
         <type category="struct" name="VkMemoryDedicatedRequirementsKHR"                        alias="VkMemoryDedicatedRequirements"/>
         <type category="struct" name="VkMemoryDedicatedAllocateInfo" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkImage</type>          <name>image</name><comment>Image that this allocation will be bound to</comment></member>
             <member optional="true"><type>VkBuffer</type>         <name>buffer</name><comment>Buffer that this allocation will be bound to</comment></member>
         </type>
         <type category="struct" name="VkMemoryDedicatedAllocateInfoKHR"                        alias="VkMemoryDedicatedAllocateInfo"/>
         <type category="struct" name="VkImageViewUsageCreateInfo" structextends="VkImageViewCreateInfo">
             <member values="VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkImageUsageFlags</type> <name>usage</name></member>
         </type>
         <type category="struct" name="VkImageViewUsageCreateInfoKHR"                           alias="VkImageViewUsageCreateInfo"/>
         <type category="struct" name="VkPipelineTessellationDomainOriginStateCreateInfo" structextends="VkPipelineTessellationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkTessellationDomainOrigin</type>    <name>domainOrigin</name></member>
         </type>
         <type category="struct" name="VkPipelineTessellationDomainOriginStateCreateInfoKHR"    alias="VkPipelineTessellationDomainOriginStateCreateInfo"/>
         <type category="struct" name="VkSamplerYcbcrConversionInfo" structextends="VkSamplerCreateInfo,VkImageViewCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkSamplerYcbcrConversion</type>      <name>conversion</name></member>
         </type>
         <type category="struct" name="VkSamplerYcbcrConversionInfoKHR"                         alias="VkSamplerYcbcrConversionInfo"/>
         <type category="struct" name="VkSamplerYcbcrConversionCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkFormat</type>                         <name>format</name></member>
             <member><type>VkSamplerYcbcrModelConversion</type> <name>ycbcrModel</name></member>
             <member><type>VkSamplerYcbcrRange</type>           <name>ycbcrRange</name></member>
@@ -2843,72 +2843,72 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkSamplerYcbcrConversionCreateInfoKHR"                   alias="VkSamplerYcbcrConversionCreateInfo"/>
         <type category="struct" name="VkBindImagePlaneMemoryInfo" structextends="VkBindImageMemoryInfo">
             <member values="VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkImageAspectFlagBits</type>            <name>planeAspect</name></member>
         </type>
         <type category="struct" name="VkBindImagePlaneMemoryInfoKHR"                           alias="VkBindImagePlaneMemoryInfo"/>
         <type category="struct" name="VkImagePlaneMemoryRequirementsInfo" structextends="VkImageMemoryRequirementsInfo2">
             <member values="VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkImageAspectFlagBits</type>            <name>planeAspect</name></member>
         </type>
         <type category="struct" name="VkImagePlaneMemoryRequirementsInfoKHR"                   alias="VkImagePlaneMemoryRequirementsInfo"/>
         <type category="struct" name="VkPhysicalDeviceSamplerYcbcrConversionFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>samplerYcbcrConversion</name><comment>Sampler color conversion supported</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR"       alias="VkPhysicalDeviceSamplerYcbcrConversionFeatures"/>
         <type category="struct" name="VkSamplerYcbcrConversionImageFormatProperties" returnedonly="true" structextends="VkImageFormatProperties2">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>combinedImageSamplerDescriptorCount</name></member>
         </type>
         <type category="struct" name="VkSamplerYcbcrConversionImageFormatPropertiesKHR"        alias="VkSamplerYcbcrConversionImageFormatProperties"/>
         <type category="struct" name="VkTextureLODGatherFormatPropertiesAMD" returnedonly="true" structextends="VkImageFormatProperties2">
             <member values="VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>supportsTextureGatherLODBiasAMD</name></member>
         </type>
         <type category="struct" name="VkConditionalRenderingBeginInfoEXT">
             <member values="VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkBuffer</type>                         <name>buffer</name></member>
             <member><type>VkDeviceSize</type>                     <name>offset</name></member>
             <member optional="true"><type>VkConditionalRenderingFlagsEXT</type>    <name>flags</name></member>
         </type>
         <type category="struct" name="VkProtectedSubmitInfo" structextends="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                     <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
             <member><type>VkBool32</type>                        <name>protectedSubmit</name><comment>Submit protected command buffers</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceProtectedMemoryFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>protectedMemory</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceProtectedMemoryProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>protectedNoFault</name></member>
         </type>
         <type category="struct" name="VkDeviceQueueInfo2">
             <member values="VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member optional="true"><type>VkDeviceQueueCreateFlags</type>            <name>flags</name></member>
             <member><type>uint32_t</type>                            <name>queueFamilyIndex</name></member>
             <member><type>uint32_t</type>                            <name>queueIndex</name></member>
         </type>
         <type category="struct" name="VkPipelineCoverageToColorStateCreateInfoNV" structextends="VkPipelineMultisampleStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                      <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCoverageToColorStateCreateFlagsNV</type>                    <name>flags</name></member>
             <member><type>VkBool32</type>                         <name>coverageToColorEnable</name></member>
             <member optional="true"><type>uint32_t</type>         <name>coverageToColorLocation</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSamplerFilterMinmaxProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>filterMinmaxSingleComponentFormats</name></member>
             <member><type>VkBool32</type>               <name>filterMinmaxImageComponentMapping</name></member>
         </type>
@@ -2919,7 +2919,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSampleLocationsInfoEXT" structextends="VkImageMemoryBarrier">
             <member values="VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member optional="true"><type>VkSampleCountFlagBits</type>  <name>sampleLocationsPerPixel</name></member>
             <member><type>VkExtent2D</type>                             <name>sampleLocationGridSize</name></member>
             <member optional="true"><type>uint32_t</type>               <name>sampleLocationsCount</name></member>
@@ -2935,7 +2935,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkRenderPassSampleLocationsBeginInfoEXT" structextends="VkRenderPassBeginInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>attachmentInitialSampleLocationsCount</name></member>
             <member len="attachmentInitialSampleLocationsCount">const <type>VkAttachmentSampleLocationsEXT</type>* <name>pAttachmentInitialSampleLocations</name></member>
             <member optional="true"><type>uint32_t</type>         <name>postSubpassSampleLocationsCount</name></member>
@@ -2943,13 +2943,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineSampleLocationsStateCreateInfoEXT" structextends="VkPipelineMultisampleStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>sampleLocationsEnable</name></member>
             <member><type>VkSampleLocationsInfoEXT</type>         <name>sampleLocationsInfo</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSampleLocationsPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkSampleCountFlags</type>               <name>sampleLocationSampleCounts</name></member>
             <member><type>VkExtent2D</type>                       <name>maxSampleLocationGridSize</name></member>
             <member><type>float</type>                            <name>sampleLocationCoordinateRange</name>[2]</member>
@@ -2958,23 +2958,23 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkMultisamplePropertiesEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkExtent2D</type>                       <name>maxSampleLocationGridSize</name></member>
         </type>
         <type category="struct" name="VkSamplerReductionModeCreateInfo" structextends="VkSamplerCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkSamplerReductionMode</type>           <name>reductionMode</name></member>
         </type>
         <type category="struct" name="VkSamplerReductionModeCreateInfoEXT" alias="VkSamplerReductionModeCreateInfo"/>
         <type category="struct" name="VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>advancedBlendCoherentOperations</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>advancedBlendMaxColorAttachments</name></member>
             <member><type>VkBool32</type>                         <name>advancedBlendIndependentBlend</name></member>
             <member><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedSrcColor</name></member>
@@ -2984,20 +2984,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineColorBlendAdvancedStateCreateInfoEXT" structextends="VkPipelineColorBlendStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>srcPremultiplied</name></member>
             <member><type>VkBool32</type>               <name>dstPremultiplied</name></member>
             <member><type>VkBlendOverlapEXT</type>      <name>blendOverlap</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceInlineUniformBlockFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>inlineUniformBlock</name></member>
             <member><type>VkBool32</type>               <name>descriptorBindingInlineUniformBlockUpdateAfterBind</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceInlineUniformBlockPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>maxInlineUniformBlockSize</name></member>
             <member><type>uint32_t</type>               <name>maxPerStageDescriptorInlineUniformBlocks</name></member>
             <member><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks</name></member>
@@ -3006,18 +3006,18 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkWriteDescriptorSetInlineUniformBlockEXT" structextends="VkWriteDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>dataSize</name></member>
             <member len="dataSize">const <type>void</type>* <name>pData</name></member>
         </type>
         <type category="struct" name="VkDescriptorPoolInlineUniformBlockCreateInfoEXT" structextends="VkDescriptorPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>maxInlineUniformBlockBindings</name></member>
         </type>
         <type category="struct" name="VkPipelineCoverageModulationStateCreateInfoNV" structextends="VkPipelineMultisampleStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                      <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCoverageModulationStateCreateFlagsNV</type>                   <name>flags</name></member>
             <member><type>VkCoverageModulationModeNV</type>                                                       <name>coverageModulationMode</name></member>
             <member><type>VkBool32</type>                                                                         <name>coverageModulationTableEnable</name></member>
@@ -3026,45 +3026,45 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImageFormatListCreateInfo" structextends="VkImageCreateInfo,VkSwapchainCreateInfoKHR,VkPhysicalDeviceImageFormatInfo2">
             <member values="VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>               <name>viewFormatCount</name></member>
             <member len="viewFormatCount">const <type>VkFormat</type>*  <name>pViewFormats</name></member>
         </type>
         <type category="struct" name="VkImageFormatListCreateInfoKHR"                          alias="VkImageFormatListCreateInfo"/>
         <type category="struct" name="VkValidationCacheCreateInfoEXT">
             <member values="VK_STRUCTURE_TYPE_VALIDATION_CACHE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkValidationCacheCreateFlagsEXT</type>    <name>flags</name></member>
             <member optional="true"><type>size_t</type>                 <name>initialDataSize</name></member>
             <member len="initialDataSize">const <type>void</type>*            <name>pInitialData</name></member>
         </type>
         <type category="struct" name="VkShaderModuleValidationCacheCreateInfoEXT" structextends="VkShaderModuleCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkValidationCacheEXT</type>    <name>validationCache</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMaintenance3Properties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>maxPerSetDescriptors</name></member>
             <member><type>VkDeviceSize</type>                     <name>maxMemoryAllocationSize</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMaintenance3PropertiesKHR"               alias="VkPhysicalDeviceMaintenance3Properties"/>
         <type category="struct" name="VkDescriptorSetLayoutSupport" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
             <member><type>VkBool32</type>         <name>supported</name></member>
         </type>
         <type category="struct" name="VkDescriptorSetLayoutSupportKHR"                         alias="VkDescriptorSetLayoutSupport"/>
         <type category="struct" name="VkPhysicalDeviceShaderDrawParametersFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>shaderDrawParameters</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderDrawParameterFeatures"             alias="VkPhysicalDeviceShaderDrawParametersFeatures"/>
         <type category="struct" name="VkPhysicalDeviceShaderFloat16Int8Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>shaderFloat16</name><comment>16-bit floats (halfs) in shaders</comment></member>
             <member><type>VkBool32</type>                         <name>shaderInt8</name><comment>8-bit integers in shaders</comment></member>
         </type>
@@ -3072,7 +3072,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceFloat16Int8FeaturesKHR"                  alias="VkPhysicalDeviceShaderFloat16Int8Features"/>
         <type category="struct" name="VkPhysicalDeviceFloatControlsProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkShaderFloatControlsIndependence</type> <name>denormBehaviorIndependence</name></member>
             <member><type>VkShaderFloatControlsIndependence</type> <name>roundingModeIndependence</name></member>
             <member><type>VkBool32</type>                         <name>shaderSignedZeroInfNanPreserveFloat16</name><comment>An implementation can preserve signed zero, nan, inf</comment></member>
@@ -3094,7 +3094,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceFloatControlsPropertiesKHR"              alias="VkPhysicalDeviceFloatControlsProperties"/>
         <type category="struct" name="VkPhysicalDeviceHostQueryResetFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>hostQueryReset</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceHostQueryResetFeaturesEXT"               alias="VkPhysicalDeviceHostQueryResetFeatures"/>
@@ -3104,7 +3104,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkNativeBufferANDROID">
             <member values="VK_STRUCTURE_TYPE_NATIVE_BUFFER_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member>const <type>void</type>* <name>handle</name></member>
             <member><type>int</type> <name>stride</name></member>
             <member><type>int</type> <name>format</name></member>
@@ -3113,12 +3113,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSwapchainImageCreateInfoANDROID">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_IMAGE_CREATE_INFO_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkSwapchainImageUsageFlagsANDROID</type> <name>usage</name></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePresentationPropertiesANDROID">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENTATION_PROPERTIES_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type> <name>sharedImage</name></member>
         </type>
         <type category="struct" name="VkShaderResourceUsageAMD" returnedonly="true">
@@ -3139,19 +3139,19 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDeviceQueueGlobalPriorityCreateInfoEXT" structextends="VkDeviceQueueCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                    <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                    <name>pNext</name></member>
             <member><type>VkQueueGlobalPriorityEXT</type>       <name>globalPriority</name></member>
         </type>
         <type category="struct" name="VkDebugUtilsObjectNameInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member><type>VkObjectType</type>                                           <name>objectType</name></member>
             <member><type>uint64_t</type>                                               <name>objectHandle</name></member>
             <member optional="true" len="null-terminated">const <type>char</type>*      <name>pObjectName</name></member>
         </type>
         <type category="struct" name="VkDebugUtilsObjectTagInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_TAG_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member><type>VkObjectType</type>                           <name>objectType</name></member>
             <member><type>uint64_t</type>                               <name>objectHandle</name></member>
             <member><type>uint64_t</type>                               <name>tagName</name></member>
@@ -3160,13 +3160,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDebugUtilsLabelEXT">
             <member values="VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member len="null-terminated">const <type>char</type>*      <name>pLabelName</name></member>
             <member optional="true"><type>float</type>                  <name>color</name>[4]</member>
         </type>
         <type category="struct" name="VkDebugUtilsMessengerCreateInfoEXT" allowduplicate="true" structextends="VkInstanceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                          <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                          <name>pNext</name></member>
             <member optional="true"><type>VkDebugUtilsMessengerCreateFlagsEXT</type>  <name>flags</name></member>
             <member><type>VkDebugUtilsMessageSeverityFlagsEXT</type>                  <name>messageSeverity</name></member>
             <member><type>VkDebugUtilsMessageTypeFlagsEXT</type>                      <name>messageType</name></member>
@@ -3189,7 +3189,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceDeviceMemoryReportFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type>                    <name>deviceMemoryReport</name></member>
         </type>
         <type category="struct" name="VkDeviceDeviceMemoryReportCreateInfoEXT" allowduplicate="true" structextends="VkDeviceCreateInfo">
@@ -3201,7 +3201,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDeviceMemoryReportCallbackDataEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DEVICE_MEMORY_REPORT_CALLBACK_DATA_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceMemoryReportFlagsEXT</type>     <name>flags</name></member>
             <member><type>VkDeviceMemoryReportEventTypeEXT</type> <name>type</name></member>
             <member><type>uint64_t</type>                         <name>memoryObjectId</name></member>
@@ -3212,23 +3212,23 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImportMemoryHostPointerInfoEXT" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
             <member optional="false"><type>void</type>* <name>pHostPointer</name></member>
         </type>
         <type category="struct" name="VkMemoryHostPointerPropertiesEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>uint32_t</type> <name>memoryTypeBits</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExternalMemoryHostPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkDeviceSize</type> <name>minImportedHostPointerAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>float</type>                  <name>primitiveOverestimationSize</name><comment>The size in pixels the primitive is enlarged at each edge during conservative rasterization</comment></member>
             <member><type>float</type>                  <name>maxExtraPrimitiveOverestimationSize</name><comment>The maximum additional overestimation the client can specify in the pipeline state</comment></member>
             <member><type>float</type>                  <name>extraPrimitiveOverestimationSizeGranularity</name><comment>The granularity of extra overestimation sizes the implementations supports between 0 and maxExtraOverestimationSize</comment></member>
@@ -3241,12 +3241,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCalibratedTimestampInfoEXT">
             <member values="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkTimeDomainEXT</type>        <name>timeDomain</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderCorePropertiesAMD" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>uint32_t</type> <name>shaderEngineCount</name><comment>number of shader engines</comment></member>
             <member><type>uint32_t</type> <name>shaderArraysPerEngineCount</name><comment>number of shader arrays</comment></member>
             <member><type>uint32_t</type> <name>computeUnitsPerShaderArray</name><comment>number of physical CUs per shader array</comment></member>
@@ -3264,20 +3264,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderCoreProperties2AMD" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name><comment>Pointer to next structure</comment></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name><comment>Pointer to next structure</comment></member>
             <member><type>VkShaderCorePropertiesFlagsAMD</type> <name>shaderCoreFeatures</name><comment>features supported by the shader core</comment></member>
             <member><type>uint32_t</type> <name>activeComputeUnitCount</name><comment>number of active compute units across all shader engines/arrays</comment></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationConservativeStateCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                      <name>pNext</name></member>
             <member optional="true"><type>VkPipelineRasterizationConservativeStateCreateFlagsEXT</type>           <name>flags</name><comment>Reserved</comment></member>
             <member><type>VkConservativeRasterizationModeEXT</type>                                               <name>conservativeRasterizationMode</name><comment>Conservative rasterization mode</comment></member>
             <member><type>float</type>                                                                            <name>extraPrimitiveOverestimationSize</name><comment>Extra overestimation to add to the primitive</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>shaderInputAttachmentArrayDynamicIndexing</name></member>
             <member><type>VkBool32</type>               <name>shaderUniformTexelBufferArrayDynamicIndexing</name></member>
             <member><type>VkBool32</type>               <name>shaderStorageTexelBufferArrayDynamicIndexing</name></member>
@@ -3302,7 +3302,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingFeaturesEXT"           alias="VkPhysicalDeviceDescriptorIndexingFeatures"/>
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>maxUpdateAfterBindDescriptorsInAllPools</name></member>
             <member><type>VkBool32</type>               <name>shaderUniformBufferArrayNonUniformIndexingNative</name></member>
             <member><type>VkBool32</type>               <name>shaderSampledImageArrayNonUniformIndexingNative</name></member>
@@ -3330,27 +3330,27 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingPropertiesEXT"         alias="VkPhysicalDeviceDescriptorIndexingProperties"/>
         <type category="struct" name="VkDescriptorSetLayoutBindingFlagsCreateInfo" structextends="VkDescriptorSetLayoutCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                        <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>                                           <name>bindingCount</name></member>
             <member len="bindingCount" optional="false,true">const <type>VkDescriptorBindingFlags</type>* <name>pBindingFlags</name></member>
         </type>
         <type category="struct" name="VkDescriptorSetLayoutBindingFlagsCreateInfoEXT"          alias="VkDescriptorSetLayoutBindingFlagsCreateInfo"/>
         <type category="struct" name="VkDescriptorSetVariableDescriptorCountAllocateInfo" structextends="VkDescriptorSetAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>               <name>descriptorSetCount</name></member>
             <member len="descriptorSetCount">const <type>uint32_t</type>* <name>pDescriptorCounts</name></member>
         </type>
         <type category="struct" name="VkDescriptorSetVariableDescriptorCountAllocateInfoEXT"   alias="VkDescriptorSetVariableDescriptorCountAllocateInfo"/>
         <type category="struct" name="VkDescriptorSetVariableDescriptorCountLayoutSupport" structextends="VkDescriptorSetLayoutSupport" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
             <member><type>uint32_t</type>         <name>maxVariableDescriptorCount</name></member>
         </type>
         <type category="struct" name="VkDescriptorSetVariableDescriptorCountLayoutSupportEXT"  alias="VkDescriptorSetVariableDescriptorCountLayoutSupport"/>
         <type category="struct" name="VkAttachmentDescription2">
             <member values="VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkAttachmentDescriptionFlags</type> <name>flags</name></member>
             <member><type>VkFormat</type>                                     <name>format</name></member>
             <member><type>VkSampleCountFlagBits</type>                        <name>samples</name></member>
@@ -3364,7 +3364,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkAttachmentDescription2KHR"                             alias="VkAttachmentDescription2"/>
         <type category="struct" name="VkAttachmentReference2">
             <member values="VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>uint32_t</type>                          <name>attachment</name></member>
             <member><type>VkImageLayout</type>                     <name>layout</name></member>
             <member noautovalidity="true"><type>VkImageAspectFlags</type> <name>aspectMask</name></member>
@@ -3372,7 +3372,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkAttachmentReference2KHR"                               alias="VkAttachmentReference2"/>
         <type category="struct" name="VkSubpassDescription2">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                           <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                           <name>pNext</name></member>
             <member optional="true"><type>VkSubpassDescriptionFlags</type>                   <name>flags</name></member>
             <member><type>VkPipelineBindPoint</type>                                         <name>pipelineBindPoint</name></member>
             <member><type>uint32_t</type>                                                    <name>viewMask</name></member>
@@ -3388,7 +3388,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkSubpassDescription2KHR"                                alias="VkSubpassDescription2"/>
         <type category="struct" name="VkSubpassDependency2">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>uint32_t</type>                          <name>srcSubpass</name></member>
             <member><type>uint32_t</type>                          <name>dstSubpass</name></member>
             <member><type>VkPipelineStageFlags</type>              <name>srcStageMask</name></member>
@@ -3401,7 +3401,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkSubpassDependency2KHR"                                 alias="VkSubpassDependency2"/>
         <type category="struct" name="VkRenderPassCreateInfo2">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                              <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                              <name>pNext</name></member>
             <member optional="true"><type>VkRenderPassCreateFlags</type>                  <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>                                 <name>attachmentCount</name></member>
             <member len="attachmentCount">const <type>VkAttachmentDescription2</type>*    <name>pAttachments</name></member>
@@ -3415,37 +3415,37 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkRenderPassCreateInfo2KHR"                              alias="VkRenderPassCreateInfo2"/>
         <type category="struct" name="VkSubpassBeginInfo">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkSubpassContents</type>      <name>contents</name></member>
         </type>
         <type category="struct" name="VkSubpassBeginInfoKHR"                                   alias="VkSubpassBeginInfo"/>
         <type category="struct" name="VkSubpassEndInfo">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_END_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
         </type>
         <type category="struct" name="VkSubpassEndInfoKHR"                                     alias="VkSubpassEndInfo"/>
         <type category="struct" name="VkPhysicalDeviceTimelineSemaphoreFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>timelineSemaphore</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTimelineSemaphoreFeaturesKHR"            alias="VkPhysicalDeviceTimelineSemaphoreFeatures"/>
         <type category="struct" name="VkPhysicalDeviceTimelineSemaphoreProperties" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>uint64_t</type>               <name>maxTimelineSemaphoreValueDifference</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTimelineSemaphorePropertiesKHR"          alias="VkPhysicalDeviceTimelineSemaphoreProperties"/>
         <type category="struct" name="VkSemaphoreTypeCreateInfo" structextends="VkSemaphoreCreateInfo,VkPhysicalDeviceExternalSemaphoreInfo">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkSemaphoreType</type>        <name>semaphoreType</name></member>
             <member><type>uint64_t</type>               <name>initialValue</name></member>
         </type>
         <type category="struct" name="VkSemaphoreTypeCreateInfoKHR"                            alias="VkSemaphoreTypeCreateInfo"/>
         <type category="struct" name="VkTimelineSemaphoreSubmitInfo" structextends="VkSubmitInfo,VkBindSparseInfo">
             <member values="VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreValueCount</name></member>
             <member optional="true" len="waitSemaphoreValueCount">const <type>uint64_t</type>* <name>pWaitSemaphoreValues</name></member>
             <member optional="true"><type>uint32_t</type>         <name>signalSemaphoreValueCount</name></member>
@@ -3454,7 +3454,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkTimelineSemaphoreSubmitInfoKHR"                        alias="VkTimelineSemaphoreSubmitInfo"/>
         <type category="struct" name="VkSemaphoreWaitInfo">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkSemaphoreWaitFlags</type> <name>flags</name></member>
             <member><type>uint32_t</type>               <name>semaphoreCount</name></member>
             <member len="semaphoreCount">const <type>VkSemaphore</type>* <name>pSemaphores</name></member>
@@ -3463,7 +3463,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkSemaphoreWaitInfoKHR"                                  alias="VkSemaphoreWaitInfo"/>
         <type category="struct" name="VkSemaphoreSignalInfo">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkSemaphore</type>            <name>semaphore</name></member>
             <member><type>uint64_t</type>               <name>value</name></member>
         </type>
@@ -3474,18 +3474,18 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineVertexInputDivisorStateCreateInfoEXT" structextends="VkPipelineVertexInputStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>vertexBindingDivisorCount</name></member>
             <member len="vertexBindingDivisorCount">const <type>VkVertexInputBindingDivisorDescriptionEXT</type>*      <name>pVertexBindingDivisors</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>maxVertexAttribDivisor</name><comment>max value of vertex attribute divisor</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePCIBusInfoPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>pciDomain</name></member>
             <member><type>uint32_t</type>               <name>pciBus</name></member>
             <member><type>uint32_t</type>               <name>pciDevice</name></member>
@@ -3493,28 +3493,28 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImportAndroidHardwareBufferInfoANDROID" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
             <member>struct <type>AHardwareBuffer</type>*            <name>buffer</name></member>
         </type>
         <type category="struct" name="VkAndroidHardwareBufferUsageANDROID" structextends="VkImageFormatProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
             <member><type>uint64_t</type>                           <name>androidHardwareBufferUsage</name></member>
         </type>
         <type category="struct" name="VkAndroidHardwareBufferPropertiesANDROID" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                       <name>allocationSize</name></member>
             <member><type>uint32_t</type>                           <name>memoryTypeBits</name></member>
         </type>
         <type category="struct" name="VkMemoryGetAndroidHardwareBufferInfoANDROID">
             <member values="VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
             <member><type>VkDeviceMemory</type>                     <name>memory</name></member>
         </type>
         <type category="struct" name="VkAndroidHardwareBufferFormatPropertiesANDROID" structextends="VkAndroidHardwareBufferPropertiesANDROID" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkFormat</type>                           <name>format</name></member>
             <member><type>uint64_t</type>                           <name>externalFormat</name></member>
             <member><type>VkFormatFeatureFlags</type>               <name>formatFeatures</name></member>
@@ -3526,17 +3526,17 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCommandBufferInheritanceConditionalRenderingInfoEXT" structextends="VkCommandBufferInheritanceInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>conditionalRenderingEnable</name><comment>Whether this secondary command buffer may be executed during an active conditional rendering</comment></member>
         </type>
         <type category="struct" name="VkExternalFormatANDROID" structextends="VkImageCreateInfo,VkSamplerYcbcrConversionCreateInfo">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
             <member><type>uint64_t</type>                           <name>externalFormat</name></member>
         </type>
         <type category="struct" name="VkPhysicalDevice8BitStorageFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>storageBuffer8BitAccess</name><comment>8-bit integer variables supported in StorageBuffer</comment></member>
             <member><type>VkBool32</type>                         <name>uniformAndStorageBuffer8BitAccess</name><comment>8-bit integer variables supported in StorageBuffer and Uniform</comment></member>
             <member><type>VkBool32</type>                         <name>storagePushConstant8</name><comment>8-bit integer variables supported in PushConstant</comment></member>
@@ -3544,13 +3544,13 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDevice8BitStorageFeaturesKHR"                  alias="VkPhysicalDevice8BitStorageFeatures"/>
         <type category="struct" name="VkPhysicalDeviceConditionalRenderingFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>conditionalRendering</name></member>
             <member><type>VkBool32</type>                           <name>inheritedConditionalRendering</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkanMemoryModelFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>vulkanMemoryModel</name></member>
             <member><type>VkBool32</type>                         <name>vulkanMemoryModelDeviceScope</name></member>
             <member><type>VkBool32</type>                         <name>vulkanMemoryModelAvailabilityVisibilityChains</name></member>
@@ -3558,14 +3558,14 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"            alias="VkPhysicalDeviceVulkanMemoryModelFeatures"/>
         <type category="struct" name="VkPhysicalDeviceShaderAtomicInt64Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>shaderBufferInt64Atomics</name></member>
             <member><type>VkBool32</type>                            <name>shaderSharedInt64Atomics</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"            alias="VkPhysicalDeviceShaderAtomicInt64Features"/>
         <type category="struct" name="VkPhysicalDeviceShaderAtomicFloatFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>shaderBufferFloat32Atomics</name></member>
             <member><type>VkBool32</type>                            <name>shaderBufferFloat32AtomicAdd</name></member>
             <member><type>VkBool32</type>                            <name>shaderBufferFloat64Atomics</name></member>
@@ -3581,24 +3581,24 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>vertexAttributeInstanceRateDivisor</name></member>
             <member><type>VkBool32</type>                           <name>vertexAttributeInstanceRateZeroDivisor</name></member>
         </type>
         <type category="struct" name="VkQueueFamilyCheckpointPropertiesNV" structextends="VkQueueFamilyProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*           <name>pNext</name></member>
+            <member optional="true"><type>void</type>*           <name>pNext</name></member>
             <member><type>VkPipelineStageFlags</type> <name>checkpointExecutionStageMask</name></member>
         </type>
         <type category="struct" name="VkCheckpointDataNV" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkPipelineStageFlagBits</type>   <name>stage</name></member>
             <member noautovalidity="true"><type>void</type>* <name>pCheckpointMarker</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDepthStencilResolveProperties" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                                <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                                <name>pNext</name></member>
             <member><type>VkResolveModeFlags</type>                   <name>supportedDepthResolveModes</name><comment>supported depth resolve modes</comment></member>
             <member><type>VkResolveModeFlags</type>                   <name>supportedStencilResolveModes</name><comment>supported stencil resolve modes</comment></member>
             <member><type>VkBool32</type>                             <name>independentResolveNone</name><comment>depth and stencil resolve modes can be set independently if one of them is none</comment></member>
@@ -3607,7 +3607,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDepthStencilResolvePropertiesKHR"        alias="VkPhysicalDeviceDepthStencilResolveProperties"/>
         <type category="struct" name="VkSubpassDescriptionDepthStencilResolve" structextends="VkSubpassDescription2">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                              <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                              <name>pNext</name></member>
             <member><type>VkResolveModeFlagBits</type>                                    <name>depthResolveMode</name><comment>depth resolve mode</comment></member>
             <member><type>VkResolveModeFlagBits</type>                                    <name>stencilResolveMode</name><comment>stencil resolve mode</comment></member>
             <member optional="true">const <type>VkAttachmentReference2</type>*            <name>pDepthStencilResolveAttachment</name><comment>depth/stencil resolve attachment</comment></member>
@@ -3615,23 +3615,23 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkSubpassDescriptionDepthStencilResolveKHR"              alias="VkSubpassDescriptionDepthStencilResolve"/>
         <type category="struct" name="VkImageViewASTCDecodeModeEXT" structextends="VkImageViewCreateInfo">
             <member values="VK_STRUCTURE_TYPE_IMAGE_VIEW_ASTC_DECODE_MODE_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkFormat</type>                         <name>decodeMode</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceASTCDecodeFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>decodeModeSharedExponent</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTransformFeedbackFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>transformFeedback</name></member>
             <member><type>VkBool32</type>               <name>geometryStreams</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTransformFeedbackPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>maxTransformFeedbackStreams</name></member>
             <member><type>uint32_t</type>               <name>maxTransformFeedbackBuffers</name></member>
             <member><type>VkDeviceSize</type>           <name>maxTransformFeedbackBufferSize</name></member>
@@ -3645,55 +3645,55 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineRasterizationStateStreamCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                      <name>pNext</name></member>
             <member optional="true"><type>VkPipelineRasterizationStateStreamCreateFlagsEXT</type>                 <name>flags</name></member>
             <member><type>uint32_t</type>                                                                         <name>rasterizationStream</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>representativeFragmentTest</name></member>
         </type>
         <type category="struct" name="VkPipelineRepresentativeFragmentTestStateCreateInfoNV" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*    <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>       <name>representativeFragmentTestEnable</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExclusiveScissorFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>exclusiveScissor</name></member>
         </type>
         <type category="struct" name="VkPipelineViewportExclusiveScissorStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                       <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                       <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>                                          <name>exclusiveScissorCount</name></member>
             <member noautovalidity="true" len="exclusiveScissorCount">const <type>VkRect2D</type>* <name>pExclusiveScissors</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCornerSampledImageFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>cornerSampledImage</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceComputeShaderDerivativesFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>computeDerivativeGroupQuads</name></member>
             <member><type>VkBool32</type>                         <name>computeDerivativeGroupLinear</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>fragmentShaderBarycentric</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderImageFootprintFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>imageFootprint</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>dedicatedAllocationImageAliasing</name></member>
         </type>
         <type category="struct" name="VkShadingRatePaletteNV">
@@ -3702,20 +3702,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineViewportShadingRateImageStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                             <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                             <name>pNext</name></member>
             <member><type>VkBool32</type>                                                                <name>shadingRateImageEnable</name></member>
             <member><type>uint32_t</type>                                                <name>viewportCount</name></member>
             <member noautovalidity="true" len="viewportCount">const <type>VkShadingRatePaletteNV</type>* <name>pShadingRatePalettes</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShadingRateImageFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>shadingRateImage</name></member>
             <member><type>VkBool32</type>                            <name>shadingRateCoarseSampleOrder</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShadingRateImagePropertiesNV" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkExtent2D</type>                          <name>shadingRateTexelSize</name></member>
             <member><type>uint32_t</type>                            <name>shadingRatePaletteSize</name></member>
             <member><type>uint32_t</type>                            <name>shadingRateMaxCoarseSamples</name></member>
@@ -3733,20 +3733,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineViewportCoarseSampleOrderStateCreateInfoNV" structextends="VkPipelineViewportStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                            <name>pNext</name></member>
             <member><type>VkCoarseSampleOrderTypeNV</type>                                              <name>sampleOrderType</name></member>
             <member optional="true"><type>uint32_t</type>                                               <name>customSampleOrderCount</name></member>
             <member len="customSampleOrderCount">const <type>VkCoarseSampleOrderCustomNV</type>*        <name>pCustomSampleOrders</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMeshShaderFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>taskShader</name></member>
             <member><type>VkBool32</type>                            <name>meshShader</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMeshShaderPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>maxDrawMeshTasksCount</name></member>
             <member><type>uint32_t</type>                            <name>maxTaskWorkGroupInvocations</name></member>
             <member><type>uint32_t</type>                            <name>maxTaskWorkGroupSize</name>[3]</member>
@@ -3767,7 +3767,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkRayTracingShaderGroupCreateInfoNV">
             <member values="VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkRayTracingShaderGroupTypeKHR</type> <name>type</name></member>
             <member><type>uint32_t</type>               <name>generalShader</name></member>
             <member><type>uint32_t</type>               <name>closestHitShader</name></member>
@@ -3776,7 +3776,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkRayTracingShaderGroupCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkRayTracingShaderGroupTypeKHR</type> <name>type</name></member>
             <member><type>uint32_t</type>               <name>generalShader</name></member>
             <member><type>uint32_t</type>               <name>closestHitShader</name></member>
@@ -3786,7 +3786,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkRayTracingPipelineCreateInfoNV">
             <member values="VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member><type>uint32_t</type>               <name>stageCount</name></member>
             <member len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
@@ -3799,7 +3799,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkRayTracingPipelineCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member optional="true"><type>uint32_t</type> <name>stageCount</name></member>
             <member len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
@@ -3814,7 +3814,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkGeometryTrianglesNV">
             <member values="VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                <name>pNext</name></member>
             <member optional="true"><type>VkBuffer</type>   <name>vertexData</name></member>
             <member><type>VkDeviceSize</type>               <name>vertexOffset</name></member>
             <member><type>uint32_t</type>                   <name>vertexCount</name></member>
@@ -3829,7 +3829,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkGeometryAABBNV">
             <member values="VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                <name>pNext</name></member>
             <member optional="true"><type>VkBuffer</type>   <name>aabbData</name></member>
             <member><type>uint32_t</type>                   <name>numAABBs</name></member>
             <member><type>uint32_t</type>                   <name>stride</name><comment>Stride in bytes between AABBs</comment></member>
@@ -3841,14 +3841,14 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkGeometryNV">
             <member values="VK_STRUCTURE_TYPE_GEOMETRY_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                   <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                   <name>pNext</name></member>
             <member><type>VkGeometryTypeKHR</type>                  <name>geometryType</name></member>
             <member><type>VkGeometryDataNV</type>                              <name>geometry</name></member>
             <member optional="true"><type>VkGeometryFlagsKHR</type> <name>flags</name></member>
         </type>
         <type category="struct" name="VkAccelerationStructureInfoNV">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member><type>VkAccelerationStructureTypeNV</type>         <name>type</name></member>
             <member optional="true"><type>VkBuildAccelerationStructureFlagsNV</type><name>flags</name></member>
             <member optional="true"><type>uint32_t</type>               <name>instanceCount</name></member>
@@ -3857,13 +3857,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkAccelerationStructureCreateInfoNV">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                           <name>compactedSize</name></member>
             <member><type>VkAccelerationStructureInfoNV</type>          <name>info</name></member>
         </type>
         <type category="struct" name="VkBindAccelerationStructureMemoryInfoKHR">
             <member values="VK_STRUCTURE_TYPE_BIND_ACCELERATION_STRUCTURE_MEMORY_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkAccelerationStructureKHR</type>       <name>accelerationStructure</name></member>
             <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
             <member><type>VkDeviceSize</type>                     <name>memoryOffset</name></member>
@@ -3873,27 +3873,27 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkBindAccelerationStructureMemoryInfoNV"                 alias="VkBindAccelerationStructureMemoryInfoKHR"/>
         <type category="struct" name="VkWriteDescriptorSetAccelerationStructureKHR" structextends="VkWriteDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>accelerationStructureCount</name></member>
             <member len="accelerationStructureCount">const <type>VkAccelerationStructureKHR</type>* <name>pAccelerationStructures</name></member>
         </type>
         <type category="struct" name="VkWriteDescriptorSetAccelerationStructureNV"             alias="VkWriteDescriptorSetAccelerationStructureKHR"/>
         <type category="struct" name="VkAccelerationStructureMemoryRequirementsInfoKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                          <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                          <name>pNext</name></member>
             <member><type>VkAccelerationStructureMemoryRequirementsTypeKHR</type>                     <name>type</name></member>
             <member><type>VkAccelerationStructureBuildTypeKHR</type>                                  <name>buildType</name></member>
             <member><type>VkAccelerationStructureKHR</type>                                           <name>accelerationStructure</name></member>
         </type>
         <type category="struct" name="VkAccelerationStructureMemoryRequirementsInfoNV">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                          <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                          <name>pNext</name></member>
             <member><type>VkAccelerationStructureMemoryRequirementsTypeNV</type>                     <name>type</name></member>
             <member><type>VkAccelerationStructureNV</type>                                           <name>accelerationStructure</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRayTracingFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>rayTracing</name></member>
             <member><type>VkBool32</type>                         <name>rayTracingShaderGroupHandleCaptureReplay</name></member>
             <member><type>VkBool32</type>                         <name>rayTracingShaderGroupHandleCaptureReplayMixed</name></member>
@@ -3906,7 +3906,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceRayTracingPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>shaderGroupHandleSize</name></member>
             <member><type>uint32_t</type>                         <name>maxRecursionDepth</name></member>
             <member><type>uint32_t</type>                         <name>maxShaderGroupStride</name></member>
@@ -3919,7 +3919,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceRayTracingPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>shaderGroupHandleSize</name></member>
             <member><type>uint32_t</type>                         <name>maxRecursionDepth</name></member>
             <member><type>uint32_t</type>                         <name>maxShaderGroupStride</name></member>
@@ -3942,7 +3942,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDrmFormatModifierPropertiesListEXT" returnedonly="true" structextends="VkFormatProperties2">
             <member values="VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type> <name>drmFormatModifierCount</name></member>
             <member optional="true,false" len="drmFormatModifierCount"><type>VkDrmFormatModifierPropertiesEXT</type>* <name>pDrmFormatModifierProperties</name></member>
         </type>
@@ -3953,7 +3953,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceImageDrmFormatModifierInfoEXT" structextends="VkPhysicalDeviceImageFormatInfo2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>uint64_t</type> <name>drmFormatModifier</name></member>
             <member><type>VkSharingMode</type> <name>sharingMode</name></member>
             <member optional="true"><type>uint32_t</type> <name>queueFamilyIndexCount</name></member>
@@ -3961,55 +3961,55 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImageDrmFormatModifierListCreateInfoEXT" structextends="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>uint32_t</type> <name>drmFormatModifierCount</name></member>
             <member len="drmFormatModifierCount">const <type>uint64_t</type>* <name>pDrmFormatModifiers</name></member>
         </type>
         <type category="struct" name="VkImageDrmFormatModifierExplicitCreateInfoEXT" structextends="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>uint64_t</type> <name>drmFormatModifier</name></member>
             <member optional="false"><type>uint32_t</type> <name>drmFormatModifierPlaneCount</name></member>
             <member len="drmFormatModifierPlaneCount">const <type>VkSubresourceLayout</type>* <name>pPlaneLayouts</name></member>
         </type>
         <type category="struct" name="VkImageDrmFormatModifierPropertiesEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>uint64_t</type> <name>drmFormatModifier</name></member>
         </type>
         <type category="struct" name="VkImageStencilUsageCreateInfo" structextends="VkImageCreateInfo,VkPhysicalDeviceImageFormatInfo2">
             <member values="VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkImageUsageFlags</type> <name>stencilUsage</name></member>
         </type>
         <type category="struct" name="VkImageStencilUsageCreateInfoEXT"                        alias="VkImageStencilUsageCreateInfo"/>
         <type category="struct" name="VkDeviceMemoryOverallocationCreateInfoAMD"  structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkMemoryOverallocationBehaviorAMD</type> <name>overallocationBehavior</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentDensityMapFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>fragmentDensityMap</name></member>
             <member><type>VkBool32</type>                         <name>fragmentDensityMapDynamic</name></member>
             <member><type>VkBool32</type>                         <name>fragmentDensityMapNonSubsampledImages</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentDensityMap2FeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>fragmentDensityMapDeferred</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentDensityMapPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkExtent2D</type>                       <name>minFragmentDensityTexelSize</name></member>
             <member><type>VkExtent2D</type>                       <name>maxFragmentDensityTexelSize</name></member>
             <member><type>VkBool32</type>                         <name>fragmentDensityInvocations</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentDensityMap2PropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                          <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                          <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>subsampledLoads</name></member>
             <member><type>VkBool32</type>                       <name>subsampledCoarseReconstructionEarlyAccess</name></member>
             <member><type>uint32_t</type>                       <name>maxSubsampledArrayLayers</name></member>
@@ -4017,56 +4017,56 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkRenderPassFragmentDensityMapCreateInfoEXT" structextends="VkRenderPassCreateInfo,VkRenderPassCreateInfo2">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkAttachmentReference</type>            <name>fragmentDensityMapAttachment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceScalarBlockLayoutFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>scalarBlockLayout</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"            alias="VkPhysicalDeviceScalarBlockLayoutFeatures"/>
         <type category="struct" name="VkSurfaceProtectedCapabilitiesKHR" structextends="VkSurfaceCapabilities2KHR">
             <member values="VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type> <name>supportsProtected</name><comment>Represents if surface can be protected</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceUniformBufferStandardLayoutFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>uniformBufferStandardLayout</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"  alias="VkPhysicalDeviceUniformBufferStandardLayoutFeatures"/>
         <type category="struct" name="VkPhysicalDeviceDepthClipEnableFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>depthClipEnable</name></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationDepthClipStateCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                                 <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                 <name>pNext</name></member>
             <member optional="true"><type>VkPipelineRasterizationDepthClipStateCreateFlagsEXT</type>         <name>flags</name><comment>Reserved</comment></member>
             <member><type>VkBool32</type>                                                                    <name>depthClipEnable</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMemoryBudgetPropertiesEXT" structextends="VkPhysicalDeviceMemoryProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                       <name>heapBudget</name>[<enum>VK_MAX_MEMORY_HEAPS</enum>]</member>
             <member><type>VkDeviceSize</type>                       <name>heapUsage</name>[<enum>VK_MAX_MEMORY_HEAPS</enum>]</member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMemoryPriorityFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>memoryPriority</name></member>
         </type>
         <type category="struct" name="VkMemoryPriorityAllocateInfoEXT" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
             <member><type>float</type>                              <name>priority</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceBufferDeviceAddressFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddress</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddressCaptureReplay</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddressMultiDevice</name></member>
@@ -4074,7 +4074,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceBufferDeviceAddressFeaturesKHR"          alias="VkPhysicalDeviceBufferDeviceAddressFeatures"/>
         <type category="struct" name="VkPhysicalDeviceBufferDeviceAddressFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddress</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddressCaptureReplay</name></member>
             <member><type>VkBool32</type>                           <name>bufferDeviceAddressMultiDevice</name></member>
@@ -4082,49 +4082,49 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceBufferAddressFeaturesEXT"                alias="VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"/>
         <type category="struct" name="VkBufferDeviceAddressInfo">
             <member values="VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member><type>VkBuffer</type>                                               <name>buffer</name></member>
         </type>
         <type category="struct" name="VkBufferDeviceAddressInfoKHR"                            alias="VkBufferDeviceAddressInfo"/>
         <type category="struct" name="VkBufferDeviceAddressInfoEXT"                            alias="VkBufferDeviceAddressInfo"/>
         <type category="struct" name="VkBufferOpaqueCaptureAddressCreateInfo" structextends="VkBufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint64_t</type>                         <name>opaqueCaptureAddress</name></member>
         </type>
         <type category="struct" name="VkBufferOpaqueCaptureAddressCreateInfoKHR"               alias="VkBufferOpaqueCaptureAddressCreateInfo"/>
         <type category="struct" name="VkBufferDeviceAddressCreateInfoEXT" structextends="VkBufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceAddress</type>                  <name>deviceAddress</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceImageViewImageFormatInfoEXT" structextends="VkPhysicalDeviceImageFormatInfo2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkImageViewType</type>                  <name>imageViewType</name></member>
         </type>
         <type category="struct" name="VkFilterCubicImageViewImageFormatPropertiesEXT" returnedonly="true" structextends="VkImageFormatProperties2">
             <member values="VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>filterCubic</name><comment>The combinations of format, image type (and image view type if provided) can be filtered with VK_FILTER_CUBIC_EXT</comment></member>
             <member><type>VkBool32</type>                         <name>filterCubicMinmax</name><comment>The combination of format, image type (and image view type if provided) can be filtered with VK_FILTER_CUBIC_EXT and ReductionMode of Min or Max</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceImagelessFramebufferFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                                    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                                    <name>pNext</name></member>
             <member><type>VkBool32</type>                                 <name>imagelessFramebuffer</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceImagelessFramebufferFeaturesKHR"         alias="VkPhysicalDeviceImagelessFramebufferFeatures"/>
         <type category="struct" name="VkFramebufferAttachmentsCreateInfo" structextends="VkFramebufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENTS_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                              <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                              <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>                 <name>attachmentImageInfoCount</name></member>
             <member len="attachmentImageInfoCount">const <type>VkFramebufferAttachmentImageInfo</type>* <name>pAttachmentImageInfos</name></member>
         </type>
         <type category="struct" name="VkFramebufferAttachmentsCreateInfoKHR"                   alias="VkFramebufferAttachmentsCreateInfo"/>
         <type category="struct" name="VkFramebufferAttachmentImageInfo">
             <member values="VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENT_IMAGE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                              <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                              <name>pNext</name></member>
             <member optional="true"><type>VkImageCreateFlags</type>       <name>flags</name><comment>Image creation flags</comment></member>
             <member><type>VkImageUsageFlags</type>                        <name>usage</name><comment>Image usage flags</comment></member>
             <member><type>uint32_t</type>                                 <name>width</name></member>
@@ -4136,30 +4136,30 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkFramebufferAttachmentImageInfoKHR"                     alias="VkFramebufferAttachmentImageInfo"/>
         <type category="struct" name="VkRenderPassAttachmentBeginInfo" structextends="VkRenderPassBeginInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                              <name>pNext</name></member>             <!-- Pointer to next structure -->
+            <member optional="true">const <type>void</type>*                              <name>pNext</name></member>             <!-- Pointer to next structure -->
             <member optional="true"><type>uint32_t</type>                 <name>attachmentCount</name></member>
             <member len="attachmentCount">const <type>VkImageView</type>* <name>pAttachments</name></member>
         </type>
         <type category="struct" name="VkRenderPassAttachmentBeginInfoKHR"                      alias="VkRenderPassAttachmentBeginInfo"/>
         <type category="struct" name="VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkBool32</type>               <name>textureCompressionASTC_HDR</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCooperativeMatrixFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>cooperativeMatrix</name></member>
             <member><type>VkBool32</type>                            <name>cooperativeMatrixRobustBufferAccess</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCooperativeMatrixPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkShaderStageFlags</type>                  <name>cooperativeMatrixSupportedStages</name></member>
         </type>
         <type category="struct" name="VkCooperativeMatrixPropertiesNV">
             <member values="VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>MSize</name></member>
             <member><type>uint32_t</type>                            <name>NSize</name></member>
             <member><type>uint32_t</type>                            <name>KSize</name></member>
@@ -4171,25 +4171,25 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceYcbcrImageArraysFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>ycbcrImageArrays</name></member>
         </type>
         <type category="struct" name="VkImageViewHandleInfoNVX">
             <member values="VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkImageView</type>                         <name>imageView</name></member>
             <member><type>VkDescriptorType</type>                    <name>descriptorType</name></member>
             <member optional="true"><type>VkSampler</type>           <name>sampler</name></member>
         </type>
         <type category="struct" name="VkImageViewAddressPropertiesNVX" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_IMAGE_VIEW_ADDRESS_PROPERTIES_NVX"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
             <member><type>VkDeviceAddress</type>    <name>deviceAddress</name></member>
             <member><type>VkDeviceSize</type>       <name>size</name></member>
         </type>
         <type category="struct" name="VkPresentFrameTokenGGP" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_FRAME_TOKEN_GGP"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>GgpFrameToken</type>                    <name>frameToken</name></member>
         </type>
         <type category="struct" name="VkPipelineCreationFeedbackEXT" returnedonly="true">
@@ -4198,39 +4198,39 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineCreationFeedbackCreateInfoEXT" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo,VkRayTracingPipelineCreateInfoNV,VkRayTracingPipelineCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>VkPipelineCreationFeedbackEXT</type>*      <name>pPipelineCreationFeedback</name><comment>Output pipeline creation feedback.</comment></member>
             <member><type>uint32_t</type>                            <name>pipelineStageCreationFeedbackCount</name></member>
             <member len="pipelineStageCreationFeedbackCount"><type>VkPipelineCreationFeedbackEXT</type>* <name>pPipelineStageCreationFeedbacks</name><comment>One entry for each shader stage specified in the parent Vk*PipelineCreateInfo struct</comment></member>
         </type>
         <type category="struct" name="VkSurfaceFullScreenExclusiveInfoEXT" structextends="VkPhysicalDeviceSurfaceInfo2KHR,VkSwapchainCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkFullScreenExclusiveEXT</type>         <name>fullScreenExclusive</name></member>
         </type>
         <type category="struct" name="VkSurfaceFullScreenExclusiveWin32InfoEXT" structextends="VkPhysicalDeviceSurfaceInfo2KHR,VkSwapchainCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*      <name>pNext</name></member>
             <member><type>HMONITOR</type>         <name>hmonitor</name></member>
         </type>
         <type category="struct" name="VkSurfaceCapabilitiesFullScreenExclusiveEXT" structextends="VkSurfaceCapabilities2KHR">
             <member values="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
             <member><type>VkBool32</type>         <name>fullScreenExclusiveSupported</name></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePerformanceQueryFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>performanceCounterQueryPools</name><comment>performance counters supported in query pools</comment></member>
             <member><type>VkBool32</type>                         <name>performanceCounterMultipleQueryPools</name><comment>performance counters from multiple query pools can be accessed in the same primary command buffer</comment></member>        </type>
         <type category="struct" name="VkPhysicalDevicePerformanceQueryPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
              <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-             <member><type>void</type>* <name>pNext</name></member>
+             <member optional="true"><type>void</type>* <name>pNext</name></member>
              <member noautovalidity="true"><type>VkBool32</type> <name>allowCommandBufferQueryCopies</name><comment>Flag to specify whether performance queries are allowed to be used in vkCmdCopyQueryPoolResults</comment></member>
         </type>
         <type category="struct" name="VkPerformanceCounterKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                             <name>pNext</name></member> <!-- Pointer to next structure -->
+            <member optional="true">const <type>void</type>*                             <name>pNext</name></member> <!-- Pointer to next structure -->
             <member><type>VkPerformanceCounterUnitKHR</type>        <name>unit</name></member>
             <member><type>VkPerformanceCounterScopeKHR</type>       <name>scope</name></member>
             <member><type>VkPerformanceCounterStorageKHR</type>     <name>storage</name></member>
@@ -4238,7 +4238,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPerformanceCounterDescriptionKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_DESCRIPTION_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                             <name>pNext</name></member> <!-- Pointer to next structure -->
+            <member optional="true">const <type>void</type>*                             <name>pNext</name></member> <!-- Pointer to next structure -->
             <member optional="true"><type>VkPerformanceCounterDescriptionFlagsKHR</type> <name>flags</name></member>
             <member><type>char</type>                                    <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
             <member><type>char</type>                                    <name>category</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
@@ -4246,7 +4246,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkQueryPoolPerformanceCreateInfoKHR" structextends="VkQueryPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                             <name>pNext</name></member> <!-- Pointer to next structure -->
+            <member optional="true">const <type>void</type>*                             <name>pNext</name></member> <!-- Pointer to next structure -->
             <member><type>uint32_t</type>                                <name>queueFamilyIndex</name></member>
             <member><type>uint32_t</type>                                <name>counterIndexCount</name></member>
             <member len="counterIndexCount">const <type>uint32_t</type>* <name>pCounterIndices</name></member>
@@ -4261,34 +4261,34 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkAcquireProfilingLockInfoKHR">
             <member values="VK_STRUCTURE_TYPE_ACQUIRE_PROFILING_LOCK_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkAcquireProfilingLockFlagsKHR</type> <name>flags</name><comment>Acquire profiling lock flags</comment></member>
             <member><type>uint64_t</type> <name>timeout</name></member>
         </type>
         <type category="struct" name="VkPerformanceQuerySubmitInfoKHR" structextends="VkSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_QUERY_SUBMIT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*         <name>pNext</name></member>
             <member><type>uint32_t</type>            <name>counterPassIndex</name><comment>Index for which counter pass to submit</comment></member>
         </type>
         <type category="struct" name="VkHeadlessSurfaceCreateInfoEXT">
             <member values="VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkHeadlessSurfaceCreateFlagsEXT</type>   <name>flags</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCoverageReductionModeFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>coverageReductionMode</name></member>
         </type>
         <type category="struct" name="VkPipelineCoverageReductionStateCreateInfoNV" structextends="VkPipelineMultisampleStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                        <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCoverageReductionStateCreateFlagsNV</type>      <name>flags</name></member>
             <member><type>VkCoverageReductionModeNV</type>                                          <name>coverageReductionMode</name></member>
         </type>
         <type category="struct" name="VkFramebufferMixedSamplesCombinationNV" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                      <name>pNext</name></member>
             <member><type>VkCoverageReductionModeNV</type>  <name>coverageReductionMode</name></member>
             <member><type>VkSampleCountFlagBits</type>      <name>rasterizationSamples</name></member>
             <member><type>VkSampleCountFlags</type>         <name>depthStencilSamples</name></member>
@@ -4296,7 +4296,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>shaderIntegerFunctions2</name></member>
         </type>
         <type category="union" name="VkPerformanceValueDataINTEL">
@@ -4312,98 +4312,98 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkInitializePerformanceApiInfoINTEL" >
             <member values="VK_STRUCTURE_TYPE_INITIALIZE_PERFORMANCE_API_INFO_INTEL"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member optional="true"><type>void</type>*               <name>pUserData</name></member>
         </type>
         <type category="struct" name="VkQueryPoolPerformanceQueryCreateInfoINTEL" structextends="VkQueryPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>VkQueryPoolSamplingModeINTEL</type>        <name>performanceCountersSampling</name></member>
         </type>
         <type category="struct" name="VkQueryPoolCreateInfoINTEL"                              alias="VkQueryPoolPerformanceQueryCreateInfoINTEL"/>
         <type category="struct" name="VkPerformanceMarkerInfoINTEL">
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_MARKER_INFO_INTEL"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>uint64_t</type>                            <name>marker</name></member>
         </type>
         <type category="struct" name="VkPerformanceStreamMarkerInfoINTEL">
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_STREAM_MARKER_INFO_INTEL"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>marker</name></member>
         </type>
         <type category="struct" name="VkPerformanceOverrideInfoINTEL">
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_OVERRIDE_INFO_INTEL"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>VkPerformanceOverrideTypeINTEL</type>      <name>type</name></member>
             <member><type>VkBool32</type>                            <name>enable</name></member>
             <member><type>uint64_t</type>                            <name>parameter</name></member>
         </type>
         <type category="struct" name="VkPerformanceConfigurationAcquireInfoINTEL">
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>VkPerformanceConfigurationTypeINTEL</type> <name>type</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderClockFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>shaderSubgroupClock</name></member>
             <member><type>VkBool32</type>                            <name>shaderDeviceClock</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceIndexTypeUint8FeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>indexTypeUint8</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderSMBuiltinsPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                          <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                          <name>pNext</name></member>
             <member><type>uint32_t</type>                       <name>shaderSMCount</name></member>
             <member><type>uint32_t</type>                       <name>shaderWarpsPerSM</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderSMBuiltinsFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>shaderSMBuiltins</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name><comment>Pointer to next structure</comment></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name><comment>Pointer to next structure</comment></member>
             <member><type>VkBool32</type>               <name>fragmentShaderSampleInterlock</name></member>
             <member><type>VkBool32</type>               <name>fragmentShaderPixelInterlock</name></member>
             <member><type>VkBool32</type>               <name>fragmentShaderShadingRateInterlock</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>separateDepthStencilLayouts</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR"  alias="VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"/>
         <type category="struct" name="VkAttachmentReferenceStencilLayout" structextends="VkAttachmentReference2">
             <member values="VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_STENCIL_LAYOUT"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkImageLayout</type>                  <name>stencilLayout</name></member>
         </type>
         <type category="struct" name="VkAttachmentReferenceStencilLayoutKHR"                   alias="VkAttachmentReferenceStencilLayout"/>
         <type category="struct" name="VkAttachmentDescriptionStencilLayout" structextends="VkAttachmentDescription2">
             <member values="VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkImageLayout</type>                  <name>stencilInitialLayout</name></member>
             <member><type>VkImageLayout</type>                  <name>stencilFinalLayout</name></member>
         </type>
         <type category="struct" name="VkAttachmentDescriptionStencilLayoutKHR"                 alias="VkAttachmentDescriptionStencilLayout"/>
         <type category="struct" name="VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
             <member><type>VkBool32</type>           <name>pipelineExecutableInfo</name></member>
         </type>
         <type category="struct" name="VkPipelineInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*        <name>pNext</name></member>
             <member><type>VkPipeline</type>         <name>pipeline</name></member>
         </type>
         <type category="struct" name="VkPipelineExecutablePropertiesKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
             <member><type>VkShaderStageFlags</type> <name>stages</name></member>
             <member><type>char</type>               <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
             <member><type>char</type>               <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
@@ -4411,7 +4411,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineExecutableInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*        <name>pNext</name></member>
             <member><type>VkPipeline</type>         <name>pipeline</name></member>
             <member><type>uint32_t</type>           <name>executableIndex</name></member>
         </type>
@@ -4423,7 +4423,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineExecutableStatisticKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
             <member><type>char</type>               <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
             <member><type>char</type>               <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
             <member><type>VkPipelineExecutableStatisticFormatKHR</type> <name>format</name></member>
@@ -4431,7 +4431,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineExecutableInternalRepresentationKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
             <member><type>char</type>               <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
             <member><type>char</type>               <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
             <member><type>VkBool32</type>           <name>isText</name></member>
@@ -4440,17 +4440,17 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>shaderDemoteToHelperInvocation</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>texelBufferAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                       <name>storageTexelBufferOffsetAlignmentBytes</name></member>
             <member><type>VkBool32</type>                           <name>storageTexelBufferOffsetSingleTexelAlignment</name></member>
             <member><type>VkDeviceSize</type>                       <name>uniformTexelBufferOffsetAlignmentBytes</name></member>
@@ -4458,13 +4458,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceSubgroupSizeControlFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
              <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-             <member><type>void</type>*                          <name>pNext</name></member>
+             <member optional="true"><type>void</type>*                          <name>pNext</name></member>
              <member><type>VkBool32</type> <name>subgroupSizeControl</name></member>
              <member><type>VkBool32</type> <name>computeFullSubgroups</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSubgroupSizeControlPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
              <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-             <member><type>void</type>*                          <name>pNext</name></member>
+             <member optional="true"><type>void</type>*                          <name>pNext</name></member>
              <member noautovalidity="true"><type>uint32_t</type> <name>minSubgroupSize</name><comment>The minimum subgroup size supported by this device</comment></member>
              <member noautovalidity="true"><type>uint32_t</type> <name>maxSubgroupSize</name><comment>The maximum subgroup size supported by this device</comment></member>
              <member noautovalidity="true"><type>uint32_t</type> <name>maxComputeWorkgroupSubgroups</name><comment>The maximum number of subgroups supported in a workgroup</comment></member>
@@ -4472,24 +4472,24 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT" returnedonly="true" structextends="VkPipelineShaderStageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>requiredSubgroupSize</name></member>
         </type>
         <type category="struct" name="VkMemoryOpaqueCaptureAddressAllocateInfo" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                   <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                   <name>pNext</name></member>
             <member><type>uint64_t</type>                      <name>opaqueCaptureAddress</name></member>
         </type>
         <type category="struct" name="VkMemoryOpaqueCaptureAddressAllocateInfoKHR"             alias="VkMemoryOpaqueCaptureAddressAllocateInfo"/>
         <type category="struct" name="VkDeviceMemoryOpaqueCaptureAddressInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
         </type>
         <type category="struct" name="VkDeviceMemoryOpaqueCaptureAddressInfoKHR"               alias="VkDeviceMemoryOpaqueCaptureAddressInfo"/>
         <type category="struct" name="VkPhysicalDeviceLineRasterizationFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>rectangularLines</name></member>
             <member><type>VkBool32</type>                           <name>bresenhamLines</name></member>
             <member><type>VkBool32</type>                           <name>smoothLines</name></member>
@@ -4499,12 +4499,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceLineRasterizationPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>lineSubPixelPrecisionBits</name></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationLineStateCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                      <name>pNext</name></member>
             <member><type>VkLineRasterizationModeEXT</type>                                       <name>lineRasterizationMode</name></member>
             <member><type>VkBool32</type>                                                         <name>stippledLineEnable</name></member>
             <member optional="true"><type>uint32_t</type>                                         <name>lineStippleFactor</name></member>
@@ -4512,12 +4512,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type>                                                         <name>pipelineCreationCacheControl</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan11Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>storageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock</comment></member>
             <member><type>VkBool32</type>                         <name>uniformAndStorageBuffer16BitAccess</name><comment>16-bit integer/floating-point variables supported in BufferBlock and Block</comment></member>
             <member><type>VkBool32</type>                         <name>storagePushConstant16</name><comment>16-bit integer/floating-point variables supported in PushConstant</comment></member>
@@ -4533,7 +4533,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan11Properties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
             <member><type>uint8_t</type>                          <name>deviceUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
             <member><type>uint8_t</type>                          <name>driverUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
             <member><type>uint8_t</type>                          <name>deviceLUID</name>[<enum>VK_LUID_SIZE</enum>]</member>
@@ -4552,7 +4552,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan12Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>samplerMirrorClampToEdge</name></member>
             <member><type>VkBool32</type>                         <name>drawIndirectCount</name></member>
             <member><type>VkBool32</type>                         <name>storageBuffer8BitAccess</name><comment>8-bit integer variables supported in StorageBuffer</comment></member>
@@ -4603,7 +4603,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan12Properties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkDriverId</type>                       <name>driverID</name></member>
             <member><type>char</type>                             <name>driverName</name>[<enum>VK_MAX_DRIVER_NAME_SIZE</enum>]</member>
             <member><type>char</type>                             <name>driverInfo</name>[<enum>VK_MAX_DRIVER_INFO_SIZE</enum>]</member>
@@ -4659,17 +4659,17 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPipelineCompilerControlCreateInfoAMD" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD"><type>VkStructureType</type>   <name>sType</name></member>
-            <member>const <type>void</type>*                                                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCompilerControlFlagsAMD</type>                                      <name>compilerControlFlags</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCoherentMemoryFeaturesAMD" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>deviceCoherentMemory</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceToolPropertiesEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>char</type>            <name>name</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member>
             <member><type>char</type>            <name>version</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member>
             <member><type>VkToolPurposeFlagsEXT</type> <name>purposes</name></member>
@@ -4678,18 +4678,18 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSamplerCustomBorderColorCreateInfoEXT" structextends="VkSamplerCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                            <name>pNext</name></member>
             <member><type>VkClearColorValue</type>                                                                      <name>customBorderColor</name></member>
             <member><type>VkFormat</type>                                                                               <name>format</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                                                                   <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                                                                   <name>pNext</name></member>
             <member><type>uint32_t</type>                                                                                      <name>maxCustomBorderColorSamplers</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>customBorderColors</name></member>
             <member><type>VkBool32</type>                           <name>customBorderColorWithoutFormat</name></member>
         </type>
@@ -4703,7 +4703,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkAccelerationStructureGeometryTrianglesDataKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                   <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                   <name>pNext</name></member>
             <member><type>VkFormat</type>                                      <name>vertexFormat</name></member>
             <member><type>VkDeviceOrHostAddressConstKHR</type>                 <name>vertexData</name></member>
             <member><type>VkDeviceSize</type>                                  <name>vertexStride</name></member>
@@ -4713,13 +4713,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkAccelerationStructureGeometryAabbsDataKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                           <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                           <name>pNext</name></member>
             <member><type>VkDeviceOrHostAddressConstKHR</type>         <name>data</name></member>
             <member><type>VkDeviceSize</type>                          <name>stride</name></member>
         </type>
         <type category="struct" name="VkAccelerationStructureGeometryInstancesDataKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                           <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                           <name>pNext</name></member>
             <member><type>VkBool32</type>                              <name>arrayOfPointers</name></member>
             <member><type>VkDeviceOrHostAddressConstKHR</type>         <name>data</name></member>
         </type>
@@ -4730,14 +4730,14 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkAccelerationStructureGeometryKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member><type>VkGeometryTypeKHR</type>                      <name>geometryType</name></member>
             <member selector="geometryType"><type>VkAccelerationStructureGeometryDataKHR</type> <name>geometry</name></member>
             <member optional="true"><type>VkGeometryFlagsKHR</type>     <name>flags</name></member>
         </type>
         <type category="struct" name="VkAccelerationStructureBuildGeometryInfoKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                        <name>pNext</name></member>
             <member><type>VkAccelerationStructureTypeKHR</type>                                     <name>type</name></member>
             <member optional="true"><type>VkBuildAccelerationStructureFlagsKHR</type>               <name>flags</name></member>
             <member><type>VkBool32</type>                                                           <name>update</name></member>
@@ -4756,7 +4756,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkAccelerationStructureCreateGeometryTypeInfoKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_GEOMETRY_TYPE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                             <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                             <name>pNext</name></member>
             <member><type>VkGeometryTypeKHR</type>                                       <name>geometryType</name></member>
             <member><type>uint32_t</type>                                                <name>maxPrimitiveCount</name></member>
             <member><type>VkIndexType</type>                                              <name>indexType</name></member>
@@ -4766,7 +4766,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkAccelerationStructureCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                             <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                             <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                                            <name>compactedSize</name></member>
             <member><type>VkAccelerationStructureTypeKHR</type>                          <name>type</name></member>
             <member optional="true"><type>VkBuildAccelerationStructureFlagsKHR</type>    <name>flags</name></member>
@@ -4799,61 +4799,61 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkAccelerationStructureInstanceNV"                       alias="VkAccelerationStructureInstanceKHR"/>
         <type category="struct" name="VkAccelerationStructureDeviceAddressInfoKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member><type>VkAccelerationStructureKHR</type>                             <name>accelerationStructure</name></member>
         </type>
         <type category="struct" name="VkAccelerationStructureVersionKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_VERSION_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member len="2*VK_UUID_SIZE">const <type>uint8_t</type>*                    <name>versionData</name></member>
         </type>
         <type category="struct" name="VkCopyAccelerationStructureInfoKHR">
             <member values="VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member><type>VkAccelerationStructureKHR</type>                             <name>src</name></member>
             <member><type>VkAccelerationStructureKHR</type>                             <name>dst</name></member>
             <member><type>VkCopyAccelerationStructureModeKHR</type>                     <name>mode</name></member>
         </type>
         <type category="struct" name="VkCopyAccelerationStructureToMemoryInfoKHR">
             <member values="VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member><type>VkAccelerationStructureKHR</type>                             <name>src</name></member>
             <member><type>VkDeviceOrHostAddressKHR</type>                               <name>dst</name></member>
             <member><type>VkCopyAccelerationStructureModeKHR</type>                     <name>mode</name></member>
         </type>
         <type category="struct" name="VkCopyMemoryToAccelerationStructureInfoKHR">
             <member values="VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member><type>VkDeviceOrHostAddressConstKHR</type>                          <name>src</name></member>
             <member><type>VkAccelerationStructureKHR</type>                             <name>dst</name></member>
             <member><type>VkCopyAccelerationStructureModeKHR</type>                     <name>mode</name></member>
         </type>
         <type category="struct" name="VkRayTracingPipelineInterfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_INTERFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member><type>uint32_t</type>                                               <name>maxPayloadSize</name></member>
             <member><type>uint32_t</type>                                               <name>maxAttributeSize</name></member>
             <member><type>uint32_t</type>                                               <name>maxCallableSize</name></member>
         </type>
         <type category="struct" name="VkDeferredOperationInfoKHR" structextends="VkRayTracingPipelineCreateInfoKHR,VkAccelerationStructureBuildGeometryInfoKHR,VkCopyAccelerationStructureInfoKHR,VkCopyMemoryToAccelerationStructureInfoKHR,VkCopyAccelerationStructureToMemoryInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DEFERRED_OPERATION_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                   <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                   <name>pNext</name></member>
             <member noautovalidity="true"><type>VkDeferredOperationKHR</type>        <name>operationHandle</name></member>
         </type>
         <type category="struct" name="VkPipelineLibraryCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>                               <name>libraryCount</name></member>
             <member len="libraryCount">const <type>VkPipeline</type>*                   <name>pLibraries</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExtendedDynamicStateFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>extendedDynamicState</name></member>
         </type>
         <type category="struct" name="VkRenderPassTransformBeginInfoQCOM" structextends="VkRenderPassBeginInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_TRANSFORM_BEGIN_INFO_QCOM"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                           <name>pNext</name><comment>Pointer to next structure</comment></member>
+            <member optional="true"><type>void</type>*                           <name>pNext</name><comment>Pointer to next structure</comment></member>
             <member noautovalidity="true"><type>VkSurfaceTransformFlagBitsKHR</type>   <name>transform</name></member>
         </type>
         <type category="struct" name="VkCopyCommandTransformInfoQCOM" structextends="VkBufferImageCopy2KHR,VkImageBlit2KHR">
@@ -4863,41 +4863,41 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCommandBufferInheritanceRenderPassTransformInfoQCOM" structextends="VkCommandBufferInheritanceInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                           <name>pNext</name><comment>Pointer to next structure</comment></member>
+            <member optional="true"><type>void</type>*                           <name>pNext</name><comment>Pointer to next structure</comment></member>
             <member noautovalidity="true"><type>VkSurfaceTransformFlagBitsKHR</type>   <name>transform</name></member>
             <member><type>VkRect2D</type>                        <name>renderArea</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDiagnosticsConfigFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>diagnosticsConfig</name></member>
         </type>
         <type category="struct" name="VkDeviceDiagnosticsConfigCreateInfoNV" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                         <name>pNext</name></member>
             <member optional="true"><type>VkDeviceDiagnosticsConfigFlagsNV</type>    <name>flags</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRobustness2FeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>robustBufferAccess2</name></member>
             <member><type>VkBool32</type>                           <name>robustImageAccess2</name></member>
             <member><type>VkBool32</type>                           <name>nullDescriptor</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRobustness2PropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                       <name>robustStorageBufferAccessSizeAlignment</name></member>
             <member><type>VkDeviceSize</type>                       <name>robustUniformBufferAccessSizeAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceImageRobustnessFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>robustImageAccess</name></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePortabilitySubsetFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>constantAlphaColorBlendFactors</name></member>
             <member><type>VkBool32</type>                           <name>events</name></member>
             <member><type>VkBool32</type>                           <name>imageViewFormatReinterpretation</name></member>
@@ -4916,25 +4916,25 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDevicePortabilitySubsetPropertiesKHR" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>uint32_t</type>                           <name>minVertexInputBindingStrideAlignment</name></member>
                 </type>
         <type category="struct" name="VkPhysicalDevice4444FormatsFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>formatA4R4G4B4</name></member>
             <member><type>VkBool32</type>                           <name>formatA4B4G4R4</name></member>
         </type>
         <type category="struct" name="VkBufferCopy2KHR">
             <member values="VK_STRUCTURE_TYPE_BUFFER_COPY_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*  <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*  <name>pNext</name></member>
             <member><type>VkDeviceSize</type> <name>srcOffset</name><comment>Specified in bytes</comment></member>
             <member><type>VkDeviceSize</type> <name>dstOffset</name><comment>Specified in bytes</comment></member>
             <member noautovalidity="true"><type>VkDeviceSize</type> <name>size</name><comment>Specified in bytes</comment></member>
         </type>
         <type category="struct" name="VkImageCopy2KHR">
             <member values="VK_STRUCTURE_TYPE_IMAGE_COPY_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkImageSubresourceLayers</type> <name>srcSubresource</name></member>
             <member><type>VkOffset3D</type> <name>srcOffset</name><comment>Specified in pixels for both compressed and uncompressed images</comment></member>
             <member><type>VkImageSubresourceLayers</type> <name>dstSubresource</name></member>
@@ -4943,7 +4943,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImageBlit2KHR">
             <member values="VK_STRUCTURE_TYPE_IMAGE_BLIT_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*  <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*  <name>pNext</name></member>
             <member><type>VkImageSubresourceLayers</type> <name>srcSubresource</name></member>
             <member><type>VkOffset3D</type> <name>srcOffsets</name>[2]<comment>Specified in pixels for both compressed and uncompressed images</comment></member>
             <member><type>VkImageSubresourceLayers</type> <name>dstSubresource</name></member>
@@ -4951,7 +4951,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkBufferImageCopy2KHR">
             <member values="VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*  <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*  <name>pNext</name></member>
             <member><type>VkDeviceSize</type> <name>bufferOffset</name><comment>Specified in bytes</comment></member>
             <member><type>uint32_t</type> <name>bufferRowLength</name><comment>Specified in texels</comment></member>
             <member><type>uint32_t</type> <name>bufferImageHeight</name></member>
@@ -4961,7 +4961,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImageResolve2KHR">
             <member values="VK_STRUCTURE_TYPE_IMAGE_RESOLVE_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*  <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*  <name>pNext</name></member>
             <member><type>VkImageSubresourceLayers</type> <name>srcSubresource</name></member>
             <member><type>VkOffset3D</type> <name>srcOffset</name></member>
             <member><type>VkImageSubresourceLayers</type> <name>dstSubresource</name></member>
@@ -4970,7 +4970,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCopyBufferInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkBuffer</type> <name>srcBuffer</name></member>
             <member><type>VkBuffer</type> <name>dstBuffer</name></member>
             <member><type>uint32_t</type> <name>regionCount</name></member>
@@ -4978,7 +4978,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCopyImageInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkImage</type> <name>srcImage</name></member>
             <member><type>VkImageLayout</type> <name>srcImageLayout</name></member>
             <member><type>VkImage</type> <name>dstImage</name></member>
@@ -4988,7 +4988,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkBlitImageInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkImage</type> <name>srcImage</name></member>
             <member><type>VkImageLayout</type> <name>srcImageLayout</name></member>
             <member><type>VkImage</type> <name>dstImage</name></member>
@@ -4999,7 +4999,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCopyBufferToImageInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkBuffer</type> <name>srcBuffer</name></member>
             <member><type>VkImage</type> <name>dstImage</name></member>
             <member><type>VkImageLayout</type> <name>dstImageLayout</name></member>
@@ -5008,7 +5008,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCopyImageToBufferInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_COPY_IMAGE_TO_BUFFER_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkImage</type> <name>srcImage</name></member>
             <member><type>VkImageLayout</type> <name>srcImageLayout</name></member>
             <member><type>VkBuffer</type> <name>dstBuffer</name></member>
@@ -5017,7 +5017,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkResolveImageInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>* <name>pNext</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkImage</type> <name>srcImage</name></member>
             <member><type>VkImageLayout</type> <name>srcImageLayout</name></member>
             <member><type>VkImage</type> <name>dstImage</name></member>
@@ -5027,32 +5027,32 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>shaderImageInt64Atomics</name></member>
             <member><type>VkBool32</type>                            <name>sparseImageInt64Atomics</name></member>
         </type>
         <type category="struct" name="VkFragmentShadingRateAttachmentInfoKHR" structextends="VkSubpassDescription2">
             <member values="VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                <name>pNext</name></member>
             <member>const <type>VkAttachmentReference2</type>* <name>pFragmentShadingRateAttachment</name></member>
             <member><type>VkExtent2D</type>                 <name>shadingRateAttachmentTexelSize</name></member>
         </type>
         <type category="struct" name="VkPipelineFragmentShadingRateStateCreateInfoKHR" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_STATE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                <name>pNext</name></member>
             <member><type>VkExtent2D</type>                                 <name>fragmentSize</name></member>
             <member><type>VkFragmentShadingRateCombinerOpKHR</type>         <name>combinerOps</name>[2]</member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRateFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
             <member><type>VkBool32</type>           <name>pipelineFragmentShadingRate</name></member>
             <member><type>VkBool32</type>           <name>primitiveFragmentShadingRate</name></member>
             <member><type>VkBool32</type>           <name>attachmentFragmentShadingRate</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkExtent2D</type>             <name>minFragmentShadingRateAttachmentTexelSize</name></member>
             <member><type>VkExtent2D</type>             <name>maxFragmentShadingRateAttachmentTexelSize</name></member>
             <member><type>uint32_t</type>               <name>maxFragmentShadingRateAttachmentTexelSizeAspectRatio</name></member>
@@ -5073,7 +5073,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRateKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
             <member><type>VkSampleCountFlags</type> <name>sampleCounts</name></member>
             <member><type>VkExtent2D</type>         <name>fragmentSize</name></member>
         </type>
@@ -5084,19 +5084,19 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>fragmentShadingRateEnums</name></member>
             <member><type>VkBool32</type>                           <name>supersampleFragmentShadingRates</name></member>
             <member><type>VkBool32</type>                           <name>noInvocationFragmentShadingRates</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                              <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
             <member><type>VkSampleCountFlagBits</type>              <name>maxFragmentShadingRateInvocationCount</name></member>
         </type>
         <type category="struct" name="VkPipelineFragmentShadingRateEnumStateCreateInfoNV" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
             <member><type>VkFragmentShadingRateTypeNV</type>        <name>shadingRateType</name></member>
             <member><type>VkFragmentShadingRateNV</type>            <name>shadingRate</name></member>
             <member><type>VkFragmentShadingRateCombinerOpKHR</type> <name>combinerOps</name>[2]</member>


### PR DESCRIPTION
While generating language bindings from vk.xml I noticed that the pNext member in structs is not marked as optional, but from what i understand pNext should be allowed to be null.

Example from khronos.org: "pNext is NULL or a pointer to the next structure in a structure chain."
(https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBaseInStructure.html)

Maybe I'm misinterpreting what optional means in this context.