### PR TITLE
[RFC] Add VK_EXT_wl_drm_lease_display

### DIFF
--- a/appendices/VK_EXT_wl_drm_lease_display.txt
+++ b/appendices/VK_EXT_wl_drm_lease_display.txt
@@ -1,0 +1,53 @@
+// Copyright 2018-2021 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_wl_drm_lease_display.txt[]
+
+*Last Modified Date*::
+    2021-05-07
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Drew DeVault, Status Holdings, Ltd.
+  - Lubosz Sarnecki, Collabora, Ltd.
+  - Simon Zeni, Status Holdings, Ltd.
+
+This extension allows an application to take exclusive control of a display
+currently leased by a Wayland compositor.
+When control is acquired, the display will be unassociated from the Wayland
+compositor until the application releases the display or the specified display
+connection is closed.
+Essentially, the Wayland compositor will behave as if the monitor has been
+unplugged until the application releases it.
+
+=== New Enum Constants
+
+None.
+
+=== New Enums
+
+None.
+
+=== New Structures
+
+  * slink:VkWaylandDrmLeaseConnectorEXT
+
+=== New Functions
+
+  * flink:vkAcquireWaylandDrmLeaseDisplayEXT
+
+=== Issues
+
+None.
+
+=== Version History
+
+ * Revision 1, 2019-10-17 (Drew DeVault)
+   - Initial draft
+ * Revision 2, 2021-02-11 (Lubosz Sarnecki)
+   - Update to Wayland drm-lease-unstable-v1 protocol changes
+ * Revision 3, 2021-05-06 (Simon Zeni)
+   - Update to Wayland drm-lease-v1 protocol changes
+ * Revision 4, 2021-05-07 (Simon Zeni)
+   - Change name from VK_EXT_acquire_wl_display to VK_EXT_wl_drm_lease_display

--- a/chapters/VK_EXT_direct_mode_display/acquire_release_displays.txt
+++ b/chapters/VK_EXT_direct_mode_display/acquire_release_displays.txt
@@ -18,6 +18,10 @@ ifdef::VK_NV_acquire_winrt_display[]
 include::{chapters}/VK_NV_acquire_winrt_display/acquire_winrt_display.txt[]
 endif::VK_NV_acquire_winrt_display[]
 
+ifdef::VK_EXT_wl_drm_lease_display[]
+include::../VK_EXT_wl_drm_lease_display/wl_drm_lease_display.txt[]
+endif::VK_EXT_wl_drm_lease_display[]
+
 [open,refpage='vkReleaseDisplayEXT',desc='Release access to an acquired VkDisplayKHR',type='protos']
 --
 

--- a/chapters/VK_EXT_wl_drm_lease_display/wl_drm_lease_display.txt
+++ b/chapters/VK_EXT_wl_drm_lease_display/wl_drm_lease_display.txt
@@ -1,0 +1,51 @@
+[open,refpage='vkAcquireWaylandDrmLeaseDisplayEXT',desc='Acquire access to a VkDisplayKHR using Wayland DRM lease',type='protos']
+--
+
+To acquire permission to directly access a display in Vulkan from a Wayland
+compositor, call:
+
+include::{generated}/api/protos/vkAcquireWaylandDrmLeaseDisplayEXT.txt[]
+
+  * pname:physicalDevice is the handle to the physical device the display is on.
+  * pname:display A code:wl_display associated with the Wayland compositor that
+    the application wishes to acquire the display(s) from.
+  * pname:leaseDevice A wp_drm_lease_device_v1 connected to the Wayland compositor
+    that associated with the connectors.
+  * pname:pConnectorCount The number of valid pointers in the pname:pConnectors
+    array.
+  * pname:pConnectors Array of slink:VkWaylandDrmLeaseConnectorEXT to be acquired.
+
+All permissions necessary to control the display are granted to the Vulkan
+instance associated with pname:physicalDevice until the display is released, the
+Wayland connection specified by pname:display is terminated, or the compositor
+revokes the lease.
+If the Wayland server declines to grant the lease or the granted lease does not
+include the requested connectors, the call must: return the error code
+ename:VK_ERROR_INITIALIZATION_FAILED.
+If the Wayland server later revokes the lease, requests using the
+acquired slink:VkDisplayKHR resources must: fail with
+ename:VK_ERROR_SURFACE_LOST_KHR.
+
+include::{generated}/validity/protos/vkAcquireWaylandDrmLeaseDisplayEXT.txt[]
+--
+
+[open,refpage='VkWaylandDrmLeaseConnectorEXT',desc='Resource for relating Wayland connectors to VkDisplayKHRs',type='structs']
+--
+
+The sname:VkWaylandDrmLeaseConnectorEXT structure is defined as:
+
+include::{generated}/api/structs/VkWaylandDrmLeaseConnectorEXT.txt[]
+
+  * pname:pConnector A Wayland wp_drm_lease_connector_v1 to include in the
+    lease.
+  * pname:pDisplay The corresponding slink:VkDisplayKHR handle will be
+    returned here.
+
+The implementation will make a best-effort attempt to match each
+slink:VkDisplayKHR acquired from the Wayland compositor to the appropriate
+pname:pConnectorIn. If no match is found or the result would be ambiguous, the
+lease is terminated, and flink:vkAcquireWaylandDrmLeaseDisplayEXT must: return
+ename:VK_ERROR_INITIALIZATION_FAILED.
+
+include::{generated}/validity/structs/VkWaylandDrmLeaseConnectorEXT.txt[]
+--

