### PR TITLE
Make treatment of empty Vk*FlagBits types consistent

### DIFF
--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -2965,7 +2965,7 @@ If a binding has a pname:descriptorCount of zero, it is skipped.
 This behavior applies recursively, with the update affecting consecutive
 bindings as needed to update all pname:descriptorCount descriptors.
 Consecutive bindings must: have identical
-elink::VkDescriptorType, elink::VkShaderStageFlags,
+elink:VkDescriptorType, tlink:VkShaderStageFlags,
 ifdef::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]
 elink:VkDescriptorBindingFlagBits,
 endif::VK_VERSION_1_2,VK_EXT_descriptor_indexing[]

--- a/chapters/pipelines.txt
+++ b/chapters/pipelines.txt
@@ -3651,6 +3651,7 @@ include::{generated}/api/enums/VkPipelineCacheCreateFlagBits.txt[]
 --
 endif::VK_EXT_pipeline_creation_cache_control[]
 
+
 [[pipelines-cache-merge]]
 === Merging Pipeline Caches
 

--- a/registry.txt
+++ b/registry.txt
@@ -1548,6 +1548,9 @@ enumerant:
   * attr:extends - the name of a separately defined enumerated type (e.g. a
     tag:type tag with attr:category``="enum"``) to which the extension
     enumerant is added.
+    The enumerated type is required to complete the definition of the
+    enumerant, in the same fashion as the attr:requires attribute of a
+    tag:type tag.
     If not present, the enumerant is treated as a global constant value.
   * attr:extnumber - an extension number.
     The extension number in turn specifies the starting value of a block
@@ -2441,6 +2444,9 @@ Changes to the `.xml` files and Python scripts are logged in Github history.
 [[changelog]]
 = Change Log
 
+  * 2021-08-15 - Add an explicit description of the tag:enum attr:extends
+    attribute as introducing a requirement for the enumerated type being
+    extended.
   * 2021-07-12 - Note that tag:extension tags describing instance extensions
     must not have dependencies on device extensions (internal issue 2387).
   * 2021-06-14 - Add an `objecttype` attribute which specifies the

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -155,7 +155,7 @@ branch of the member gitlab server.
         <type category="define" requires="VK_MAKE_API_VERSION">// Vulkan 1.2 version number
 #define <name>VK_API_VERSION_1_2</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 2, 0)// Patch version should always be set to 0</type>
         <type category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 188</type>
+#define <name>VK_HEADER_VERSION</name> 187</type>
         <type category="define" requires="VK_HEADER_VERSION">// Complete version of this file
 #define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 2, VK_HEADER_VERSION)</type>
 
@@ -261,12 +261,11 @@ typedef void <name>CAMetalLayer</name>;
         <type requires="VkPipelineCreateFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCreateFlags</name>;</type>
         <type requires="VkColorComponentFlagBits"         category="bitmask">typedef <type>VkFlags</type> <name>VkColorComponentFlags</name>;</type>
         <type requires="VkFenceCreateFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkFenceCreateFlags</name>;</type>
-            <comment>When VkSemaphoreCreateFlagBits is first extended, need to add a requires= attribute for it to VkSemaphoreCreateFlags</comment>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkSemaphoreCreateFlags</name>;</type>
         <type requires="VkFormatFeatureFlagBits"          category="bitmask">typedef <type>VkFlags</type> <name>VkFormatFeatureFlags</name>;</type>
         <type requires="VkQueryControlFlagBits"           category="bitmask">typedef <type>VkFlags</type> <name>VkQueryControlFlags</name>;</type>
         <type requires="VkQueryResultFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkQueryResultFlags</name>;</type>
-        <type requires="VkShaderModuleCreateFlagBits"     category="bitmask">typedef <type>VkFlags</type> <name>VkShaderModuleCreateFlags</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkShaderModuleCreateFlags</name>;</type>
         <type requires="VkEventCreateFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkEventCreateFlags</name>;</type>
         <type requires="VkCommandPoolCreateFlagBits"      category="bitmask">typedef <type>VkFlags</type> <name>VkCommandPoolCreateFlags</name>;</type>
         <type requires="VkCommandPoolResetFlagBits"       category="bitmask">typedef <type>VkFlags</type> <name>VkCommandPoolResetFlags</name>;</type>
@@ -548,7 +547,7 @@ typedef void <name>CAMetalLayer</name>;
         <type name="VkObjectType" category="enum"/>
         <type name="VkEventCreateFlagBits" category="enum"/>
         <type name="VkPipelineLayoutCreateFlagBits" category="enum"/>
