### PR TITLE
Marks all pNext fields as optional in `vk.xml`

### DIFF
--- a/scripts/xml_consistency.py
+++ b/scripts/xml_consistency.py
@@ -234,7 +234,7 @@ class Checker(XMLChecker):
             if next_member is not None:
                 # Ensure that the 'optional' attribute is set to 'true'
                 optional = next_member.get('optional')
-                if optional is None or optional is not 'true':
+                if optional is None or optional != 'true':
                     self.record_error(next_name, "must have 'optional=\"true\"' attribute set")
 
         elif category == "bitmask":

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -2360,18 +2360,18 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImportMemoryZirconHandleInfoFUCHSIA" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_ZIRCON_HANDLE_INFO_FUCHSIA"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
             <member optional="true"><type>zx_handle_t</type>           <name>handle</name></member>
         </type>
         <type category="struct" name="VkMemoryZirconHandlePropertiesFUCHSIA" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MEMORY_ZIRCON_HANDLE_PROPERTIES_FUCHSIA"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>memoryTypeBits</name></member>
         </type>
         <type category="struct" name="VkMemoryGetZirconHandleInfoFUCHSIA">
             <member values="VK_STRUCTURE_TYPE_MEMORY_GET_ZIRCON_HANDLE_INFO_FUCHSIA"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
             <member><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
         </type>
@@ -2766,7 +2766,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPresentIdKHR" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_ID_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>swapchainCount</name><comment>Copy of VkPresentInfoKHR::swapchainCount</comment></member>
             <member len="swapchainCount" optional="true">const <type>uint64_t</type>* <name>pPresentIds</name><comment>Present ID values for each swapchain</comment></member>
         </type>
@@ -3176,7 +3176,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiDrawFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                     <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*                     <name>pNext</name></member>
             <member><type>VkBool32</type>                                        <name>multiDraw</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
@@ -3351,7 +3351,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>* <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type>                    <name>globalPriorityQuery</name></member>
         </type>
         <type category="struct" name="VkQueueFamilyGlobalPriorityPropertiesEXT" structextends="VkQueueFamilyProperties2">
@@ -3799,7 +3799,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>shaderBufferFloat16Atomics</name></member>
             <member><type>VkBool32</type>                            <name>shaderBufferFloat16AtomicAdd</name></member>
             <member><type>VkBool32</type>                            <name>shaderBufferFloat16AtomicMinMax</name></member>
@@ -4735,7 +4735,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSubpassShadingPipelineCreateInfoHUAWEI" returnedonly="true" structextends="VkComputePipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_SHADING_PIPELINE_CREATE_INFO_HUAWEI"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkRenderPass</type>           <name>renderPass</name></member>
             <member><type>uint32_t</type>               <name>subpass</name></member>
         </type>
@@ -5140,12 +5140,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*          <name>pNext</name></member>
+            <member optional="true"><type>void</type>*          <name>pNext</name></member>
             <member><type>VkBool32</type>       <name>shaderZeroInitializeWorkgroupMemory</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type> <name>shaderSubgroupUniformControlFlow</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRobustness2FeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
@@ -5168,7 +5168,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>workgroupMemoryExplicitLayout</name></member>
             <member><type>VkBool32</type>                           <name>workgroupMemoryExplicitLayoutScalarBlockLayout</name></member>
             <member><type>VkBool32</type>                           <name>workgroupMemoryExplicitLayout8BitAccess</name></member>
@@ -5394,7 +5394,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_VALVE"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                     <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*                     <name>pNext</name></member>
             <member><type>VkBool32</type>                                        <name>mutableDescriptorType</name></member>
         </type>
         <type category="struct" name="VkMutableDescriptorTypeListVALVE">
