### PR TITLE
Clarify docs for VK_FORMAT_D32_SFLOAT_S8_UINT

### DIFF
--- a/chapters/formats.txt
+++ b/chapters/formats.txt
@@ -483,7 +483,7 @@ endif::VK_EXT_4444_formats[]
   * ename:VK_FORMAT_D24_UNORM_S8_UINT specifies a two-component, 32-bit
     packed format that has 8 unsigned integer bits in the stencil component,
     and 24 unsigned normalized bits in the depth component.
-  * ename:VK_FORMAT_D32_SFLOAT_S8_UINT specifies a two-component format that
+  * ename:VK_FORMAT_D32_SFLOAT_S8_UINT specifies a two-component, 64-bit format that
     has 32 signed float bits in the depth component and 8 unsigned integer
     bits in the stencil component.
     There are optionally: 24-bits that are unused.


### PR DESCRIPTION
Make the description follow the other descriptions, as I was almost tricked into thinking it was a 32-bit format or even a 40-bit format.

Just a tiny change.