-            <comment>When VkSemaphoreCreateFlagBits is first extended, need to add a type enum tag for it here</comment>
+        <type name="VkSemaphoreCreateFlagBits" category="enum"/>
 
         <comment>Extensions</comment>
         <type name="VkIndirectCommandsLayoutUsageFlagBitsNV" category="enum"/>
@@ -6192,7 +6191,8 @@ typedef void <name>CAMetalLayer</name>;
     <enums name="VkPipelineCacheHeaderVersion" type="enum">
         <enum value="1"     name="VK_PIPELINE_CACHE_HEADER_VERSION_ONE"/>
     </enums>
-    <enums name="VkPipelineCacheCreateFlagBits" type="bitmask"></enums>
+    <enums name="VkPipelineCacheCreateFlagBits" type="bitmask">
+    </enums>
     <enums name="VkPrimitiveTopology" type="enum">
         <enum value="0"     name="VK_PRIMITIVE_TOPOLOGY_POINT_LIST"/>
         <enum value="1"     name="VK_PRIMITIVE_TOPOLOGY_LINE_LIST"/>
@@ -6651,8 +6651,10 @@ typedef void <name>CAMetalLayer</name>;
         <enum bitpos="1"    name="VK_CULL_MODE_BACK_BIT"/>
         <enum value="0x00000003" name="VK_CULL_MODE_FRONT_AND_BACK"/>
     </enums>
-    <enums name="VkRenderPassCreateFlagBits" type="bitmask"></enums>
-    <enums name="VkDeviceQueueCreateFlagBits" type="bitmask"></enums>
+    <enums name="VkRenderPassCreateFlagBits" type="bitmask">
+    </enums>
+    <enums name="VkDeviceQueueCreateFlagBits" type="bitmask">
+    </enums>
     <enums name="VkMemoryPropertyFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT"               comment="If otherwise stated, then allocate memory on device"/>
         <enum bitpos="1"    name="VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT"               comment="Memory is mappable by host"/>
@@ -6745,7 +6747,8 @@ typedef void <name>CAMetalLayer</name>;
     <enums name="VkFenceCreateFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_FENCE_CREATE_SIGNALED_BIT"/>
     </enums>
-        <comment>When VkSemaphoreCreateFlagBits is first extended, need to add a bitmask enums tag for it here</comment>
+    <enums name="VkSemaphoreCreateFlagBits" type="bitmask">
+    </enums>
     <enums name="VkFormatFeatureFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT"               comment="Format can be used for sampled images (SAMPLED_IMAGE and COMBINED_IMAGE_SAMPLER descriptor types)"/>
         <enum bitpos="1"    name="VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT"               comment="Format can be used for storage images (STORAGE_IMAGE descriptor type)"/>
@@ -10776,7 +10779,7 @@ typedef void <name>CAMetalLayer</name>;
             <type name="VkImageUsageFlagBits"/>
             <type name="VkImageUsageFlags"/>
             <type name="VkInstance"/>
-            <type name="VkInstanceCreateFlags"/>
+            <type name="VkInstanceCreateFlags" comment="Will add VkInstanceCreateFlagBits when bits are defined in the future"/>
             <type name="VkInstanceCreateInfo"/>
             <type name="VkInternalAllocationType"/>
             <type name="VkMemoryHeap"/>
@@ -10812,10 +10815,9 @@ typedef void <name>CAMetalLayer</name>;
         </require>
         <require comment="Device commands">
             <type name="VkDevice"/>
-            <type name="VkDeviceCreateFlags"/>
+            <type name="VkDeviceCreateFlags" comment="Will add VkDeviceCreateFlagBits when bits are defined in the future"/>
             <type name="VkDeviceCreateInfo"/>
-            <type name="VkDeviceQueueCreateFlagBits"/>
-            <type name="VkDeviceQueueCreateFlags"/>
+            <type name="VkDeviceQueueCreateFlags" comment="VkDeviceQueueCreateFlagBits was added later"/>
             <type name="VkDeviceQueueCreateInfo"/>
             <command name="vkCreateDevice"/>
             <command name="vkDestroyDevice"/>
@@ -10893,7 +10895,7 @@ typedef void <name>CAMetalLayer</name>;
         </require>
         <require comment="Queue semaphore commands">
             <type name="VkSemaphore"/>
-            <type name="VkSemaphoreCreateFlags"/>
+            <type name="VkSemaphoreCreateFlags" comment="Will add VkSemaphoreCreateFlagBits when bits are defined in the future"/>
             <type name="VkSemaphoreCreateInfo"/>
             <command name="vkCreateSemaphore"/>
             <command name="vkDestroySemaphore"/>
