### PR TITLE
Remove redundant / incomplete handle comments from VkObjectType enums

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -5664,31 +5664,31 @@ typedef void <name>CAMetalLayer</name>;
     </enums>
     <enums name="VkObjectType" type="enum" comment="Enums to track objects of various types - also see objtypeenum attributes on type tags">
         <enum value="0"     name="VK_OBJECT_TYPE_UNKNOWN"/>
-        <enum value="1"     name="VK_OBJECT_TYPE_INSTANCE"                           comment="VkInstance"/>
-        <enum value="2"     name="VK_OBJECT_TYPE_PHYSICAL_DEVICE"                    comment="VkPhysicalDevice"/>
-        <enum value="3"     name="VK_OBJECT_TYPE_DEVICE"                             comment="VkDevice"/>
-        <enum value="4"     name="VK_OBJECT_TYPE_QUEUE"                              comment="VkQueue"/>
-        <enum value="5"     name="VK_OBJECT_TYPE_SEMAPHORE"                          comment="VkSemaphore"/>
-        <enum value="6"     name="VK_OBJECT_TYPE_COMMAND_BUFFER"                     comment="VkCommandBuffer"/>
-        <enum value="7"     name="VK_OBJECT_TYPE_FENCE"                              comment="VkFence"/>
-        <enum value="8"     name="VK_OBJECT_TYPE_DEVICE_MEMORY"                      comment="VkDeviceMemory"/>
-        <enum value="9"     name="VK_OBJECT_TYPE_BUFFER"                             comment="VkBuffer"/>
-        <enum value="10"    name="VK_OBJECT_TYPE_IMAGE"                              comment="VkImage"/>
-        <enum value="11"    name="VK_OBJECT_TYPE_EVENT"                              comment="VkEvent"/>
-        <enum value="12"    name="VK_OBJECT_TYPE_QUERY_POOL"                         comment="VkQueryPool"/>
-        <enum value="13"    name="VK_OBJECT_TYPE_BUFFER_VIEW"                        comment="VkBufferView"/>
-        <enum value="14"    name="VK_OBJECT_TYPE_IMAGE_VIEW"                         comment="VkImageView"/>
-        <enum value="15"    name="VK_OBJECT_TYPE_SHADER_MODULE"                      comment="VkShaderModule"/>
-        <enum value="16"    name="VK_OBJECT_TYPE_PIPELINE_CACHE"                     comment="VkPipelineCache"/>
-        <enum value="17"    name="VK_OBJECT_TYPE_PIPELINE_LAYOUT"                    comment="VkPipelineLayout"/>
-        <enum value="18"    name="VK_OBJECT_TYPE_RENDER_PASS"                        comment="VkRenderPass"/>
-        <enum value="19"    name="VK_OBJECT_TYPE_PIPELINE"                           comment="VkPipeline"/>
-        <enum value="20"    name="VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT"              comment="VkDescriptorSetLayout"/>
-        <enum value="21"    name="VK_OBJECT_TYPE_SAMPLER"                            comment="VkSampler"/>
-        <enum value="22"    name="VK_OBJECT_TYPE_DESCRIPTOR_POOL"                    comment="VkDescriptorPool"/>
-        <enum value="23"    name="VK_OBJECT_TYPE_DESCRIPTOR_SET"                     comment="VkDescriptorSet"/>
-        <enum value="24"    name="VK_OBJECT_TYPE_FRAMEBUFFER"                        comment="VkFramebuffer"/>
-        <enum value="25"    name="VK_OBJECT_TYPE_COMMAND_POOL"                       comment="VkCommandPool"/>
+        <enum value="1"     name="VK_OBJECT_TYPE_INSTANCE"/>
+        <enum value="2"     name="VK_OBJECT_TYPE_PHYSICAL_DEVICE"/>
+        <enum value="3"     name="VK_OBJECT_TYPE_DEVICE"/>
+        <enum value="4"     name="VK_OBJECT_TYPE_QUEUE"/>
+        <enum value="5"     name="VK_OBJECT_TYPE_SEMAPHORE"/>
+        <enum value="6"     name="VK_OBJECT_TYPE_COMMAND_BUFFER"/>
+        <enum value="7"     name="VK_OBJECT_TYPE_FENCE"/>
+        <enum value="8"     name="VK_OBJECT_TYPE_DEVICE_MEMORY"/>
+        <enum value="9"     name="VK_OBJECT_TYPE_BUFFER"/>
+        <enum value="10"    name="VK_OBJECT_TYPE_IMAGE"/>
+        <enum value="11"    name="VK_OBJECT_TYPE_EVENT"/>
+        <enum value="12"    name="VK_OBJECT_TYPE_QUERY_POOL"/>
+        <enum value="13"    name="VK_OBJECT_TYPE_BUFFER_VIEW"/>
+        <enum value="14"    name="VK_OBJECT_TYPE_IMAGE_VIEW"/>
+        <enum value="15"    name="VK_OBJECT_TYPE_SHADER_MODULE"/>
+        <enum value="16"    name="VK_OBJECT_TYPE_PIPELINE_CACHE"/>
+        <enum value="17"    name="VK_OBJECT_TYPE_PIPELINE_LAYOUT"/>
+        <enum value="18"    name="VK_OBJECT_TYPE_RENDER_PASS"/>
+        <enum value="19"    name="VK_OBJECT_TYPE_PIPELINE"/>
+        <enum value="20"    name="VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT"/>
+        <enum value="21"    name="VK_OBJECT_TYPE_SAMPLER"/>
+        <enum value="22"    name="VK_OBJECT_TYPE_DESCRIPTOR_POOL"/>
+        <enum value="23"    name="VK_OBJECT_TYPE_DESCRIPTOR_SET"/>
+        <enum value="24"    name="VK_OBJECT_TYPE_FRAMEBUFFER"/>
+        <enum value="25"    name="VK_OBJECT_TYPE_COMMAND_POOL"/>
     </enums>
 
         <comment>Flags</comment>