@@ -5403,23 +5403,23 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkMutableDescriptorTypeCreateInfoVALVE" structextends="VkDescriptorSetLayoutCreateInfo,VkDescriptorPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_MUTABLE_DESCRIPTOR_TYPE_CREATE_INFO_VALVE"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                                                                      <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                      <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>                                                         <name>mutableDescriptorTypeListCount</name></member>
             <member len="mutableDescriptorTypeListCount">const <type>VkMutableDescriptorTypeListVALVE</type>* <name>pMutableDescriptorTypeLists</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>vertexInputDynamicState</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExternalMemoryRDMAFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>externalMemoryRDMA</name></member>
         </type>
         <type category="struct" name="VkVertexInputBindingDescription2EXT">
             <member values="VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>uint32_t</type>                       <name>binding</name></member>
             <member><type>uint32_t</type>                       <name>stride</name></member>
             <member><type>VkVertexInputRate</type>              <name>inputRate</name></member>
@@ -5427,7 +5427,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVertexInputAttributeDescription2EXT">
             <member values="VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT"><type>VkStructureType</type><name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>uint32_t</type>                       <name>location</name><comment>location of the shader vertex attrib</comment></member>
             <member><type>uint32_t</type>                       <name>binding</name><comment>Vertex buffer binding id</comment></member>
             <member><type>VkFormat</type>                       <name>format</name><comment>format of source data</comment></member>
@@ -5446,7 +5446,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkMemoryBarrier2KHR" structextends="VkSubpassDependency2">
             <member values="VK_STRUCTURE_TYPE_MEMORY_BARRIER_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                               <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                               <name>pNext</name></member>
             <member optional="true"><type>VkPipelineStageFlags2KHR</type>  <name>srcStageMask</name></member>
             <member optional="true"><type>VkAccessFlags2KHR</type>         <name>srcAccessMask</name></member>
             <member optional="true"><type>VkPipelineStageFlags2KHR</type>  <name>dstStageMask</name></member>
@@ -5454,7 +5454,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkImageMemoryBarrier2KHR">
             <member values="VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                               <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                               <name>pNext</name></member>
             <member optional="true"><type>VkPipelineStageFlags2KHR</type>  <name>srcStageMask</name></member>
             <member optional="true"><type>VkAccessFlags2KHR</type>         <name>srcAccessMask</name></member>
             <member optional="true"><type>VkPipelineStageFlags2KHR</type>  <name>dstStageMask</name></member>
@@ -5468,7 +5468,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkBufferMemoryBarrier2KHR">
             <member values="VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                               <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                               <name>pNext</name></member>
             <member optional="true"><type>VkPipelineStageFlags2KHR</type>  <name>srcStageMask</name></member>
             <member optional="true"><type>VkAccessFlags2KHR</type>         <name>srcAccessMask</name></member>
             <member optional="true"><type>VkPipelineStageFlags2KHR</type>  <name>dstStageMask</name></member>
@@ -5481,7 +5481,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkDependencyInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                               <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                               <name>pNext</name></member>
             <member optional="true"><type>VkDependencyFlags</type>         <name>dependencyFlags</name></member>
             <member optional="true"><type>uint32_t</type>                  <name>memoryBarrierCount</name></member>
             <member len="memoryBarrierCount">const <type>VkMemoryBarrier2KHR</type>* <name>pMemoryBarriers</name></member>
@@ -5492,7 +5492,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSemaphoreSubmitInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO_KHR"><type>VkStructureType</type>       <name>sType</name></member>
-            <member>const <type>void</type>*                                                                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                <name>pNext</name></member>
             <member><type>VkSemaphore</type>                                                                <name>semaphore</name></member>
             <member><type>uint64_t</type>                                                                   <name>value</name></member>
             <member optional="true"><type>VkPipelineStageFlags2KHR</type>                                   <name>stageMask</name></member>
@@ -5500,13 +5500,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkCommandBufferSubmitInfoKHR">
             <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO_KHR"><type>VkStructureType</type>  <name>sType</name></member>
-            <member>const <type>void</type>*                                                                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                <name>pNext</name></member>
             <member><type>VkCommandBuffer</type>                                                            <name>commandBuffer</name></member>
             <member><type>uint32_t</type>                                                                   <name>deviceMask</name></member>
         </type>
         <type category="struct" name="VkSubmitInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_SUBMIT_INFO_2_KHR"><type>VkStructureType</type>               <name>sType</name></member>