@@ -10913,7 +10915,7 @@ typedef void <name>CAMetalLayer</name>;
             <type name="VkQueryPipelineStatisticFlagBits"/>
             <type name="VkQueryPipelineStatisticFlags"/>
             <type name="VkQueryPool"/>
-            <type name="VkQueryPoolCreateFlags"/>
+            <type name="VkQueryPoolCreateFlags" comment="Will add VkQueryPoolCreateFlagBits when bits are defined in the future"/>
             <type name="VkQueryPoolCreateInfo"/>
             <type name="VkQueryResultFlagBits"/>
             <type name="VkQueryResultFlags"/>
@@ -10935,7 +10937,7 @@ typedef void <name>CAMetalLayer</name>;
         </require>
         <require comment="Buffer view commands">
             <type name="VkBufferView"/>
-            <type name="VkBufferViewCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkBufferViewCreateFlags" comment="Will add VkBufferViewFlagBits when bits are defined in the future"/>
             <type name="VkBufferViewCreateInfo"/>
             <command name="vkCreateBufferView"/>
             <command name="vkDestroyBufferView"/>
@@ -10963,7 +10965,6 @@ typedef void <name>CAMetalLayer</name>;
         </require>
         <require comment="Shader commands">
             <type name="VkShaderModule"/>
-            <type name="VkShaderModuleCreateFlagBits"/>
             <type name="VkShaderModuleCreateFlags"/>
             <type name="VkShaderModuleCreateInfo"/>
             <command name="vkCreateShaderModule"/>
@@ -10971,8 +10972,7 @@ typedef void <name>CAMetalLayer</name>;
         </require>
         <require comment="Pipeline Cache commands">
             <type name="VkPipelineCache"/>
-            <type name="VkPipelineCacheCreateFlagBits"/>
-            <type name="VkPipelineCacheCreateFlags"/>
+            <type name="VkPipelineCacheCreateFlags" comment="VkPipelineCacheCreateFlagBits was added later"/>
             <type name="VkPipelineCacheCreateInfo"/>
             <command name="vkCreatePipelineCache"/>
             <command name="vkDestroyPipelineCache"/>
@@ -10994,29 +10994,29 @@ typedef void <name>CAMetalLayer</name>;
             <type name="VkLogicOp"/>
             <type name="VkPipeline"/>
             <type name="VkPipelineColorBlendAttachmentState"/>
-            <type name="VkPipelineColorBlendStateCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkPipelineColorBlendStateCreateFlags" comment="Will add VkPipeline*StateFlagBits when bits are defined in the future"/>
             <type name="VkPipelineColorBlendStateCreateInfo"/>
             <type name="VkPipelineCreateFlagBits"/>
             <type name="VkPipelineCreateFlags"/>
-            <type name="VkPipelineDepthStencilStateCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkPipelineDepthStencilStateCreateFlags" comment="Will add VkPipeline*StateFlagBits when bits are defined in the future"/>
             <type name="VkPipelineDepthStencilStateCreateInfo"/>
-            <type name="VkPipelineDynamicStateCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkPipelineDynamicStateCreateFlags" comment="Will add VkPipeline*StateFlagBits when bits are defined in the future"/>
             <type name="VkPipelineDynamicStateCreateInfo"/>
-            <type name="VkPipelineInputAssemblyStateCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkPipelineInputAssemblyStateCreateFlags" comment="Will add VkPipeline*StateFlagBits when bits are defined in the future"/>
             <type name="VkPipelineInputAssemblyStateCreateInfo"/>
-            <type name="VkPipelineLayoutCreateFlags" comment="Will need FlagBits type eventually"/>
-            <type name="VkPipelineMultisampleStateCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkPipelineLayoutCreateFlags" comment="Will add VkPipelineLayoutCreateFlagBits when bits are defined in the future"/>
+            <type name="VkPipelineMultisampleStateCreateFlags" comment="Will add VkPipelineMultisampleStateCreateFlagBits when bits are defined in the future"/>
             <type name="VkPipelineMultisampleStateCreateInfo"/>
-            <type name="VkPipelineRasterizationStateCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkPipelineRasterizationStateCreateFlags" comment="Will add VkPipelineRasterizationStateCreateFlagBits when bits are defined in the future"/>
             <type name="VkPipelineRasterizationStateCreateInfo"/>
             <type name="VkPipelineShaderStageCreateFlagBits"/>
             <type name="VkPipelineShaderStageCreateFlags"/>
             <type name="VkPipelineShaderStageCreateInfo"/>
-            <type name="VkPipelineTessellationStateCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkPipelineTessellationStateCreateFlags" comment="Will add VkPipelineTessellationStateCreateFlagBits when bits are defined in the future"/>
             <type name="VkPipelineTessellationStateCreateInfo"/>
-            <type name="VkPipelineVertexInputStateCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkPipelineVertexInputStateCreateFlags" comment="Will add VkPipelineVertexInputStateCreateFlagBits when bits are defined in the future"/>
             <type name="VkPipelineVertexInputStateCreateInfo"/>
-            <type name="VkPipelineViewportStateCreateFlags" comment="Will need FlagBits type eventually"/>
+            <type name="VkPipelineViewportStateCreateFlags" comment="Will add VkPipelineViewportStateCreateFlagBits when bits are defined in the future"/>
             <type name="VkPipelineViewportStateCreateInfo"/>
             <type name="VkPolygonMode"/>
             <type name="VkPrimitiveTopology"/>
@@ -11369,6 +11369,7 @@ typedef void <name>CAMetalLayer</name>;
             <enum extends="VkStructureType" extnumber="146" offset="3"          name="VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2"/>
             <enum bitpos="4"  extends="VkQueueFlagBits"                         name="VK_QUEUE_PROTECTED_BIT" comment="Queues may support protected operations"/>
             <enum bitpos="0"  extends="VkDeviceQueueCreateFlagBits"             name="VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT" comment="Queue is a protected-capable device queue"/>
+            <type name="VkDeviceQueueCreateFlagBits" comment="This is a temporary workaround for processors not recognizing that VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT above also requires this type"/>
             <enum bitpos="5"  extends="VkMemoryPropertyFlagBits"                name="VK_MEMORY_PROPERTY_PROTECTED_BIT" comment="Memory is protected"/>
             <enum bitpos="3"  extends="VkBufferCreateFlagBits"                  name="VK_BUFFER_CREATE_PROTECTED_BIT" comment="Buffer requires protected memory"/>
             <enum bitpos="11" extends="VkImageCreateFlagBits"                   name="VK_IMAGE_CREATE_PROTECTED_BIT" comment="Image requires protected memory"/>
@@ -15626,6 +15627,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum extends="VkResult"            name="VK_ERROR_PIPELINE_COMPILE_REQUIRED_EXT" alias="VK_PIPELINE_COMPILE_REQUIRED_EXT"/>
                 <enum bitpos="0"  extends="VkPipelineCacheCreateFlagBits"
                     name="VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT"/>
+                <type name="VkPipelineCacheCreateFlagBits" comment="This is a temporary workaround for processors not recognizing that VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT above also requires this type"/>
             </require>
         </extension>
         <extension name="VK_KHR_extension_299" number="299" author="KHR" contact="Mark Bellamy @mark.bellamy_arm" supported="disabled">


### PR DESCRIPTION
This originated with #1601 noting a cross-link to a nonexistent FlagBits
refpage, then expanded in scope a bit as I dealt with inconsistent treatment
of unused FlagBits types.

All FlagBits types with no bits defined are now treated consistently:
the unused (and currently useless) FlagBits type has no description in
the spec and no dependency on it exists in vk.xml at the point where the
corresponding Flags type is required. This meant removing
VkDeviceQueueCreateFlagBits, VkShaderModuleCreateFlagBits, and
VkPipelineCacheCreateFlagBits from the VK_VERSION_1_0 XML block. The
only semantic header file difference in the current headers is that
VkShaderModuleCreateFlagBits is no longer defined in vulkan_core.h:

```
2125a2126,2129
>
> typedef enum VkShaderModuleCreateFlagBits {
>     VK_SHADER_MODULE_CREATE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
> } VkShaderModuleCreateFlagBits;
```

In addition the spec interface listings for VkDeviceQueueCreateFlagBits and
VkPipelineCacheCreateFlagBits drop the

```
// Provided by VK_VERSION_1_0
```

comment, but still describe each actual enum with the version or
extension that introduced it. These two type definitions also moved
around in vulkan_core.h to be with the version or extension that first
added an extending enum to them.

It's possible that some XML processors do not recognize

> \<enum extends="VkSomeFlagBits">

as an explicit requirement of VkSomeFlagBits. There's a temporary
workaround for this, although we plan to remove it before the PR is
accepted, and a note in the schema document to clarify this case.

Futureproofing XML comments about needing to define the FlagBits types
when they're needed have been made consistent.

I think this is a small net win, although it is possible that there is
existing code which defines a VkShaderModuleCreateFlagBits variable
somewhere despite its uselessness, and would not compile with this
change.

The other alternative to remain consistent would be to *always* require
the FlagBits type whenever a Flags type is defined as a member of a new
structure, even when the FlagBits type has no enumerants defined in to
begin with. This would add many new, empty FlagBits enumerations to the
headers, most of which would probably never be used.

We will let this PR sit for feedback for a bit before deciding to move
this direction, or not.