--- a/include/vulkan/vk_platform.h
+++ b/include/vulkan/vk_platform.h
@@ -77,6 +77,12 @@ extern "C"
     #endif
 #endif // !defined(VK_NO_STDINT_H)
 
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    // Forward declared for VK_EXT_wl_drm_lease_display
+    struct wp_drm_lease_device_v1;
+    struct wp_drm_lease_connector_v1;
+#endif // VK_USE_PLATFORM_WAYLAND_KHR
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/scripts/genvk.py
+++ b/scripts/genvk.py
@@ -323,7 +323,9 @@ def makeGenOpts(args):
         [ 'vulkan_ios.h',         [ 'VK_MVK_ios_surface'          ], commonSuppressExtensions ],
         [ 'vulkan_macos.h',       [ 'VK_MVK_macos_surface'        ], commonSuppressExtensions ],
         [ 'vulkan_vi.h',          [ 'VK_NN_vi_surface'            ], commonSuppressExtensions ],
-        [ 'vulkan_wayland.h',     [ 'VK_KHR_wayland_surface'      ], commonSuppressExtensions ],
+        [ 'vulkan_wayland.h',     [ 'VK_KHR_wayland_surface',
+                                    'VK_EXT_wl_drm_lease_display'
+                                                                  ], commonSuppressExtensions ],
         [ 'vulkan_win32.h',       [ 'VK_.*_win32(|_.*)', 'VK_EXT_full_screen_exclusive' ],
                                                                      commonSuppressExtensions +
                                                                      [ 'VK_KHR_external_semaphore',

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -109,6 +109,8 @@ branch of the member gitlab server.
         <type requires="X11/extensions/Xrandr.h" name="RROutput"/>
         <type requires="wayland-client.h" name="wl_display"/>
         <type requires="wayland-client.h" name="wl_surface"/>
+        <type name="wp_drm_lease_device_v1"/>
+        <type name="wp_drm_lease_connector_v1"/>
         <type requires="windows.h" name="HINSTANCE"/>
         <type requires="windows.h" name="HWND"/>
         <type requires="windows.h" name="HMONITOR"/>
@@ -5804,6 +5806,10 @@ typedef void <name>CAMetalLayer</name>;
             <member>const <type>void</type>*                        <name>pNext</name></member>
             <member><type>VkProvokingVertexModeEXT</type>           <name>provokingVertexMode</name></member>
         </type>
+        <type category="struct" name="VkWaylandDrmLeaseConnectorEXT">
+            <member>struct <type>wp_drm_lease_connector_v1</type>* <name>pConnector</name></member>
+            <member><type>VkDisplayKHR</type> <name>pDisplay</name></member>
+        </type>
     </types>
     <comment>Vulkan enumerant (token) definitions</comment>
 
@@ -10326,7 +10332,14 @@ typedef void <name>CAMetalLayer</name>;
             <param><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param>const <type>VkVideoEncodeInfoKHR</type>* <name>pEncodeInfo</name></param>
         </command>
-
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkAcquireWaylandDrmLeaseDisplayEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>struct <type>wl_display</type>* <name>display</name></param>
+            <param>struct <type>wp_drm_lease_device_v1</type>* <name>leaseDevice</name></param>
+            <param><type>uint32_t</type> <name>pConnectorCount</name></param>
+            <param len="connectorCount"><type>VkWaylandDrmLeaseConnectorEXT</type>* <name>pConnectors</name></param>
+        </command>
     </commands>
 
     <feature api="vulkan" name="VK_VERSION_1_0" number="1.0" comment="Vulkan core API interface definitions">
@@ -15106,10 +15119,11 @@ typedef void <name>CAMetalLayer</name>;
                 <type name="PFN_vkDeviceMemoryReportCallbackEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_286" number="286" type="instance" author="EXT" contact="Drew DeVault sir@cmpwn.com" supported="disabled">
+        <extension name="VK_EXT_wl_drm_lease_display" number="286" type="instance" requires="VK_EXT_direct_mode_display" author="EXT" contact="Drew DeVault @ddevault" platform="wayland" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_286_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_286&quot;"              name="VK_EXT_extension_286"/>
+                <enum value="1"                                             name="VK_EXT_WL_DRM_LEASE_DISPLAY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_wl_drm_lease_display&quot;"         name="VK_EXT_WL_DRM_LEASEDISPLAY_EXTENSION_NAME"/>
+                <command name="vkAcquireWaylandDrmLeaseDisplayEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_robustness2" number="287"  type="device" author="EXT" contact="Liam Middlebrook @liam-middlebrook" supported="vulkan">


### PR DESCRIPTION
Hi, this pull request is the continuation of the work started by Drew Devault and by Lubosz Sarnecki and superseded both #1001 and #1450

I rebased the patch against `main` and upgraded the protocol [`drm_lease_v1`][1] by Xaver Hugl to the latest version (staging). I will go through the issues that were raised on #1001 and #1450 to get the merge request in a good shape.

I will also take care of the Mesa [2] [3] and Monado [4] [5] implementation, I'll update the status of the merge request in time.

This is my first contribution to a Vulkan extensions, your patience will be greatly appreciated.

[1]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/67 
[2]: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/1509
[3]: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/8981
[4]: https://gitlab.freedesktop.org/monado/monado/-/merge_requests/141
[5]: https://gitlab.freedesktop.org/monado/monado/-/merge_requests/683