@@ -10303,7 +10303,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_KHR_surface&quot;"                        name="VK_KHR_SURFACE_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkResult" dir="-"                     name="VK_ERROR_SURFACE_LOST_KHR"/>
                 <enum offset="1" extends="VkResult" dir="-"                     name="VK_ERROR_NATIVE_WINDOW_IN_USE_KHR"/>
-                <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_SURFACE_KHR"                comment="VkSurfaceKHR"/>
+                <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_SURFACE_KHR"/>
                 <type name="VkSurfaceKHR"/>
                 <type name="VkSurfaceTransformFlagBitsKHR"/>
                 <type name="VkPresentModeKHR"/>
@@ -10328,7 +10328,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum offset="2" extends="VkImageLayout"                        name="VK_IMAGE_LAYOUT_PRESENT_SRC_KHR"/>
                 <enum offset="3" extends="VkResult"                             name="VK_SUBOPTIMAL_KHR"/>
                 <enum offset="4" extends="VkResult" dir="-"                     name="VK_ERROR_OUT_OF_DATE_KHR"/>
-                <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_SWAPCHAIN_KHR"              comment="VkSwapchainKHR"/>
+                <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_SWAPCHAIN_KHR"/>
                 <type name="VkSwapchainCreateFlagBitsKHR"/>
                 <type name="VkSwapchainCreateFlagsKHR"/>
                 <type name="VkSwapchainCreateInfoKHR"/>
@@ -10370,8 +10370,8 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_KHR_display&quot;"                        name="VK_KHR_DISPLAY_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR"/>
                 <enum offset="1" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR"/>
-                <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_DISPLAY_KHR"                comment="VkDisplayKHR"/>
-                <enum offset="1" extends="VkObjectType"                         name="VK_OBJECT_TYPE_DISPLAY_MODE_KHR"           comment="VkDisplayModeKHR"/>
+                <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_DISPLAY_KHR"/>
+                <enum offset="1" extends="VkObjectType"                         name="VK_OBJECT_TYPE_DISPLAY_MODE_KHR"/>
                 <type name="VkDisplayKHR"/>
                 <type name="VkDisplayModeCreateFlagsKHR"/>
                 <type name="VkDisplayModeCreateInfoKHR"/>
@@ -10495,7 +10495,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT"/>
                 <enum alias="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT" extends="VkStructureType" name="VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT" comment="Backwards-compatible alias containing a typo"/>
                 <enum offset="1" extends="VkResult" dir="-"                     name="VK_ERROR_VALIDATION_FAILED_EXT"/>
-                <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT"  comment="VkDebugReportCallbackEXT"/>
+                <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT"/>
                 <type name="VkDebugReportCallbackEXT"/>
                 <type name="PFN_vkDebugReportCallbackEXT"/>
                 <type name="VkDebugReportFlagBitsEXT"/>
@@ -11860,7 +11860,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT"/>
                 <enum offset="3" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT"/>
                 <enum offset="4" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT"/>
-                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT"      comment="VkDebugUtilsMessengerEXT"/>
+                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT"/>
                 <type name="PFN_vkDebugUtilsMessengerCallbackEXT"/>
                 <type name="VkDebugUtilsLabelEXT"/>
                 <type name="VkDebugUtilsMessageSeverityFlagBitsEXT"/>
@@ -12448,7 +12448,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_EXT_validation_cache&quot;"           name="VK_EXT_VALIDATION_CACHE_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VALIDATION_CACHE_CREATE_INFO_EXT"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT"/>
-                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_VALIDATION_CACHE_EXT" comment="VkValidationCacheEXT"/>
+                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_VALIDATION_CACHE_EXT"/>
                 <type name="VkValidationCacheEXT"/>
                 <type name="VkValidationCacheCreateInfoEXT"/>
                 <type name="VkShaderModuleValidationCacheCreateInfoEXT"/>
@@ -13773,7 +13773,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum bitpos="17" extends="VkPipelineStageFlagBits"         name="VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV"/>
                 <enum bitpos="17" extends="VkAccessFlagBits"                name="VK_ACCESS_COMMAND_PREPROCESS_READ_BIT_NV"/>
                 <enum bitpos="18" extends="VkAccessFlagBits"                name="VK_ACCESS_COMMAND_PREPROCESS_WRITE_BIT_NV"/>
-                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV" comment="VkIndirectCommandsLayoutNV"/>
+                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV"/>
                 <type name="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"/>
                 <type name="VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"/>
                 <type name="VkGraphicsShaderGroupCreateInfoNV"/>


### PR DESCRIPTION
Followup to #1379. There is now a semantically meaningful schema
attribute mapping handles to corresponding VK_OBJECT_TYPES enum names.
This removes the comments which were previously being used by some
downstream consumers of the XML to infer this information on the basis
that (a) they are not defined to be usable for this purpose (b) they are
incomplete and (c) we have no intention of maintaining them in the
future when new handle types are defined.