### PR TITLE
`Sampled=1` should apply to `OpTypeImage`

### DIFF
--- a/chapters/interfaces.txt
+++ b/chapters/interfaces.txt
@@ -930,8 +930,8 @@ A noteworthy example of using multiple statically-used shader variables
 sharing the same descriptor set and binding values is a descriptor of type
 ename:VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER that has multiple
 corresponding shader variables in the code:UniformConstant storage class,
-where some could be code:OpTypeImage, some could be code:OpTypeSampler
-(code:Sampled=1), and some could be code:OpTypeSampledImage.
+where some could be code:OpTypeImage (code:Sampled=1), some could be code:OpTypeSampler, 
+and some could be code:OpTypeSampledImage.
 ====
 
 [[interfaces-resources-limits]]


### PR DESCRIPTION
The `Sampled=1` bit should go in front of `OpTypeImage` instead of `OpTypeSampler` in the comment about variables sharing the same descriptor set and binding. `OpTypeSampler` doesn't have a `Sampled` operand.
