### PR TITLE
Add VK_EXT_acquire_drm_display

### DIFF
--- a/appendices/VK_EXT_acquire_drm_display.txt
+++ b/appendices/VK_EXT_acquire_drm_display.txt
@@ -1,0 +1,32 @@
+// Copyright 2018-2021 The Khronos Group, Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_acquire_drm_display.txt[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2021-06-09
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Simon Zeni, Status Holdings, Ltd.
+
+=== Description
+
+This extension allows an application to take exclusive control of a display
+using the Direct Rendering Manager (DRM) interface. When acquired, the display
+will be under full control of the application until the display is either
+released or the connector is unplugged.
+
+include::{generated}/interfaces/VK_EXT_acquire_drm_display.txt[]
+
+=== Issues
+
+None.
+
+=== Version History
+
+* Revision 1, 2021-05-11 (Simon Zeni)
+    - Initial draft

--- a/chapters/VK_EXT_acquire_drm_display/acquire_drm_display.txt
+++ b/chapters/VK_EXT_acquire_drm_display/acquire_drm_display.txt
@@ -1,0 +1,60 @@
+// Copyright 2018-2021 The Khronos Group, Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[open,refpage='vkAcquireDrmDisplayEXT',desc='Acquire access to a VkDisplayKHR using DRM',type='protos']
+--
+
+To acquire permission to directly a display in Vulkan from the Direct Rendering
+Manager (DRM) interface, call:
+
+include::{generated}/api/protos/vkAcquireDrmDisplayEXT.txt[]
+
+  * pname:physicalDevice The physical device the display is on.
+  * pname:drmFd DRM primary file descriptor.
+  * pname:display The display the caller wishes Vulkan to control.
+
+All permissions necessary to control the display are granted to the Vulkan
+instance associated with the provided pname:physicalDevice until the display is
+either released or the connector is unplugged.
+The provided pname:drmFd must correspond to the one owned by the
+pname:physicalDevice. If not, the error code ename:VK_ERROR_UNKNOWN must be
+returned. The DRM FD must have DRM master permissions.
+If any error is encountered during the acquisition of the display, the call
+must return the error code ename:VK_ERROR_INITIALIZATION_FAILED.
+
+The provided DRM fd should not be closed before the display is released,
+attempting to do it may result in undefined: behaviour.
+
+include::{generated}/validity/protos/vkAcquireDrmDisplayEXT.txt[]
+--
+
+[open,refpage='vkGetDrmDisplayEXT',desc='Query the VkDisplayKHR corresponding to a DRM connector ID',type='protos']
+--
+
+Before acquiring a display from the DRM interface, the caller may want to
+select a specific sname:VkDisplayKHR handle by identifying it using a
+pname:connectorId. To do so, call:
+
+include::{generated}/api/protos/vkGetDrmDisplayEXT.txt[]
+
+  * pname:physicalDevice The physical device to query the display from.
+  * pname:drmFd DRM primary file descriptor.
+  * pname:connectorId Identifier of the specified DRM connector.
+  * pname:display The corresponding slink:VkDisplayKHR handle will be returned
+    here.
+
+If there is no slink:VkDisplayKHR corresponding to the pname:connectorId on
+the pname:physicalDevice, the returning pname:display must be set to
+dlink:VK_NULL_HANDLE.
+The provided pname:drmFd must correspond to the one owned by the
+pname:physicalDevice. If not, the error code ename:VK_ERROR_UNKNOWN must be
+returned. Master permissions are not required, because the file descriptor is
+just used for information gathering purposes.
+The given pname:connectorId must be a resource owned by the provided
+pname:drmFd. If not, the error code ename:VK_ERROR_UNKNOWN must be returned.
+If any error is encountered during the identification of the display, the call
+must return the error code ename:VK_ERROR_INITIALIZATION_FAILED.
+
+include::{generated}/validity/protos/vkGetDrmDisplayEXT.txt[]
+--

--- a/chapters/VK_EXT_direct_mode_display/acquire_release_displays.txt
+++ b/chapters/VK_EXT_direct_mode_display/acquire_release_displays.txt
@@ -18,6 +18,10 @@ ifdef::VK_NV_acquire_winrt_display[]
 include::{chapters}/VK_NV_acquire_winrt_display/acquire_winrt_display.txt[]
 endif::VK_NV_acquire_winrt_display[]
 
+ifdef::VK_EXT_acquire_drm_display[]
+include::{chapters}/VK_EXT_acquire_drm_display/acquire_drm_display.txt[]
+endif::VK_EXT_acquire_drm_display[]
+
 [open,refpage='vkReleaseDisplayEXT',desc='Release access to an acquired VkDisplayKHR',type='protos']
 --
 To release a previously acquired display, call:

--- a/include/vulkan/vulkan.h
+++ b/include/vulkan/vulkan.h
@@ -85,7 +85,6 @@
 #include "vulkan_screen.h"
 #endif
 
-
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 #include "vulkan_beta.h"
 #endif

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -10450,6 +10450,19 @@ typedef void <name>CAMetalLayer</name>;
             <param><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param>const <type>VkCuLaunchInfoNVX</type>* <name>pLaunchInfo</name></param>
         </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkAcquireDrmDisplayEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>int32_t</type> <name>drmFd</name></param>
+            <param><type>VkDisplayKHR</type> <name>display</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetDrmDisplayEXT</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>int32_t</type> <name>drmFd</name></param>
+            <param><type>uint32_t</type> <name>connectorId</name></param>
+            <param><type>VkDisplayKHR</type>* <name>display</name></param>
+        </command>
     </commands>
 
     <feature api="vulkan" name="VK_VERSION_1_0" number="1.0" comment="Vulkan core API interface definitions">
@@ -15219,10 +15232,12 @@ typedef void <name>CAMetalLayer</name>;
                 <type name="PFN_vkDeviceMemoryReportCallbackEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_286" number="286" type="instance" author="EXT" contact="Drew DeVault sir@cmpwn.com" supported="disabled">
+        <extension name="VK_EXT_acquire_drm_display" number="286" type="instance" requires="VK_EXT_direct_mode_display" author="EXT" contact="Drew DeVault sir@cmpwn.com" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_286_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_286&quot;"              name="VK_EXT_extension_286"/>
+                <enum value="1"                                             name="VK_EXT_ACQUIRE_DRM_DISPLAY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_acquire_drm_display&quot;"        name="VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME"/>
+                <command name="vkAcquireDrmDisplayEXT"/>
+                <command name="vkGetDrmDisplayEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_robustness2" number="287"  type="device" author="EXT" contact="Liam Middlebrook @liam-middlebrook" supported="vulkan">


### PR DESCRIPTION
This pull request is a continuation of the work done in https://github.com/KhronosGroup/Vulkan-Docs/pull/1525, where it was discussed that instead of having a Wayland-centered approach to DRM leasing to handle VR headset (see  #1001 and #1450), we would change the design to have a more generic FD-based approach.

[Mesa implementation](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/11014)
[Monado usage](https://gitlab.freedesktop.org/monado/monado/-/merge_requests/832)