-            <member>const <type>void</type>*                                                                <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                                                <name>pNext</name></member>
             <member optional="true"><type>VkSubmitFlagsKHR</type>                                           <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>                                                   <name>waitSemaphoreInfoCount</name></member>
             <member len="waitSemaphoreInfoCount">const <type>VkSemaphoreSubmitInfoKHR</type>*               <name>pWaitSemaphoreInfos</name></member>
@@ -5517,45 +5517,45 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkQueueFamilyCheckpointProperties2NV" structextends="VkQueueFamilyProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*           <name>pNext</name></member>
+            <member optional="true"><type>void</type>*           <name>pNext</name></member>
             <member><type>VkPipelineStageFlags2KHR</type> <name>checkpointExecutionStageMask</name></member>
         </type>
         <type category="struct" name="VkCheckpointData2NV" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_CHECKPOINT_DATA_2_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkPipelineStageFlags2KHR</type>   <name>stage</name></member>
             <member noautovalidity="true"><type>void</type>* <name>pCheckpointMarker</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSynchronization2FeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>synchronization2</name></member>
         </type>
         <type category="struct" name="VkVideoQueueFamilyProperties2KHR" structextends="VkQueueFamilyProperties2">
           <member values="VK_STRUCTURE_TYPE_VIDEO_QUEUE_FAMILY_PROPERTIES_2_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member><type>void</type>*                              <name>pNext</name></member>
+          <member optional="true"><type>void</type>*                              <name>pNext</name></member>
           <member><type>VkVideoCodecOperationFlagsKHR</type>      <name>videoCodecOperations</name></member>
         </type>
         <type category="struct" name="VkVideoProfilesKHR" structextends="VkFormatProperties2,VkImageCreateInfo,VkImageViewCreateInfo,VkBufferCreateInfo">
           <member values="VK_STRUCTURE_TYPE_VIDEO_PROFILES_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member><type>void</type>*                              <name>pNext</name></member>
+          <member optional="true"><type>void</type>*                              <name>pNext</name></member>
           <member><type>uint32_t</type>                           <name>profileCount</name></member>
           <member>const <type>VkVideoProfileKHR</type>*           <name>pProfiles</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVideoFormatInfoKHR" returnedonly="true">
           <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member><type>void</type>*                              <name>pNext</name></member>
+          <member optional="true"><type>void</type>*                              <name>pNext</name></member>
           <member><type>VkImageUsageFlags</type>                  <name>imageUsage</name></member>
           <member>const <type>VkVideoProfilesKHR</type>*          <name>pVideoProfiles</name></member>
         </type>
         <type category="struct" name="VkVideoFormatPropertiesKHR" returnedonly="true">
           <member values="VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member><type>void</type>*                              <name>pNext</name></member>
+          <member optional="true"><type>void</type>*                              <name>pNext</name></member>
           <member><type>VkFormat</type>                           <name>format</name></member>
         </type>
         <type category="struct" name="VkVideoProfileKHR" structextends="VkQueryPoolCreateInfo,VkFormatProperties2,VkImageCreateInfo,VkImageViewCreateInfo,VkBufferCreateInfo">
           <member values="VK_STRUCTURE_TYPE_VIDEO_PROFILE_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member><type>void</type>*                              <name>pNext</name></member>
+          <member optional="true"><type>void</type>*                              <name>pNext</name></member>
           <member><type>VkVideoCodecOperationFlagBitsKHR</type>   <name>videoCodecOperation</name></member>
           <member><type>VkVideoChromaSubsamplingFlagsKHR</type>   <name>chromaSubsampling</name></member>
           <member><type>VkVideoComponentBitDepthFlagsKHR</type>   <name>lumaBitDepth</name></member>
@@ -5563,8 +5563,8 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoCapabilitiesKHR" returnedonly="true">
           <member values="VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member><type>void</type>*                            <name>pNext</name></member>
