### PR TITLE
WIP: Add VK_EXT_acquire_wl_display

### DIFF
--- a/appendices/VK_EXT_acquire_wl_display.txt
+++ b/appendices/VK_EXT_acquire_wl_display.txt
@@ -5,11 +5,12 @@
 include::{generated}/meta/{refprefix}VK_EXT_acquire_wl_display.txt[]
 
 *Last Modified Date*::
-    2019-10-17
+    2021-02-11
 *IP Status*::
     No known IP claims.
 *Contributors*::
   - Drew DeVault, Status Holdings, Ltd.
+  - Lubosz Sarnecki, Collabora, Ltd.
 
 This extension allows an application to take exclusive control of a display
 currently associated with a Wayland compositor.
@@ -43,3 +44,5 @@ None.
 
  * Revision 1, 2019-10-17 (Drew DeVault)
    - Initial draft
+ * Revision 2, 2021-02-11 (Lubosz Sarnecki)
+   - Update to Wayland drm-lease-unstable-v1 protocol changes

--- a/appendices/VK_EXT_acquire_wl_display.txt
+++ b/appendices/VK_EXT_acquire_wl_display.txt
@@ -1,0 +1,45 @@
+// Copyright 2018-2021 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_acquire_wl_display.txt[]
+
+*Last Modified Date*::
+    2019-10-17
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Drew DeVault, Status Holdings, Ltd.
+
+This extension allows an application to take exclusive control of a display
+currently associated with a Wayland compositor.
+When control is acquired, the display will be unassociated from the Wayland
+compositor until the application releases the display or the specified display
+connection is closed.
+Essentially, the Wayland compositor will behave as if the monitor has been
+unplugged until the application releases it.
+
+=== New Enum Constants
+
+None.
+
+=== New Enums
+
+None.
+
+=== New Structures
+
+  * slink:VkWaylandLeaseConnectorEXT
+
+=== New Functions
+
+  * flink:vkAcquireWaylandDisplayEXT
+
+=== Issues
+
+None.
+
+=== Version History
+
+ * Revision 1, 2019-10-17 (Drew DeVault)
+   - Initial draft

--- a/chapters/VK_EXT_acquire_wl_display/acquire_wl_display.txt
+++ b/chapters/VK_EXT_acquire_wl_display/acquire_wl_display.txt
@@ -1,0 +1,51 @@
+[open,refpage='vkAcquireWaylandDisplayEXT',desc='Acquire access to a VkDisplayKHR using Wayland',type='protos']
+--
+
+To acquire permission to directly access a display in Vulkan from a Wayland
+compositor, call:
+
+include::{generated}/api/protos/vkAcquireWaylandDisplayEXT.txt[]
+
+  * pname:physicalDevice is the handle to the physical device the display is on.
+  * pname:display A code:wl_display associated with the Wayland compositor that
+	the application wishes to acquire the display(s) from.
+  * pname:manager A zwp_drm_lease_manager_v1 connected to the Wayland compositor
+	that associated with the connectors.
+  * pname:pConnectorCount The number of valid pointers in the pname:pConnectors
+	array.
+  * pname:pConnectors Array of slink:VkWaylandLeaseConnectorEXT to be acquired.
+
+All permissions necessary to control the display are granted to the Vulkan
+instance associated with pname:physicalDevice until the display is released, the
+Wayland connection specified by pname:display is terminated, or the compositor
+revokes the lease.
+If the Wayland server declines to grant the lease or the granted lease does not
+include the requested connectors, the call must: return the error code
+ename:VK_ERROR_INITIALIZATION_FAILED.
+If the Wayland server later revokes the lease, requests using the
+acquired slink:VkDisplayKHR resources must: fail with
+ename:VK_ERROR_SURFACE_LOST_KHR.
+
+include::{generated}/validity/protos/vkAcquireWaylandDisplayEXT.txt[]
+--
+
+[open,refpage='VkWaylandLeaseConnectorEXT',desc='Resource for relating Wayland connectors to VkDisplayKHRs',type='structs']
+--
+
+The sname:VkWaylandLeaseConnectorEXT structure is defined as:
+
+include::{generated}/api/structs/VkWaylandLeaseConnectorEXT.txt[]
+
+  * pname:pConnector A Wayland zwp_drm_lease_connector_v1 to include in the
+	lease.
+  * pname:pDisplay The corresponding slink:VkDisplayKHR handle will be
+    returned here.
+
+The implementation will make a best-effort attempt to match each
+slink:VkDisplayKHR acquired from the Wayland compositor to the appropriate
+pname:pConnectorIn. If no match is found or the result would be ambiguous, the
+lease is terminated, and flink:vkAcquireWaylandDisplayEXT must: return
+ename:VK_ERROR_INITIALIZATION_FAILED.
+
+include::{generated}/validity/structs/VkWaylandLeaseConnectorEXT.txt[]
+--

