### PR TITLE
Remove exporting of D3D memory handles

### DIFF
--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -1741,15 +1741,6 @@ For handles of the following types:
 The implementation must: ensure the access rights allow read and write
 access to the memory.
 
-For handles of the following types:
-
-  * ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_BIT
-  * ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT
-
-The access rights must: be:
-
-  * code:GENERIC_ALL
-
 1::
     https://docs.microsoft.com/en-us/windows/win32/sync/synchronization-object-security-and-access-rights
 
@@ -1757,10 +1748,7 @@ The access rights must: be:
 ****
   * [[VUID-VkExportMemoryWin32HandleInfoKHR-handleTypes-00657]]
     If slink:VkExportMemoryAllocateInfo::pname:handleTypes does not include
-    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT,
-    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT,
-    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_BIT, or
-    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT, a
+    ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT, a
     sname:VkExportMemoryWin32HandleInfoKHR structure must: not be included
     in the pname:pNext chain of slink:VkMemoryAllocateInfo
 ****

--- a/chapters/memory.txt
+++ b/chapters/memory.txt
@@ -1737,7 +1737,6 @@ the handle type.
 For handles of the following types:
 
   * ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT
-  * ename:VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT
 
 The implementation must: ensure the access rights allow read and write
 access to the memory.


### PR DESCRIPTION
Remove VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT from VkExportMemoryWin32HandleInfoKHR.

Closes #1551 