-          <member><type>VkVideoCapabilityFlagsKHR</type>        <name>capabilityFlags</name></member>
+          <member optional="true"><type>void</type>*                            <name>pNext</name></member>
+          <member><type>VkVideoCapabilitiesFlagsKHR</type>      <name>capabilityFlags</name></member>
           <member><type>VkDeviceSize</type>                     <name>minBitstreamBufferOffsetAlignment</name></member>
           <member><type>VkDeviceSize</type>                     <name>minBitstreamBufferSizeAlignment</name></member>
           <member><type>VkExtent2D</type>                       <name>videoPictureExtentGranularity</name></member>
@@ -5575,13 +5575,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoGetMemoryPropertiesKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_GET_MEMORY_PROPERTIES_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                       <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                       <name>pNext</name></member>
           <member><type>uint32_t</type>                          <name>memoryBindIndex</name></member>
           <member><type>VkMemoryRequirements2</type>*            <name>pMemoryRequirements</name></member>
         </type>
         <type category="struct" name="VkVideoBindMemoryKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_BIND_MEMORY_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                       <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                       <name>pNext</name></member>
           <member><type>uint32_t</type>                          <name>memoryBindIndex</name></member>
           <member><type>VkDeviceMemory</type>                    <name>memory</name></member>
           <member><type>VkDeviceSize</type>                      <name>memoryOffset</name></member>
@@ -5589,7 +5589,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoPictureResourceKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*        <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*        <name>pNext</name></member>
           <member><type>VkOffset2D</type>         <name>codedOffset</name><comment>The offset to be used for the picture resource, currently only used in field mode</comment></member>
           <member><type>VkExtent2D</type>         <name>codedExtent</name><comment>The extent to be used for the picture resource</comment></member>
           <member><type>uint32_t</type>           <name>baseArrayLayer</name><comment>TThe first array layer to be accessed for the Decode or Encode Operations</comment></member>
@@ -5597,13 +5597,13 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoReferenceSlotKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*        <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*        <name>pNext</name></member>
           <member><type>int8_t</type>             <name>slotIndex</name><comment>The reference slot index</comment></member>
           <member>const <type>VkVideoPictureResourceKHR</type>* <name>pPictureResource</name><comment>The reference picture resource</comment></member>
         </type>
         <type category="struct" name="VkVideoDecodeInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                            <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
           <member optional="true"><type>VkVideoDecodeFlagsKHR</type>  <name>flags</name></member>
           <member><type>VkOffset2D</type>                             <name>codedOffset</name></member>
           <member><type>VkExtent2D</type>                             <name>codedExtent</name></member>
@@ -5645,20 +5645,20 @@ typedef void <name>CAMetalLayer</name>;
         <type requires="vk_video/vulkan_video_codec_h264std_decode.h" name="StdVideoDecodeH264MvcElementFlags"/>
         <type category="struct" name="VkVideoDecodeH264ProfileEXT" structextends="VkVideoProfileKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                            <name>pNext</name></member>
-          <member><type>StdVideoH264ProfileIdc</type>                 <name>stdProfileIdc</name></member>
-          <member><type>VkVideoDecodeH264PictureLayoutFlagsEXT</type> <name>pictureLayout</name></member>
+          <member optional="true">const <type>void</type>*                          <name>pNext</name></member>
+          <member><type>StdVideoH264ProfileIdc</type>               <name>stdProfileIdc</name></member>
+          <member><type>VkVideoDecodeH264FieldLayoutFlagsEXT</type> <name>fieldLayout</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH264CapabilitiesEXT" returnedonly="true" structextends="VkVideoCapabilitiesKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member><type>void</type>*                            <name>pNext</name></member>
+          <member optional="true"><type>void</type>*                            <name>pNext</name></member>
           <member><type>uint32_t</type>                         <name>maxLevel</name></member>
           <member><type>VkOffset2D</type>                       <name>fieldOffsetGranularity</name></member>
           <member><type>VkExtensionProperties</type>            <name>stdExtensionVersion</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH264SessionCreateInfoEXT" structextends="VkVideoSessionCreateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_CREATE_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                      <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
           <member><type>VkVideoDecodeH264CreateFlagsEXT</type>  <name>flags</name></member>
           <member>const <type>VkExtensionProperties</type>*     <name>pStdExtensionVersion</name></member>
         </type>
