### PR TITLE
Add additional `vk_video` types

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -5509,10 +5509,31 @@ typedef void <name>CAMetalLayer</name>;
             <comment>Video Decode Codec Standard specific structures</comment>
         <type category="include" name="vk_video/vulkan_video_codec_h264std.h">#include "vk_video/vulkan_video_codec_h264std.h"</type>
         <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264ProfileIdc"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264Level"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264ChromaFormatIdc"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264PocType"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264SpsFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264ScalingLists"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264SequenceParameterSetVui"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264AspectRatioIdc"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264HrdParameters"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264SpsVuiFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264WeightedBiPredIdc"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264PpsFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264SliceType"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264CabacInitIdc"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264DisableDeblockingFilterIdc"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264PictureType"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264ModificationOfPicNumsIdc"/>
+        <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264MemMgmtControlOp"/>
         <type category="include" name="vk_video/vulkan_video_codec_h264std_decode.h">#include "vk_video/vulkan_video_codec_h264std_decode.h"</type>
         <type requires="vk_video/vulkan_video_codec_h264std_decode.h" name="StdVideoDecodeH264PictureInfo"/>
         <type requires="vk_video/vulkan_video_codec_h264std_decode.h" name="StdVideoDecodeH264ReferenceInfo"/>
         <type requires="vk_video/vulkan_video_codec_h264std_decode.h" name="StdVideoDecodeH264Mvc"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_decode.h" name="StdVideoDecodeH264PictureInfoFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_decode.h" name="StdVideoDecodeH264ReferenceInfoFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_decode.h" name="StdVideoDecodeH264MvcElement"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_decode.h" name="StdVideoDecodeH264MvcElementFlags"/>
         <type category="struct" name="VkVideoDecodeH264ProfileEXT" structextends="VkVideoProfileKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_EXT"><type>VkStructureType</type><name>sType</name></member>
           <member>const <type>void</type>*                          <name>pNext</name></member>
@@ -5571,9 +5592,23 @@ typedef void <name>CAMetalLayer</name>;
         <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265VideoParameterSet"/>
         <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265SequenceParameterSet"/>
         <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265PictureParameterSet"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265DecPicBufMgr"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265HrdParameters"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265VpsFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265Level"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265SpsFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265ScalingLists"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265SequenceParameterSetVui"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265PredictorPaletteEntries"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265PpsFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265SubLayerHrdParameters"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265HrdFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265SpsVuiFlags"/>
         <type category="include" name="vk_video/vulkan_video_codec_h265std_decode.h">#include "vk_video/vulkan_video_codec_h265std_decode.h"</type>
         <type requires="vk_video/vulkan_video_codec_h265std_decode.h" name="StdVideoDecodeH265PictureInfo"/>
         <type requires="vk_video/vulkan_video_codec_h265std_decode.h" name="StdVideoDecodeH265ReferenceInfo"/>
+        <type requires="vk_video/vulkan_video_codec_h265std_decode.h" name="StdVideoDecodeH265PictureInfoFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h265std_decode.h" name="StdVideoDecodeH265ReferenceInfoFlags"/>
         <type category="struct" name="VkVideoDecodeH265ProfileEXT" structextends="VkVideoProfileKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_EXT"><type>VkStructureType</type><name>sType</name></member>
           <member>const <type>void</type>*                    <name>pNext</name></member>
@@ -5711,6 +5746,12 @@ typedef void <name>CAMetalLayer</name>;
         <type category="include" name="vk_video/vulkan_video_codec_h264std_encode.h">#include "vk_video/vulkan_video_codec_h264std_encode.h"</type>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264SliceHeader"/>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264PictureInfo"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264SliceHeaderFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefMemMgmtCtrlOperations"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264PictureInfoFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefMgmtFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefListModEntry"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefPicMarkingEntry"/>
         <type category="struct" name="VkVideoEncodeH264SessionParametersAddInfoEXT" structextends="VkVideoSessionParametersUpdateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
           <member>const <type>void</type>*                                                               <name>pNext</name></member>


### PR DESCRIPTION
These are additional types that are defined in `vk_video` but have not been referenced in `vk.xml`.

This should ideally be kept up to date. I am using this information for the generation of bindings.