### PR TITLE
Fix typo in ifdef/endif directives

### DIFF
--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -180,12 +180,12 @@ or knowledge of runtime information, such as enabled features.
     If the semantics for code:OpControlBarrier includes one of *Acquire*,
     *Release*, *AcquireRelease*, or *SequentiallyConsistent* memory
     semantics, then it must: include at least one storage class
-#ifndef::VK_KHR_zero_initialize_workgroup_memory
+ifndef::VK_KHR_zero_initialize_workgroup_memory
   * [[VUID-{refpage}-OpVariable-04651]]
     Any code:OpVariable with an code:Initializer operand must: have
     *Output*, *Private*, or *Function* as its *Storage Class* operand
-#endif::VK_KHR_zero_initialize_workgroup_memory
-#ifdef::VK_KHR_zero_initialize_workgroup_memory
+endif::VK_KHR_zero_initialize_workgroup_memory
+ifdef::VK_KHR_zero_initialize_workgroup_memory
   * [[VUID-{refpage}-OpVariable-04651]]
     Any code:OpVariable with an code:Initializer operand must: have
     *Output*, *Private*, *Function*, or *Workgroup* as its *Storage Class*
@@ -194,7 +194,7 @@ or knowledge of runtime information, such as enabled features.
     Any code:OpVariable with an code:Initializer operand and *Workgroup* as
     its *Storage Class* operand must: use code:OpConstantNull as the
     initializer.
-#endif::VK_KHR_zero_initialize_workgroup_memory
+endif::VK_KHR_zero_initialize_workgroup_memory
   * [[VUID-{refpage}-OpReadClockKHR-04652]]
     *Scope* for code:OpReadClockKHR must: be limited to *Subgroup* or
     *Device*
@@ -911,12 +911,12 @@ endif::VK_KHR_ray_tracing_pipeline[]
   * The product of pname:x size, pname:y size, and pname:z size in
     code:LocalSize must: be less than or equal to
     sname:VkPhysicalDeviceLimits::pname:maxComputeWorkGroupInvocations
-#ifdef::VK_KHR_zero_initialize_workgroup_memory
+ifdef::VK_KHR_zero_initialize_workgroup_memory
   * If
     <<features-shaderZeroInitializeWorkgroupMemory,pname:shaderZeroInitializeWorkgroupMemory>>
     is not enabled, any code:OpVariable with *Workgroup* as its *Storage
     Class* must: not have an code:Initializer operand
-#endif::VK_KHR_zero_initialize_workgroup_memory
+endif::VK_KHR_zero_initialize_workgroup_memory
 ifdef::VK_KHR_workgroup_memory_explicit_layout[]
   * If
     <<features-workgroupMemoryExplicitLayout8BitAccess,pname:workgroupMemoryExplicitLayout8BitAccess>>


### PR DESCRIPTION
Found when Vulkan-ValidationLayers code generation scripts complained about duplicated VUID in `validusage.json`.

CC: @oddhack @alan-baker