@@ -5666,7 +5666,7 @@ typedef void <name>CAMetalLayer</name>;
         <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264PictureParameterSet"/>
         <type category="struct" name="VkVideoDecodeH264SessionParametersAddInfoEXT" structextends="VkVideoSessionParametersUpdateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_ADD_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                                               <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                                               <name>pNext</name></member>
           <member><type>uint32_t</type>                                                                  <name>spsStdCount</name></member>
           <member len="spsStdCount" optional="true">const <type>StdVideoH264SequenceParameterSet</type>* <name>pSpsStd</name></member>
           <member><type>uint32_t</type>                                                                  <name>ppsStdCount</name></member>
@@ -5674,26 +5674,26 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoDecodeH264SessionParametersCreateInfoEXT" structextends="VkVideoSessionParametersCreateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_CREATE_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                                               <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                                               <name>pNext</name></member>
           <member><type>uint32_t</type>                                                                  <name>maxSpsStdCount</name></member>
           <member><type>uint32_t</type>                                                                  <name>maxPpsStdCount</name></member>
           <member optional="true">const <type>VkVideoDecodeH264SessionParametersAddInfoEXT</type>*       <name>pParametersAddInfo</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH264PictureInfoEXT" structextends="VkVideoDecodeInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PICTURE_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member noautovalidity="true">const <type>void</type>*     <name>pNext</name></member>
+          <member optional="true" noautovalidity="true">const <type>void</type>*     <name>pNext</name></member>
           <member>const <type>StdVideoDecodeH264PictureInfo</type>*  <name>pStdPictureInfo</name></member>
           <member><type>uint32_t</type>                              <name>slicesCount</name></member>
           <member len="slicesCount">const <type>uint32_t</type>*     <name>pSlicesDataOffsets</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH264DpbSlotInfoEXT" structextends="VkVideoReferenceSlotKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_DPB_SLOT_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                            <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
           <member>const <type>StdVideoDecodeH264ReferenceInfo</type>* <name>pStdReferenceInfo</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH264MvcEXT" structextends="VkVideoDecodeH264PictureInfoEXT">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_MVC_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member noautovalidity="true">const <type>void</type>*<name>pNext</name></member>
+          <member optional="true" noautovalidity="true">const <type>void</type>*<name>pNext</name></member>
           <member>const <type>StdVideoDecodeH264Mvc</type>*   <name>pStdMvc</name></member>
         </type>
         <type category="include" name="vk_video/vulkan_video_codec_h265std.h">#include "vk_video/vulkan_video_codec_h265std.h"</type>
@@ -5720,24 +5720,24 @@ typedef void <name>CAMetalLayer</name>;
         <type requires="vk_video/vulkan_video_codec_h265std_decode.h" name="StdVideoDecodeH265ReferenceInfoFlags"/>
         <type category="struct" name="VkVideoDecodeH265ProfileEXT" structextends="VkVideoProfileKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                    <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                    <name>pNext</name></member>
           <member><type>StdVideoH265ProfileIdc</type>         <name>stdProfileIdc</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH265CapabilitiesEXT" returnedonly="true" structextends="VkVideoCapabilitiesKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member><type>void</type>*                            <name>pNext</name></member>
+          <member optional="true"><type>void</type>*                            <name>pNext</name></member>
           <member><type>uint32_t</type>                         <name>maxLevel</name></member>
           <member><type>VkExtensionProperties</type>            <name>stdExtensionVersion</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH265SessionCreateInfoEXT" structextends="VkVideoSessionCreateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_CREATE_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                      <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
           <member><type>VkVideoDecodeH265CreateFlagsEXT</type>  <name>flags</name></member>
           <member>const <type>VkExtensionProperties</type>*     <name>pStdExtensionVersion</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH265SessionParametersAddInfoEXT" structextends="VkVideoSessionParametersUpdateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_ADD_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                                               <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                                               <name>pNext</name></member>
           <member><type>uint32_t</type>                                                                  <name>spsStdCount</name></member>
           <member len="spsStdCount" optional="true">const <type>StdVideoH265SequenceParameterSet</type>* <name>pSpsStd</name></member>
           <member><type>uint32_t</type>                                                                  <name>ppsStdCount</name></member>
