### PR TITLE
Remove extraneous newline from texel block size table

### DIFF
--- a/chapters/formats.txt
+++ b/chapters/formats.txt
@@ -2034,7 +2034,6 @@ endif::VK_EXT_texture_compression_astc_hdr[]
 ifdef::VK_EXT_texture_compression_astc_hdr[]
                     ename:VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT, +
 endif::VK_EXT_texture_compression_astc_hdr[]
-
                     ename:VK_FORMAT_ASTC_6x5_SRGB_BLOCK
 | ASTC_6x6 (128 bit) +
   Block size 16 bytes +


### PR DESCRIPTION
Small formatting typo I stumbled upon.