### PR TITLE
Revert vk_platform path change from PR #1538

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -75,7 +75,7 @@ branch of the member gitlab server.
     </tags>
 
     <types comment="Vulkan type definitions">
-        <type name="vk_platform" category="include">#include "vulkan/vk_platform.h"</type>
+        <type name="vk_platform" category="include">#include "vk_platform.h"</type>
 
             <comment>WSI extensions</comment>
 


### PR DESCRIPTION
This caused some issues with search paths per #1573. There will probably
be a downstream change to move the vk_video/ headers under
vulkan/vk_video instead of in a parallel directory. We are not entirely
settled on how to move this forward at the moment and there's a mix of
philosophical correctness and concrete build issues being discussed in #1573.