@@ -5745,26 +5745,26 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoDecodeH265SessionParametersCreateInfoEXT" structextends="VkVideoSessionParametersCreateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_CREATE_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                                         <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                                         <name>pNext</name></member>
           <member><type>uint32_t</type>                                                            <name>maxSpsStdCount</name></member>
           <member><type>uint32_t</type>                                                            <name>maxPpsStdCount</name></member>
           <member optional="true">const <type>VkVideoDecodeH265SessionParametersAddInfoEXT</type>* <name>pParametersAddInfo</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH265PictureInfoEXT" structextends="VkVideoDecodeInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PICTURE_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                        <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
           <member><type>StdVideoDecodeH265PictureInfo</type>*     <name>pStdPictureInfo</name></member>
           <member><type>uint32_t</type>                           <name>slicesCount</name></member>
           <member len="slicesCount">const <type>uint32_t</type>*  <name>pSlicesDataOffsets</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH265DpbSlotInfoEXT" structextends="VkVideoReferenceSlotKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_DPB_SLOT_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                             <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                             <name>pNext</name></member>
           <member>const <type>StdVideoDecodeH265ReferenceInfo</type>*  <name>pStdReferenceInfo</name></member>
         </type>
         <type category="struct" name="VkVideoSessionCreateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_SESSION_CREATE_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                   <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                   <name>pNext</name></member>
           <member><type>uint32_t</type>                                      <name>queueFamilyIndex</name></member>
           <member optional="true"><type>VkVideoSessionCreateFlagsKHR</type>  <name>flags</name></member>
           <member>const <type>VkVideoProfileKHR</type>*                      <name>pVideoProfile</name></member>
@@ -5776,18 +5776,18 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoSessionParametersCreateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_CREATE_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                            <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
           <member><type>VkVideoSessionParametersKHR</type>                            <name>videoSessionParametersTemplate</name></member>
           <member><type>VkVideoSessionKHR</type>                                      <name>videoSession</name></member>
         </type>
         <type category="struct" name="VkVideoSessionParametersUpdateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_UPDATE_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                            <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
           <member><type>uint32_t</type>                                               <name>updateSequenceCount</name></member>
         </type>
         <type category="struct" name="VkVideoBeginCodingInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_BEGIN_CODING_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                             <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                             <name>pNext</name></member>
           <member optional="true"><type>VkVideoBeginCodingFlagsKHR</type>              <name>flags</name></member>
           <member><type>VkVideoCodingQualityPresetFlagsKHR</type>                      <name>codecQualityPreset</name></member>
           <member><type>VkVideoSessionKHR</type>                                       <name>videoSession</name></member>
@@ -5797,17 +5797,17 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoEndCodingInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_END_CODING_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                              <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                              <name>pNext</name></member>
           <member optional="true"><type>VkVideoEndCodingFlagsKHR</type> <name>flags</name></member>
         </type>
         <type category="struct" name="VkVideoCodingControlInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_CODING_CONTROL_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                  <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                  <name>pNext</name></member>
           <member optional="true"><type>VkVideoCodingControlFlagsKHR</type> <name>flags</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                            <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
           <member optional="true"><type>VkVideoEncodeFlagsKHR</type>  <name>flags</name></member>
           <member><type>uint32_t</type>                               <name>qualityLevel</name></member>
           <member><type>VkExtent2D</type>                             <name>codedExtent</name></member>
