### PR TITLE
vk.xml: Include `vk_platform` type-header from `vulkan/vk_platform.h`

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -74,7 +74,7 @@ branch of the member gitlab server.
     </tags>
 
     <types comment="Vulkan type definitions">
-        <type name="vk_platform" category="include">#include "vk_platform.h"</type>
+        <type name="vk_platform" category="include">#include "vulkan/vk_platform.h"</type>
 
             <comment>WSI extensions</comment>
 


### PR DESCRIPTION
It is generally expected that "top level" includes are relative to the `./include` directory in this repo.  The video headers, sitting at the root of the `./include` folder in `./include/vk_video/vulkan_video_*.h`, are listed as `vk_video/vulkan_video_*.h` in `vk.xml`.  Likewise the `vk_platform` type-header is supposed to be listed as `vulkan/vk_platform.h` to match its relative location under `./include`.
