### PR TITLE
Clarify PatchVertices documentation for tessellation shaders.

### DIFF
--- a/chapters/interfaces.txt
+++ b/chapters/interfaces.txt
@@ -2752,9 +2752,12 @@ code:PatchVertices::
 Decorating a variable with the code:PatchVertices built-in decoration will
 make that variable contain the number of vertices in the input patch being
 processed by the shader.
-A single tessellation control or tessellation evaluation shader can: read
-patches of differing sizes, so the value of the code:PatchVertices variable
-may: differ between patches.
+In a Tessellation Control Shader, this is the same as the name:patchControlPoints
+member of slink:VkPipelineTessellationStateCreateInfo.
+In a Tessellation Evaluation Shader, code:PatchVertices is equal to the
+tessellation control output patch size.
+When the same shader is used in different pipelines where the patch sizes
+are configured differently, the value of the code:PatchVertices variable will also differ.
 
 .Valid Usage
 ****


### PR DESCRIPTION
I attempted to make the `PatchVertices` documentation clearer. See #1461 for the discussion that motivated this change.