@@ -5821,7 +5821,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoEncodeRateControlInfoKHR" structextends="VkVideoCodingControlInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                              <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                              <name>pNext</name></member>
           <member><type>VkVideoEncodeRateControlFlagsKHR</type>         <name>flags</name></member>
           <member><type>VkVideoEncodeRateControlModeFlagBitsKHR</type>  <name>rateControlMode</name></member>
           <member><type>uint32_t</type>                                 <name>averageBitrate</name></member>
@@ -5832,8 +5832,8 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoEncodeH264CapabilitiesEXT" structextends="VkVideoCapabilitiesKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                           <name>pNext</name></member>
-          <member><type>VkVideoEncodeH264CapabilityFlagsEXT</type>   <name>flags</name></member>
+          <member optional="true">const <type>void</type>*                           <name>pNext</name></member>
+          <member><type>VkVideoEncodeH264CapabilitiesFlagsEXT</type> <name>flags</name></member>
           <member><type>VkVideoEncodeH264InputModeFlagsEXT</type>    <name>inputModeFlags</name></member>
           <member><type>VkVideoEncodeH264OutputModeFlagsEXT</type>   <name>outputModeFlags</name></member>
           <member><type>VkExtent2D</type>                            <name>minPictureSizeInMbs</name></member>
@@ -5847,7 +5847,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoEncodeH264SessionCreateInfoEXT" structextends="VkVideoSessionCreateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_CREATE_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                     <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
           <member><type>VkVideoEncodeH264CreateFlagsEXT</type> <name>flags</name></member>
           <member><type>VkExtent2D</type>                      <name>maxPictureSizeInMbs</name></member>
           <member>const <type>VkExtensionProperties</type>*    <name>pStdExtensionVersion</name></member>
@@ -5863,7 +5863,7 @@ typedef void <name>CAMetalLayer</name>;
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefPicMarkingEntry"/>
         <type category="struct" name="VkVideoEncodeH264SessionParametersAddInfoEXT" structextends="VkVideoSessionParametersUpdateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                                               <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                                               <name>pNext</name></member>
           <member><type>uint32_t</type>                                                                  <name>spsStdCount</name></member>
           <member len="spsStdCount" optional="true">const <type>StdVideoH264SequenceParameterSet</type>* <name>pSpsStd</name></member>
           <member><type>uint32_t</type>                                                                  <name>ppsStdCount</name></member>
@@ -5871,20 +5871,20 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoEncodeH264SessionParametersCreateInfoEXT" structextends="VkVideoSessionParametersCreateInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                                         <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                                         <name>pNext</name></member>
           <member><type>uint32_t</type>                                                            <name>maxSpsStdCount</name></member>
           <member><type>uint32_t</type>                                                            <name>maxPpsStdCount</name></member>
           <member optional="true">const <type>VkVideoEncodeH264SessionParametersAddInfoEXT</type>* <name>pParametersAddInfo</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH264DpbSlotInfoEXT">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                                          <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                                          <name>pNext</name></member>
           <member><type>int8_t</type>                                                               <name>slotIndex</name></member>
           <member>const <type>StdVideoEncodeH264PictureInfo</type>*                                 <name>pStdPictureInfo</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH264VclFrameInfoEXT" structextends="VkVideoEncodeInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_VCL_FRAME_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                                          <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                                          <name>pNext</name></member>
           <member><type>uint8_t</type>                                                              <name>refDefaultFinalList0EntryCount</name></member>
           <member len="refDefaultFinalList0EntryCount">const <type>VkVideoEncodeH264DpbSlotInfoEXT</type>* <name>pRefDefaultFinalList0Entries</name></member>
           <member><type>uint8_t</type>                                                              <name>refDefaultFinalList1EntryCount</name></member>
@@ -5895,7 +5895,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoEncodeH264EmitPictureParametersEXT" structextends="VkVideoEncodeInfoKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_EMIT_PICTURE_PARAMETERS_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                             <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                             <name>pNext</name></member>
           <member><type>uint8_t</type>                                 <name>spsId</name></member>
           <member><type>VkBool32</type>                                <name>emitSpsEnable</name></member>
           <member><type>uint32_t</type>                                <name>ppsIdEntryCount</name></member>
