### PR TITLE
Add a new VK_EXT_calibrated_timestamps extension

### DIFF
--- a/appendices/VK_EXT_calibrated_queue_timestamps.txt
+++ b/appendices/VK_EXT_calibrated_queue_timestamps.txt
@@ -1,0 +1,29 @@
+// Copyright 2018-2021 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_calibrated_queue_timestamps.txt[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2021-04-28
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Jason Ekstrand, Intel
+  - Lionel Landwerlin, Intel
+
+=== Description
+
+This extension builds on top of `<<VK_EXT_calibrated_timestamps>>` and
+provides a mechanism to query a per-queue timestamp.
+
+include::{generated}/interfaces/VK_EXT_calibrated_queue_timestamps.txt[]
+
+=== Issues
+
+=== Version History
+
+  * Revision 1, 2021-04-28 (Jason Ekstrand)
+    - Internal revisions.

--- a/appendices/VK_EXT_calibrated_timestamps.txt
+++ b/appendices/VK_EXT_calibrated_timestamps.txt
@@ -76,6 +76,9 @@ of time?
 
 *RESOLVED*: Yes, especially as some time domains by definition allow for
 that to happen (e.g. CLOCK_MONOTONIC is subject to NTP adjustments).
+Other events outside the application's control such as host suspend and
+resume as well as ename:VK_ERROR_DEVICE_LOST scenarios in other processes
+may also cause clocks to pause or be reset.
 Thus it's recommended that applications re-calibrate from time to time.
 
 7) Should we add a query for reporting the maximum deviation of the

--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -6293,6 +6293,11 @@ include::{generated}/api/structs/VkCalibratedTimestampInfoEXT.txt[]
   * [[VUID-VkCalibratedTimestampInfoEXT-timeDomain-02354]]
     pname:timeDomain must: be one of the elink:VkTimeDomainEXT values
     returned by flink:vkGetPhysicalDeviceCalibrateableTimeDomainsEXT
+ifdef::VK_EXT_calibrated_queue_timestamps[]
+  * If pname:timeDomain is ename:VK_TIME_DOMAIN_QUEUE_EXT, then a
+    slink:VkCalibratedTimestampQueueInfoEXT structure must: be included in
+    the pname:pNext chain of this structure.
+endif::VK_EXT_calibrated_queue_timestamps[]
 ****
 include::{generated}/validity/structs/VkCalibratedTimestampInfoEXT.txt[]
 --
@@ -6325,6 +6330,15 @@ ifdef::VK_KHR_synchronization2[]
 or flink:vkCmdWriteTimestamp2KHR
 endif::VK_KHR_synchronization2[]
 .
+ifdef::VK_EXT_calibrated_queue_timestamps[]
+If an implementation does not support ename:VK_TIME_DOMAIN_DEVICE_EXT, it
+may still allow calibrating timestamps comparable with
+flink:vkCmdWriteTimestamp
+ifdef::VK_KHR_synchronization2[]
+or flink:vkCmdWriteTimestamp2KHR
+endif::VK_KHR_synchronization2[]
+on a per-queue basis via ename:VK_TIME_DOMAIN_QUEUE_EXT.
+endif::VK_EXT_calibrated_queue_timestamps[]
 ====
 
   * ename:VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT specifies the CLOCK_MONOTONIC
@@ -6367,6 +6381,42 @@ QueryPerformanceCounter(&counter);
 return counter.QuadPart;
 ----
 
+ifdef::VK_EXT_calibrated_queue_timestamps[]
+  * ename:VK_TIME_DOMAIN_QUEUE_EXT specifies the time domain for a
+    particular queue.
+    Timestamp values in this time domain use the same units and are
+    comparable with device timestamp values captured using
+    flink:vkCmdWriteTimestamp
+ifdef::VK_KHR_synchronization2[]
+    or flink:vkCmdWriteTimestamp2KHR
+endif::VK_KHR_synchronization2[]
+    on the specified queue and are defined to be incrementing according to
+    the <<limits-timestampPeriod,timestampPeriod>> of the device.
+endif::VK_EXT_calibrated_queue_timestamps[]
+
 --
