### PR TITLE
Reserve extension number for VK_EXT_disable_cube_map_wrap.

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -16690,6 +16690,13 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_EXT_extension_422&quot;"              name="VK_EXT_EXTENSION_422_EXTENSION_NAME"/>
             </require>
         </extension>
+        <extension name="VK_EXT_disable_cube_map_wrap" number="423" author="EXT" contact="Georg Lehmann @DadSchoorse" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_DISABLE_CUBE_MAP_WRAP_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_disable_cube_map_wrap&quot;"      name="VK_EXT_DISABLE_CUBE_MAP_WRAP_EXTENSION_NAME"/>
+                <enum bitpos="2"  extends="VkSamplerCreateFlagBits"         name="VK_SAMPLER_CREATE_RESERVED_2_BIT_EXT"/>
+            </require>
+        </extension>
 
     </extensions>
     <spirvextensions comment="SPIR-V Extensions allowed in Vulkan and what is required to use it">


### PR DESCRIPTION
A work in progress version can be found here: https://github.com/DadSchoorse/Vulkan-Docs/tree/VK_EXT_disable_cube_map_wrap