@@ -5903,12 +5903,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkVideoEncodeH264ProfileEXT" structextends="VkVideoProfileKHR">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                    <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                    <name>pNext</name></member>
           <member><type>StdVideoH264ProfileIdc</type>         <name>stdProfileIdc</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH264NaluSliceEXT">
           <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_EXT"><type>VkStructureType</type><name>sType</name></member>
-          <member>const <type>void</type>*                                     <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                     <name>pNext</name></member>
           <member>const <type>StdVideoEncodeH264SliceHeader</type>*            <name>pSliceHeaderStd</name></member>
           <member><type>uint32_t</type>                                        <name>mbCount</name></member>
           <member><type>uint8_t</type>                                         <name>refFinalList0EntryCount</name></member>
@@ -5921,12 +5921,12 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceInheritedViewportScissorFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
           <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-          <member><type>void</type>*                               <name>pNext</name></member>
+          <member optional="true"><type>void</type>*                               <name>pNext</name></member>
           <member><type>VkBool32</type>                            <name>inheritedViewportScissor2D</name></member>
         </type>
         <type category="struct" name="VkCommandBufferInheritanceViewportScissorInfoNV" structextends="VkCommandBufferInheritanceInfo">
           <member values="VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
-          <member>const <type>void</type>*                                    <name>pNext</name></member>
+          <member optional="true">const <type>void</type>*                                    <name>pNext</name></member>
           <member><type>VkBool32</type>                                       <name>viewportScissor2D</name></member>
           <member><type>uint32_t</type>                                       <name>viewportDepthCount</name></member>
           <member noautovalidity="true">const <type>VkViewport</type>*        <name>pViewportDepths</name></member>
@@ -5938,36 +5938,36 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceProvokingVertexFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>provokingVertexLast</name></member>
             <member><type>VkBool32</type>                           <name>transformFeedbackPreservesProvokingVertex</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceProvokingVertexPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>*                               <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>provokingVertexModePerPipeline</name></member>
             <member><type>VkBool32</type>                            <name>transformFeedbackPreservesTriangleFanProvokingVertex</name></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationProvokingVertexStateCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
             <member><type>VkProvokingVertexModeEXT</type>           <name>provokingVertexMode</name></member>
         </type>
         <type category="struct" name="VkCuModuleCreateInfoNVX">
             <member values="VK_STRUCTURE_TYPE_CU_MODULE_CREATE_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>size_t</type>                 <name>dataSize</name></member>
             <member>const <type>void</type>*            <name>pData</name></member>
         </type>
         <type category="struct" name="VkCuFunctionCreateInfoNVX">
             <member values="VK_STRUCTURE_TYPE_CU_FUNCTION_CREATE_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
             <member><type>VkCuModuleNVX</type>                      <name>module</name></member>
             <member len="null-terminated">const <type>char</type>*  <name>pName</name></member>
         </type>
         <type category="struct" name="VkCuLaunchInfoNVX">
             <member values="VK_STRUCTURE_TYPE_CU_LAUNCH_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkCuFunctionNVX</type>        <name>function</name></member>
             <member><type>uint32_t</type>               <name>gridDimX</name></member>
             <member><type>uint32_t</type>               <name>gridDimY</name></member>
@@ -5983,7 +5983,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceDrmPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type> <name>hasPrimary</name></member>
             <member><type>VkBool32</type> <name>hasRender</name></member>
             <member><type>int64_t</type> <name>primaryMajor</name></member>
@@ -5993,7 +5993,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceRayTracingMotionBlurFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>rayTracingMotionBlur</name></member>
             <member><type>VkBool32</type>                           <name>rayTracingMotionBlurPipelineTraceRaysIndirect</name></member>
         </type>


### PR DESCRIPTION
As discussed in #1396, `pNext` fields should be marked as optional. This wasn't ensured for more recently added changes (which breaks some binding generators), so this PR updates the XML file to match that discussion.

#1396 mentions
> add something to the style guide about setting this attribute on pNext members

which appears to not have happened. It might be worth looking into again.