--- a/chapters/VK_EXT_acquire_wl_display/acquire_wl_display.txt
+++ b/chapters/VK_EXT_acquire_wl_display/acquire_wl_display.txt
@@ -9,7 +9,7 @@ include::{generated}/api/protos/vkAcquireWaylandDisplayEXT.txt[]
   * pname:physicalDevice is the handle to the physical device the display is on.
   * pname:display A code:wl_display associated with the Wayland compositor that
 	the application wishes to acquire the display(s) from.
-  * pname:manager A zwp_drm_lease_manager_v1 connected to the Wayland compositor
+  * pname:leaseDevice A zwp_drm_lease_device_v1 connected to the Wayland compositor
 	that associated with the connectors.
   * pname:pConnectorCount The number of valid pointers in the pname:pConnectors
 	array.

--- a/chapters/VK_EXT_direct_mode_display/acquire_release_displays.txt
+++ b/chapters/VK_EXT_direct_mode_display/acquire_release_displays.txt
@@ -18,6 +18,10 @@ ifdef::VK_NV_acquire_winrt_display[]
 include::{chapters}/VK_NV_acquire_winrt_display/acquire_winrt_display.txt[]
 endif::VK_NV_acquire_winrt_display[]
 
+ifdef::VK_EXT_acquire_wl_display[]
+include::../VK_EXT_acquire_wl_display/acquire_wl_display.txt[]
+endif::VK_EXT_acquire_wl_display[]
+
 [open,refpage='vkReleaseDisplayEXT',desc='Release access to an acquired VkDisplayKHR',type='protos']
 --
 

--- a/include/vulkan/vk_platform.h
+++ b/include/vulkan/vk_platform.h
@@ -79,7 +79,7 @@ extern "C"
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
     // Forward declared for VK_EXT_acquire_wl_display
-    struct zwp_drm_lease_manager_v1;
+    struct zwp_drm_lease_device_v1;
     struct zwp_drm_lease_connector_v1;
 #endif // VK_USE_PLATFORM_WAYLAND_KHR
 

--- a/include/vulkan/vk_platform.h
+++ b/include/vulkan/vk_platform.h
@@ -77,6 +77,12 @@ extern "C"
     #endif
 #endif // !defined(VK_NO_STDINT_H)
 
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    // Forward declared for VK_EXT_acquire_wl_display
+    struct zwp_drm_lease_manager_v1;
+    struct zwp_drm_lease_connector_v1;
+#endif // VK_USE_PLATFORM_WAYLAND_KHR
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/scripts/genvk.py
+++ b/scripts/genvk.py
@@ -306,7 +306,9 @@ def makeGenOpts(args):
         [ 'vulkan_ios.h',         [ 'VK_MVK_ios_surface'          ], commonSuppressExtensions ],
         [ 'vulkan_macos.h',       [ 'VK_MVK_macos_surface'        ], commonSuppressExtensions ],
         [ 'vulkan_vi.h',          [ 'VK_NN_vi_surface'            ], commonSuppressExtensions ],