+
+ifdef::VK_EXT_calibrated_queue_timestamps[]
+
+[open,refpage='VkCalibratedTimestampQueueInfoEXT',desc='Structure specifying the queue for a calibrated timestamp query on a queue',type='structs']
+--
+
+To query a calibrated timestamp for a particular queue, set
+pname:timeDomain to ename:VK_TIME_DOMAIN_QUEUE_EXT and add a
+slink:VkCalibratedTimestampQueueInfoEXT structure to the pname:pNext chain
+of the slink:VkCalibratedTimestampInfoEXT structure.
+The slink:VkCalibratedTimestampQueueInfoEXT structure is defined as:
+
+include::{generated}/api/structs/VkCalibratedTimestampQueueInfoEXT.txt[]
+
+  * pname:sType is the type of this structure.
+  * pname:pNext is `NULL` or a pointer to a structure extending this
+    structure.
+  * pname:queue is a sname:VkQueue to query for a calibrated timestamp.
+
+include::{generated}/validity/structs/VkCalibratedTimestampQueueInfoEXT.txt[]
+--
+
+endif::VK_EXT_calibrated_queue_timestamps[]
 
 endif::VK_EXT_calibrated_timestamps[]

--- a/chapters/synchronization.txt
+++ b/chapters/synchronization.txt
@@ -6314,12 +6314,6 @@ endif::VK_KHR_synchronization2[]
     and are defined to be incrementing according to the
     <<limits-timestampPeriod,timestampPeriod>> of the device.
 
-  * ename:VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT specifies the CLOCK_MONOTONIC
-    time domain available on POSIX platforms.
-    Timestamp values in this time domain are in units of nanoseconds and are
-    comparable with platform timestamp values captured using the POSIX
-    clock_gettime API as computed by this example:
-
 [NOTE]
 .Note
 ====
@@ -6332,6 +6326,12 @@ or flink:vkCmdWriteTimestamp2KHR
 endif::VK_KHR_synchronization2[]
 .
 ====
+
+  * ename:VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT specifies the CLOCK_MONOTONIC
+    time domain available on POSIX platforms.
+    Timestamp values in this time domain are in units of nanoseconds and are
+    comparable with platform timestamp values captured using the POSIX
+    clock_gettime API as computed by this example:
 
 [source,c]
 ----

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -5804,6 +5804,11 @@ typedef void <name>CAMetalLayer</name>;
             <member>const <type>void</type>*                        <name>pNext</name></member>
             <member><type>VkProvokingVertexModeEXT</type>           <name>provokingVertexMode</name></member>
         </type>
+        <type category="struct" name="VkCalibratedTimestampQueueInfoEXT" structextends="VkCalibratedTimestampInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_QUEUE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                        <name>pNext</name></member>
+            <member><type>VkQueue</type>                            <name>queue</name></member>
+        </type>
     </types>
     <comment>Vulkan enumerant (token) definitions</comment>
 
@@ -14972,10 +14977,13 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_KHR_extension_273&quot;"              name="VK_INTEL_extension_273"/>
             </require>
         </extension>
-        <extension name="VK_INTEL_extension_274" number="274" type="device" author="INTEL" contact="Jason Ekstrand @jekstrand" supported="disabled">
+        <extension name="VK_EXT_calibrated_queue_timestamps" number="274" type="device" requires="VK_EXT_calibrated_timestamps" author="EXT" contact="Jason Ekstrand @jekstrand" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_INTEL_EXTENSION_274_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_274&quot;"              name="VK_INTEL_extension_274"/>
+                <enum value="1"                                             name="VK_EXT_CALIBRATED_QUEUE_TIMESTAMPS_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_calibrated_queue_timestamps&quot;" name="VK_EXT_calibrated_queue_timestamps"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_QUEUE_INFO_EXT"/>
+                <enum offset="0" extends="VkTimeDomainEXT"                  name="VK_TIME_DOMAIN_QUEUE_EXT"/>
+                <type name="VkCalibratedTimestampQueueInfoEXT"/>
             </require>
         </extension>
         <extension name="VK_KHR_extension_275" number="275" type="instance" author="KHR" contact="Lionel Landwerlin @llandwerlin" supported="disabled">


### PR DESCRIPTION
Intel hardware doesn't necessarily guarantee a single time domain across the entire device for `vkCmdWriteTimestamp()`.  This hasn't been a problem for us because we ran everything on the 3D queue.  However, with things like Vulkan video up-and-coming as well as additional compute queues, this is turning into a real issue.  This tiny little extension allows the client to get calibrated timestamps on a per-queue basis rather than just per-device.