-        [ 'vulkan_wayland.h',     [ 'VK_KHR_wayland_surface'      ], commonSuppressExtensions ],
+        [ 'vulkan_wayland.h',     [ 'VK_KHR_wayland_surface',
+                                    'VK_EXT_acquire_wl_display'
+                                                                  ], commonSuppressExtensions ],
         [ 'vulkan_win32.h',       [ 'VK_.*_win32(|_.*)', 'VK_EXT_full_screen_exclusive' ],
                                                                      commonSuppressExtensions +
                                                                      [ 'VK_KHR_external_semaphore',

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -108,7 +108,7 @@ branch of the member gitlab server.
         <type requires="X11/extensions/Xrandr.h" name="RROutput"/>
         <type requires="wayland-client.h" name="wl_display"/>
         <type requires="wayland-client.h" name="wl_surface"/>
-        <type name="zwp_drm_lease_manager_v1"/>
+        <type name="zwp_drm_lease_device_v1"/>
         <type name="zwp_drm_lease_connector_v1"/>
         <type requires="windows.h" name="HINSTANCE"/>
         <type requires="windows.h" name="HWND"/>
@@ -9316,7 +9316,7 @@ typedef void <name>CAMetalLayer</name>;
             <proto><type>VkResult</type> <name>vkAcquireWaylandDisplayEXT</name></proto>
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
             <param>struct <type>wl_display</type>* <name>display</name></param>
-            <param>struct <type>zwp_drm_lease_manager_v1</type>* <name>manager</name></param>
+            <param>struct <type>zwp_drm_lease_device_v1</type>* <name>leaseDevice</name></param>
             <param><type>uint32_t</type> <name>pConnectorCount</name></param>
             <param len="connectorCount"><type>VkWaylandLeaseConnectorEXT</type>* <name>pConnectors</name></param>
         </command>

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -108,6 +108,8 @@ branch of the member gitlab server.
         <type requires="X11/extensions/Xrandr.h" name="RROutput"/>
         <type requires="wayland-client.h" name="wl_display"/>
         <type requires="wayland-client.h" name="wl_surface"/>
+        <type name="zwp_drm_lease_manager_v1"/>
+        <type name="zwp_drm_lease_connector_v1"/>
         <type requires="windows.h" name="HINSTANCE"/>
         <type requires="windows.h" name="HWND"/>
         <type requires="windows.h" name="HMONITOR"/>
@@ -5148,6 +5150,10 @@ typedef void <name>CAMetalLayer</name>;
             <member optional="true"><type>uint32_t</type>                                                         <name>mutableDescriptorTypeListCount</name></member>
             <member len="mutableDescriptorTypeListCount">const <type>VkMutableDescriptorTypeListVALVE</type>* <name>pMutableDescriptorTypeLists</name></member>
         </type>
+        <type category="struct" name="VkWaylandLeaseConnectorEXT">
+            <member>struct <type>zwp_drm_lease_connector_v1</type>* <name>pConnector</name></member>
+            <member><type>VkDisplayKHR</type> <name>pDisplay</name></member>
+        </type>
     </types>
 
     <comment>Vulkan enumerant (token) definitions</comment>
@@ -9305,6 +9311,14 @@ typedef void <name>CAMetalLayer</name>;
             <param>const <type>VkAccelerationStructureBuildGeometryInfoKHR</type>*  <name>pBuildInfo</name></param>
             <param optional="true" len="pBuildInfo-&gt;geometryCount">const <type>uint32_t</type>*  <name>pMaxPrimitiveCounts</name></param>
             <param><type>VkAccelerationStructureBuildSizesInfoKHR</type>*           <name>pSizeInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkAcquireWaylandDisplayEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>struct <type>wl_display</type>* <name>display</name></param>
+            <param>struct <type>zwp_drm_lease_manager_v1</type>* <name>manager</name></param>
+            <param><type>uint32_t</type> <name>pConnectorCount</name></param>
+            <param len="connectorCount"><type>VkWaylandLeaseConnectorEXT</type>* <name>pConnectors</name></param>
         </command>
     </commands>
 
@@ -13904,10 +13918,11 @@ typedef void <name>CAMetalLayer</name>;
                 <type name="PFN_vkDeviceMemoryReportCallbackEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_286" number="286" type="instance" author="EXT" contact="Drew DeVault sir@cmpwn.com" supported="disabled">
+        <extension name="VK_EXT_acquire_wl_display" number="286" type="instance" requires="VK_EXT_direct_mode_display" author="EXT" contact="Drew DeVault @ddevault" platform="wayland" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_286_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_286&quot;"              name="VK_EXT_extension_286"/>
+                <enum value="1"                                             name="VK_EXT_ACQUIRE_WL_DISPLAY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_acquire_wl_display&quot;"         name="VK_EXT_ACQUIRE_WL_DISPLAY_EXTENSION_NAME"/>
+                <command name="vkAcquireWaylandDisplayEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_robustness2" number="287"  type="device" author="EXT" contact="Liam Middlebrook @liam-middlebrook" supported="vulkan">


### PR DESCRIPTION
This is a continuation of the original PR #1001 

I rebased the patch on the current master branch and am willing to integrate changes from reviews, so this can land.

An overview of all related branches and merge requests to the stack can be found in the [README here](https://gitlab.freedesktop.org/lubosz/wlxr-pkgbuilds).

The only part which the Vulkan extension depends on is the Wayland protocol, currently proposed in a [new MR by Xaver Hugl](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/67).

Not sure how the procedure is with `Vulkan-Headers` and `Vulkan-Loader`, but I have branches for both enabling this extension:

https://github.com/lubosz/Vulkan-Loader/tree/acquire_wl_display
https://github.com/lubosz/Vulkan-Headers/tree/acquire_wl_display

An updated implementation of this extension in mesa can be found here:
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/8981