### PR TITLE
[WIP] Add limit values for tool chain usage

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -1600,152 +1600,120 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceLimits" returnedonly="true">
                 <comment>resource maximum sizes</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension1D</name><limit supported="4096" /><comment>max 1D image dimension</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension2D</name><limit supported="4096" /><comment>max 2D image dimension</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension3D</name><limit supported="256" /><comment>max 3D image dimension</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimensionCube</name><limit supported="4096" /><comment>max cubemap image dimension</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageArrayLayers</name><limit supported="256" /><comment>max layers for image arrays</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTexelBufferElements</name><limit supported="65536" /><comment>max texel buffer size (fstexels)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxUniformBufferRange</name><limit supported="65536" /><comment>max uniform buffer range (bytes)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxStorageBufferRange</name><limit supported="134217728" /><comment>max storage buffer range (bytes)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPushConstantsSize</name><limit supported="128" /><comment>max size of the push constants pool (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension1D</name><comment>max 1D image dimension</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension2D</name><comment>max 2D image dimension</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension3D</name><comment>max 3D image dimension</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimensionCube</name><comment>max cubemap image dimension</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageArrayLayers</name><comment>max layers for image arrays</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTexelBufferElements</name><comment>max texel buffer size (fstexels)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxUniformBufferRange</name><comment>max uniform buffer range (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxStorageBufferRange</name><comment>max storage buffer range (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPushConstantsSize</name><comment>max size of the push constants pool (bytes)</comment></member>
                 <comment>memory limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxMemoryAllocationCount</name><limit supported="4096" /><comment>max number of device memory allocations supported</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxSamplerAllocationCount</name><limit supported="4000" /><comment>max number of samplers that can be allocated on a device</comment></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>           <name>bufferImageGranularity</name><limit supported="131072" /><comment>Granularity (in bytes) at which buffers and images can be bound to adjacent memory for simultaneous usage</comment></member>
-            <member limittype="max"><type>VkDeviceSize</type>           <name>sparseAddressSpaceSize</name><limit supported="2147483648" unsupported="0" /><comment>Total address space available for sparse allocations (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxMemoryAllocationCount</name><comment>max number of device memory allocations supported</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxSamplerAllocationCount</name><comment>max number of samplers that can be allocated on a device</comment></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>           <name>bufferImageGranularity</name><comment>Granularity (in bytes) at which buffers and images can be bound to adjacent memory for simultaneous usage</comment></member>
+            <member limittype="max"><type>VkDeviceSize</type>           <name>sparseAddressSpaceSize</name><comment>Total address space available for sparse allocations (bytes)</comment></member>
                 <comment>descriptor set limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxBoundDescriptorSets</name><limit supported="4" /><comment>max number of descriptors sets that can be bound to a pipeline</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorSamplers</name><limit supported="16" /><comment>max number of samplers allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUniformBuffers</name><limit supported="12" /><comment>max number of uniform buffers allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorStorageBuffers</name><limit supported="4" /><comment>max number of storage buffers allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorSampledImages</name><limit supported="16" /><comment>max number of sampled images allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorStorageImages</name><limit supported="4" /><comment>max number of storage images allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorInputAttachments</name><limit supported="4" /><comment>max number of input attachments allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageResources</name><limit supported="128" /><comment>max number of resources allowed by a single stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetSamplers</name><limit supported="96" /><comment>max number of samplers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffers</name><limit supported="72" /><comment>max number of uniform buffers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffersDynamic</name><limit supported="8" /><comment>max number of dynamic uniform buffers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffers</name><limit supported="24" /><comment>max number of storage buffers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffersDynamic</name><limit supported="4" /><comment>max number of dynamic storage buffers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetSampledImages</name><limit supported="96" /><comment>max number of sampled images allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageImages</name><limit supported="24" /><comment>max number of storage images allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetInputAttachments</name><limit supported="4" /><comment>max number of input attachments allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxBoundDescriptorSets</name><comment>max number of descriptors sets that can be bound to a pipeline</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorSamplers</name><comment>max number of samplers allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUniformBuffers</name><comment>max number of uniform buffers allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorStorageBuffers</name><comment>max number of storage buffers allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorSampledImages</name><comment>max number of sampled images allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorStorageImages</name><comment>max number of storage images allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorInputAttachments</name><comment>max number of input attachments allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageResources</name><comment>max number of resources allowed by a single stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetSamplers</name><comment>max number of samplers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffers</name><comment>max number of uniform buffers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffersDynamic</name><comment>max number of dynamic uniform buffers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffers</name><comment>max number of storage buffers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffersDynamic</name><comment>max number of dynamic storage buffers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetSampledImages</name><comment>max number of sampled images allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageImages</name><comment>max number of storage images allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetInputAttachments</name><comment>max number of input attachments allowed in all stages in a descriptor set</comment></member>
                 <comment>vertex stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputAttributes</name><limit supported="16" /><comment>max number of vertex input attribute slots</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputBindings</name><limit supported="16" /><comment>max number of vertex input binding slots</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputAttributeOffset</name><limit supported="2047" /><comment>max vertex input attribute offset added to vertex buffer offset</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputBindingStride</name><limit supported="2048" /><comment>max vertex input binding stride</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexOutputComponents</name><limit supported="64" /><comment>max number of output components written by vertex shader</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputAttributes</name><comment>max number of vertex input attribute slots</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputBindings</name><comment>max number of vertex input binding slots</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputAttributeOffset</name><comment>max vertex input attribute offset added to vertex buffer offset</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputBindingStride</name><comment>max vertex input binding stride</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexOutputComponents</name><comment>max number of output components written by vertex shader</comment></member>
                 <comment>tessellation control stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationGenerationLevel</name><limit supported="64" unsupported="0" /><comment>max level supported by tessellation primitive generator</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationPatchSize</name><limit supported="32" unsupported="0" /><comment>max patch size (vertices)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerVertexInputComponents</name><limit supported="64" unsupported="0" /><comment>max number of input components per-vertex in TCS</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerVertexOutputComponents</name><limit supported="64" unsupported="0" /><comment>max number of output components per-vertex in TCS</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerPatchOutputComponents</name><limit supported="120" unsupported="0" /><comment>max number of output components per-patch in TCS</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlTotalOutputComponents</name><limit supported="2048" unsupported="0" /><comment>max total number of per-vertex and per-patch output components in TCS</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationGenerationLevel</name><comment>max level supported by tessellation primitive generator</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationPatchSize</name><comment>max patch size (vertices)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerVertexInputComponents</name><comment>max number of input components per-vertex in TCS</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerVertexOutputComponents</name><comment>max number of output components per-vertex in TCS</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerPatchOutputComponents</name><comment>max number of output components per-patch in TCS</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlTotalOutputComponents</name><comment>max total number of per-vertex and per-patch output components in TCS</comment></member>
                 <comment>tessellation evaluation stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationEvaluationInputComponents</name><limit supported="64" unsupported="0" /><comment>max number of input components per vertex in TES</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationEvaluationOutputComponents</name><limit supported="64" unsupported="0" /><comment>max number of output components per vertex in TES</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationEvaluationInputComponents</name><comment>max number of input components per vertex in TES</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationEvaluationOutputComponents</name><comment>max number of output components per vertex in TES</comment></member>
                 <comment>geometry stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryShaderInvocations</name><limit supported="32" unsupported="0" /><comment>max invocation count supported in geometry shader</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryInputComponents</name><limit supported="64" unsupported="0" /><comment>max number of input components read in geometry stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryOutputComponents</name><limit supported="64" unsupported="0" /><comment>max number of output components written in geometry stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryOutputVertices</name><limit supported="256" unsupported="0" /><comment>max number of vertices that can be emitted in geometry stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryTotalOutputComponents</name><limit supported="1024" unsupported="0" /><comment>max total number of components (all vertices) written in geometry stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryShaderInvocations</name><comment>max invocation count supported in geometry shader</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryInputComponents</name><comment>max number of input components read in geometry stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryOutputComponents</name><comment>max number of output components written in geometry stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryOutputVertices</name><comment>max number of vertices that can be emitted in geometry stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryTotalOutputComponents</name><comment>max total number of components (all vertices) written in geometry stage</comment></member>
                 <comment>fragment stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentInputComponents</name><limit supported="64" /><comment>max number of input components read in fragment stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentOutputAttachments</name><limit supported="4" /><comment>max number of output attachments written in fragment stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentDualSrcAttachments</name><limit supported="1" unsupported="0" /><comment>max number of output attachments written when using dual source blending</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentCombinedOutputResources</name><limit supported="4" /><comment>max total number of storage buffers, storage images and output buffers</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentInputComponents</name><comment>max number of input components read in fragment stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentOutputAttachments</name><comment>max number of output attachments written in fragment stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentDualSrcAttachments</name><comment>max number of output attachments written when using dual source blending</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentCombinedOutputResources</name><comment>max total number of storage buffers, storage images and output buffers</comment></member>
                 <comment>compute stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxComputeSharedMemorySize</name><limit supported="16384" /><comment>max total storage size of work group local storage (bytes)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupCount</name>[3]<limit supported="65536" /><limit supported="65536" /><limit supported="65536" /><comment>max num of compute work groups that may be dispatched by a single command (x,y,z)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupInvocations</name><limit supported="128" /><comment>max total compute invocations in a single local work group</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupSize</name>[3]<limit supported="128" /><limit supported="128" /><limit supported="64" /><comment>max local size of a compute work group (x,y,z)</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>subPixelPrecisionBits</name><limit supported="4" /><comment>number bits of subpixel precision in screen x and y</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>subTexelPrecisionBits</name><limit supported="4" /><comment>number bits of precision for selecting texel weights</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>mipmapPrecisionBits</name><limit supported="4" /><comment>number bits of precision for selecting mipmap weights</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDrawIndexedIndexValue</name><limit supported="4294967295" unsupported="16777215" /><comment>max index value for indexed draw calls (for 32-bit indices)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDrawIndirectCount</name><limit supported="65535" unsupported="1" /><comment>max draw count for indirect draw calls</comment></member>
-            <member limittype="max"><type>float</type>                  <name>maxSamplerLodBias</name><limit supported="2.0" /><comment>max absolute sampler LOD bias</comment></member>
-            <member limittype="max"><type>float</type>                  <name>maxSamplerAnisotropy</name><limit supported="16.0" unsupported="1.0" /><comment>max degree of sampler anisotropy</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxViewports</name><limit supported="16" unsupported="1" /><comment>max number of active viewports</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxViewportDimensions</name>[2]<limit supported="4096" /><limit supported="4096" /><comment>max viewport dimensions (x,y)</comment></member>
-            <member limittype="range"><type>float</type>                  <name>viewportBoundsRange</name>[2]<limit supported="-8192.0" /><limit supported="8192.0" /><comment>viewport bounds range (min,max)</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>viewportSubPixelBits</name><limit supported="0" /><comment>number bits of subpixel precision for viewport</comment></member>
-            <member limittype="noauto"><type>size_t</type>                 <name>minMemoryMapAlignment</name><limit supported="64" /><comment>min required alignment of pointers returned by MapMemory (bytes)</comment></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minTexelBufferOffsetAlignment</name><limit supported="256" /><comment>min required alignment for texel buffer offsets (bytes) </comment></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minUniformBufferOffsetAlignment</name><limit supported="256" /><comment>min required alignment for uniform buffer sizes and offsets (bytes)</comment></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minStorageBufferOffsetAlignment</name><limit supported="256" /><comment>min required alignment for storage buffer offsets (bytes)</comment></member>
-            <member limittype="min"><type>int32_t</type>                <name>minTexelOffset</name><limit supported="-8" /><comment>min texel offset for OpTextureSampleOffset</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTexelOffset</name><limit supported="7" /><comment>max texel offset for OpTextureSampleOffset</comment></member>
-            <member limittype="min"><type>int32_t</type>                <name>minTexelGatherOffset</name><limit supported="-8" unsupported="0" /><comment>min texel offset for OpTextureGatherOffset</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTexelGatherOffset</name><limit supported="7" unsupported="0" /><comment>max texel offset for OpTextureGatherOffset</comment></member>
-            <member limittype="min"><type>float</type>                  <name>minInterpolationOffset</name><limit supported="-0.5" unsupported="0.0" /><comment>furthest negative offset for interpolateAtOffset</comment></member>
-            <member limittype="max"><type>float</type>                  <name>maxInterpolationOffset</name><limit supported="0.5" unsupported="0.0" /><comment>furthest positive offset for interpolateAtOffset</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>subPixelInterpolationOffsetBits</name><limit supported="4" unsupported="0" /><comment>number of subpixel bits for interpolateAtOffset</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferWidth</name><limit supported="4096" /><comment>max width for a framebuffer</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferHeight</name><limit supported="4096" /><comment>max height for a framebuffer</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferLayers</name><limit supported="256" /><comment>max layer count for a layered framebuffer</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferColorSampleCounts</name><comment>supported color sample counts for a framebuffer</comment>
-                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
-            </member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferDepthSampleCounts</name><comment>supported depth sample counts for a framebuffer</comment>
-                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
-            </member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferStencilSampleCounts</name><comment>supported stencil sample counts for a framebuffer</comment>
-                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
-            </member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferNoAttachmentsSampleCounts</name><comment>supported sample counts for a subpass which uses no attachments</comment>
-                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
-            </member>
-            <member limittype="bitmask"><type>uint32_t</type>               <name>maxColorAttachments</name><comment>max number of color attachments per subpass</comment><limit supported="4" /></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageColorSampleCounts</name><comment>supported color sample counts for a non-integer sampled image</comment>
-                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
-            </member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageIntegerSampleCounts</name><comment>supported sample counts for an integer image</comment>
-                <limit supported="VK_SAMPLE_COUNT_1_BIT" />
-            </member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageDepthSampleCounts</name><comment>supported depth sample counts for a sampled image</comment>
-                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
-            </member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageStencilSampleCounts</name><comment>supported stencil sample counts for a sampled image</comment>
-                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
-            </member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>storageImageSampleCounts</name><comment>supported sample counts for a storage image</comment>
-                <limit supported="VK_SAMPLE_COUNT_1_BIT" unsupported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
-            </member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxSampleMaskWords</name><comment>max number of sample mask words</comment><limit supported="1" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxComputeSharedMemorySize</name><comment>max total storage size of work group local storage (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupCount</name>[3]<comment>max num of compute work groups that may be dispatched by a single command (x,y,z)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupInvocations</name><comment>max total compute invocations in a single local work group</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupSize</name>[3]<comment>max local size of a compute work group (x,y,z)</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>subPixelPrecisionBits</name><comment>number bits of subpixel precision in screen x and y</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>subTexelPrecisionBits</name><comment>number bits of precision for selecting texel weights</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>mipmapPrecisionBits</name><comment>number bits of precision for selecting mipmap weights</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDrawIndexedIndexValue</name><comment>max index value for indexed draw calls (for 32-bit indices)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDrawIndirectCount</name><comment>max draw count for indirect draw calls</comment></member>
+            <member limittype="max"><type>float</type>                  <name>maxSamplerLodBias</name><comment>max absolute sampler LOD bias</comment></member>
+            <member limittype="max"><type>float</type>                  <name>maxSamplerAnisotropy</name><comment>max degree of sampler anisotropy</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxViewports</name><comment>max number of active viewports</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxViewportDimensions</name>[2]<comment>max viewport dimensions (x,y)</comment></member>
+            <member limittype="range"><type>float</type>                  <name>viewportBoundsRange</name>[2]<comment>viewport bounds range (min,max)</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>viewportSubPixelBits</name><comment>number bits of subpixel precision for viewport</comment></member>
+            <member limittype="noauto"><type>size_t</type>                 <name>minMemoryMapAlignment</name><comment>min required alignment of pointers returned by MapMemory (bytes)</comment></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minTexelBufferOffsetAlignment</name><comment>min required alignment for texel buffer offsets (bytes) </comment></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minUniformBufferOffsetAlignment</name><comment>min required alignment for uniform buffer sizes and offsets (bytes)</comment></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minStorageBufferOffsetAlignment</name><comment>min required alignment for storage buffer offsets (bytes)</comment></member>
+            <member limittype="min"><type>int32_t</type>                <name>minTexelOffset</name><comment>min texel offset for OpTextureSampleOffset</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTexelOffset</name><comment>max texel offset for OpTextureSampleOffset</comment></member>
+            <member limittype="min"><type>int32_t</type>                <name>minTexelGatherOffset</name><comment>min texel offset for OpTextureGatherOffset</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTexelGatherOffset</name><comment>max texel offset for OpTextureGatherOffset</comment></member>
+            <member limittype="min"><type>float</type>                  <name>minInterpolationOffset</name><comment>furthest negative offset for interpolateAtOffset</comment></member>
+            <member limittype="max"><type>float</type>                  <name>maxInterpolationOffset</name><comment>furthest positive offset for interpolateAtOffset</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>subPixelInterpolationOffsetBits</name><comment>number of subpixel bits for interpolateAtOffset</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferWidth</name><comment>max width for a framebuffer</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferHeight</name><comment>max height for a framebuffer</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferLayers</name><comment>max layer count for a layered framebuffer</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferColorSampleCounts</name><comment>supported color sample counts for a framebuffer</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferDepthSampleCounts</name><comment>supported depth sample counts for a framebuffer</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferStencilSampleCounts</name><comment>supported stencil sample counts for a framebuffer</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferNoAttachmentsSampleCounts</name><comment>supported sample counts for a subpass which uses no attachments</comment></member>
+            <member limittype="bitmask"><type>uint32_t</type>               <name>maxColorAttachments</name><comment>max number of color attachments per subpass</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageColorSampleCounts</name><comment>supported color sample counts for a non-integer sampled image</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageIntegerSampleCounts</name><comment>supported sample counts for an integer image</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageDepthSampleCounts</name><comment>supported depth sample counts for a sampled image</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageStencilSampleCounts</name><comment>supported stencil sample counts for a sampled image</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>storageImageSampleCounts</name><comment>supported sample counts for a storage image</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxSampleMaskWords</name><comment>max number of sample mask words</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>               <name>timestampComputeAndGraphics</name><comment>timestamps on graphics and compute queues</comment></member>
             <member limittype="noauto"><type>float</type>                  <name>timestampPeriod</name><comment>number of nanoseconds it takes for timestamp query value to increment by 1</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxClipDistances</name><comment>max number of clip distances</comment>
-                <limit supported="8" unsupported="0" />
-            </member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxCullDistances</name><comment>max number of cull distances</comment>
-                <limit supported="8" unsupported="0" />
-            </member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxCombinedClipAndCullDistances</name><comment>max combined number of user clipping</comment>
-                <limit supported="8" unsupported="0" />
-            </member>
-            <member limittype="max"><type>uint32_t</type>               <name>discreteQueuePriorities</name><comment>distinct queue priorities available </comment><limit supported="2" /></member>
-            <member limittype="range"><type>float</type>                  <name>pointSizeRange</name>[2]<comment>range (min,max) of supported point sizes</comment>
-                <limit supported="1.0" unsupported="1.0" /><limit supported="64.0 - ULP" unsupported="1.0" />
-            </member>
-            <member limittype="range"><type>float</type>                  <name>lineWidthRange</name>[2]<comment>range (min,max) of supported line widths</comment>
-                <limit supported="1.0" unsupported="1.0" /><limit supported="8.0 - ULP" unsupported="1.0" />
-            </member>
-            <member limittype="max"><type>float</type>                  <name>pointSizeGranularity</name><comment>granularity of supported point sizes</comment>
-                <limit supported="1.0" unsupported="0.0" />
-            </member>
-            <member limittype="max"><type>float</type>                  <name>lineWidthGranularity</name><comment>granularity of supported line widths</comment>
-                <limit supported="1.0" unsupported="0.0" />
-            </member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxClipDistances</name><comment>max number of clip distances</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxCullDistances</name><comment>max number of cull distances</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxCombinedClipAndCullDistances</name><comment>max combined number of user clipping</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>discreteQueuePriorities</name><comment>distinct queue priorities available </comment></member>
+            <member limittype="range"><type>float</type>                  <name>pointSizeRange</name>[2]<comment>range (min,max) of supported point sizes</comment></member>
+            <member limittype="range"><type>float</type>                  <name>lineWidthRange</name>[2]<comment>range (min,max) of supported line widths</comment></member>
+            <member limittype="max"><type>float</type>                  <name>pointSizeGranularity</name><comment>granularity of supported point sizes</comment></member>
+            <member limittype="max"><type>float</type>                  <name>lineWidthGranularity</name><comment>granularity of supported line widths</comment></member>
             <member limittype="noauto"><type>VkBool32</type>               <name>strictLines</name><comment>line rasterization follows preferred rules</comment></member>
             <member limittype="noauto"><type>VkBool32</type>               <name>standardSampleLocations</name><comment>supports standard sample locations for all supported sample counts</comment></member>
             <member limittype="noauto"><type>VkDeviceSize</type>           <name>optimalBufferCopyOffsetAlignment</name><comment>optimal offset of buffer copies</comment></member>
             <member limittype="noauto"><type>VkDeviceSize</type>           <name>optimalBufferCopyRowPitchAlignment</name><comment>optimal pitch of buffer copies</comment></member>
-            <member limittype="min"><type>VkDeviceSize</type>           <name>nonCoherentAtomSize</name><comment>minimum size and alignment for non-coherent host-mapped device memory access</comment><limit supported="256" /></member>
+            <member limittype="min"><type>VkDeviceSize</type>           <name>nonCoherentAtomSize</name><comment>minimum size and alignment for non-coherent host-mapped device memory access</comment></member>
         </type>
         <type category="struct" name="VkSemaphoreCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -2105,15 +2073,15 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*    <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxGraphicsShaderGroupCount</name><limit supported="4096" /></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectSequenceCount</name><limit supported="1048576" /></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsTokenCount</name><limit supported="16" /></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsStreamCount</name><limit supported="16" /></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsTokenOffset</name><limit supported="2047" /></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsStreamStride</name><limit supported="2048" /></member>
-            <member limittype="noauto"><type>uint32_t</type>         <name>minSequencesCountBufferOffsetAlignment</name><limit supported="256" /></member>
-            <member limittype="noauto"><type>uint32_t</type>         <name>minSequencesIndexBufferOffsetAlignment</name><limit supported="256" /></member>
-            <member limittype="noauto"><type>uint32_t</type>         <name>minIndirectCommandsBufferOffsetAlignment</name><limit supported="256" /></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxGraphicsShaderGroupCount</name></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectSequenceCount</name></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsTokenCount</name></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsStreamCount</name></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsTokenOffset</name></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsStreamStride</name></member>
+            <member limittype="noauto"><type>uint32_t</type>         <name>minSequencesCountBufferOffsetAlignment</name></member>
+            <member limittype="noauto"><type>uint32_t</type>         <name>minSequencesIndexBufferOffsetAlignment</name></member>
+            <member limittype="noauto"><type>uint32_t</type>         <name>minIndirectCommandsBufferOffsetAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiDrawPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -2273,9 +2241,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDevicePushDescriptorPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPushDescriptors</name>
-                <limit supported="32" />
-            </member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPushDescriptors</name></member>
         </type>
         <type category="struct" name="VkConformanceVersion">
             <member><type>uint8_t</type>                          <name>major</name></member>
@@ -2592,12 +2558,8 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMultiviewProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment>
-                <limit supported="6" />
-            </member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment>
-                <limit supported="13421771" />
-            </member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewPropertiesKHR"                  alias="VkPhysicalDeviceMultiviewProperties"/>
         <type category="struct" name="VkRenderPassMultiviewCreateInfo" structextends="VkRenderPassCreateInfo">
@@ -2902,9 +2864,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDiscardRectanglePropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDiscardRectangles</name><comment>max number of active discard rectangles</comment>
-                <limit supported="4" unsupported="0" />
-            </member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDiscardRectangles</name><comment>max number of active discard rectangles</comment></member>
         </type>
         <type category="struct" name="VkPipelineDiscardRectangleStateCreateInfoEXT" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -2917,7 +2877,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>perViewPositionAllComponents</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>perViewPositionAllComponents</name></member>
         </type>
         <type category="struct" name="VkInputAttachmentAspectReference">
             <member><type>uint32_t</type>                        <name>subpass</name></member>
@@ -3150,8 +3110,8 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceSamplerFilterMinmaxProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>filterMinmaxSingleComponentFormats</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>filterMinmaxImageComponentMapping</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>filterMinmaxSingleComponentFormats</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>filterMinmaxImageComponentMapping</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT" alias="VkPhysicalDeviceSamplerFilterMinmaxProperties"/>
         <type category="struct" name="VkSampleLocationEXT">
@@ -3191,21 +3151,11 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceSampleLocationsPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="bitmask"><type>VkSampleCountFlags</type>               <name>sampleLocationSampleCounts</name>
-                <limit supported="VK_SAMPLE_COUNT_4_BIT" />
-            </member>
-            <member limittype="max"><type>VkExtent2D</type>                       <name>maxSampleLocationGridSize</name>
-                <limit supported="1" /><limit supported="1" />
-            </member>
-            <member limittype="range"><type>float</type>                            <name>sampleLocationCoordinateRange</name>[2]
-                <limit supported="0.0" /><limit supported="0.9375" />
-            </member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>sampleLocationSubPixelBits</name>
-                <limit supported="4" />
-            </member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>variableSampleLocations</name>
-                <limit supported="false" />
-            </member>
+            <member limittype="bitmask"><type>VkSampleCountFlags</type>               <name>sampleLocationSampleCounts</name></member>
+            <member limittype="max"><type>VkExtent2D</type>                       <name>maxSampleLocationGridSize</name></member>
+            <member limittype="range"><type>float</type>                            <name>sampleLocationCoordinateRange</name>[2]</member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>sampleLocationSubPixelBits</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>variableSampleLocations</name></member>
         </type>
         <type category="struct" name="VkMultisamplePropertiesEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3231,12 +3181,12 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>advancedBlendMaxColorAttachments</name><limit supported="1" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendIndependentBlend</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedSrcColor</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedDstColor</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendCorrelatedOverlap</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendAllOperations</name><limit supported="false" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>advancedBlendMaxColorAttachments</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendIndependentBlend</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedSrcColor</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedDstColor</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendCorrelatedOverlap</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendAllOperations</name></member>
         </type>
         <type category="struct" name="VkPipelineColorBlendAdvancedStateCreateInfoEXT" structextends="VkPipelineColorBlendStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3254,11 +3204,11 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceInlineUniformBlockPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxInlineUniformBlockSize</name><limit supported="256" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorInlineUniformBlocks</name><limit supported="4" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks</name><limit supported="4" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetInlineUniformBlocks</name><limit supported="4" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindInlineUniformBlocks</name><limit supported="4" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxInlineUniformBlockSize</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorInlineUniformBlocks</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetInlineUniformBlocks</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindInlineUniformBlocks</name></member>
         </type>
         <type category="struct" name="VkWriteDescriptorSetInlineUniformBlockEXT" structextends="VkWriteDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3302,12 +3252,8 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMaintenance3Properties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerSetDescriptors</name>
-                <limit supported="1024" />
-            </member>
-            <member limittype="max"><type>VkDeviceSize</type>                     <name>maxMemoryAllocationSize</name>
-                <limit supported="1073741824" />
-            </member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerSetDescriptors</name></member>
+            <member limittype="max"><type>VkDeviceSize</type>                     <name>maxMemoryAllocationSize</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMaintenance3PropertiesKHR"               alias="VkPhysicalDeviceMaintenance3Properties"/>
         <type category="struct" name="VkDescriptorSetLayoutSupport" returnedonly="true">
@@ -3495,22 +3441,20 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceExternalMemoryHostPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>* <name>pNext</name></member>
-            <member limittype="noauto"><type>VkDeviceSize</type> <name>minImportedHostPointerAlignment</name>
-                <limit supported="65536" />
-            </member>
+            <member limittype="noauto"><type>VkDeviceSize</type> <name>minImportedHostPointerAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="noauto"><type>float</type>                  <name>primitiveOverestimationSize</name><comment>The size in pixels the primitive is enlarged at each edge during conservative rasterization</comment><limit supported="0.0" /></member>
-            <member limittype="max"><type>float</type>                  <name>maxExtraPrimitiveOverestimationSize</name><comment>The maximum additional overestimation the client can specify in the pipeline state</comment><limit supported="0.0" /></member>
-            <member limittype="noauto"><type>float</type>                  <name>extraPrimitiveOverestimationSizeGranularity</name><comment>The granularity of extra overestimation sizes the implementations supports between 0 and maxExtraOverestimationSize</comment><limit supported="0.0" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>primitiveUnderestimation</name><comment>true if the implementation supports conservative rasterization underestimation mode</comment><limit supported="false" /></member>
-            <member limittype="noauto"><type>VkBool32</type>               <name>conservativePointAndLineRasterization</name><comment>true if conservative rasterization also applies to points and lines</comment><limit supported="false" /></member>
-            <member limittype="noauto"><type>VkBool32</type>               <name>degenerateTrianglesRasterized</name><comment>true if degenerate triangles (those with zero area after snap) are rasterized</comment><limit supported="false" /></member>
-            <member limittype="noauto"><type>VkBool32</type>               <name>degenerateLinesRasterized</name><comment>true if degenerate lines (those with zero length after snap) are rasterized</comment><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fullyCoveredFragmentShaderInputVariable</name><comment>true if the implementation supports the FullyCoveredEXT SPIR-V builtin fragment shader input variable</comment><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>conservativeRasterizationPostDepthCoverage</name><comment>true if the implementation supports both conservative rasterization and post depth coverage sample coverage mask</comment><limit supported="false" /></member>
+            <member limittype="noauto"><type>float</type>                  <name>primitiveOverestimationSize</name><comment>The size in pixels the primitive is enlarged at each edge during conservative rasterization</comment></member>
+            <member limittype="max"><type>float</type>                  <name>maxExtraPrimitiveOverestimationSize</name><comment>The maximum additional overestimation the client can specify in the pipeline state</comment></member>
+            <member limittype="noauto"><type>float</type>                  <name>extraPrimitiveOverestimationSizeGranularity</name><comment>The granularity of extra overestimation sizes the implementations supports between 0 and maxExtraOverestimationSize</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>primitiveUnderestimation</name><comment>true if the implementation supports conservative rasterization underestimation mode</comment></member>
+            <member limittype="noauto"><type>VkBool32</type>               <name>conservativePointAndLineRasterization</name><comment>true if conservative rasterization also applies to points and lines</comment></member>
+            <member limittype="noauto"><type>VkBool32</type>               <name>degenerateTrianglesRasterized</name><comment>true if degenerate triangles (those with zero area after snap) are rasterized</comment></member>
+            <member limittype="noauto"><type>VkBool32</type>               <name>degenerateLinesRasterized</name><comment>true if degenerate lines (those with zero length after snap) are rasterized</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fullyCoveredFragmentShaderInputVariable</name><comment>true if the implementation supports the FullyCoveredEXT SPIR-V builtin fragment shader input variable</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>conservativeRasterizationPostDepthCoverage</name><comment>true if the implementation supports both conservative rasterization and post depth coverage sample coverage mask</comment></member>
         </type>
         <type category="struct" name="VkCalibratedTimestampInfoEXT">
             <member values="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3576,29 +3520,29 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxUpdateAfterBindDescriptorsInAllPools</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderUniformBufferArrayNonUniformIndexingNative</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderSampledImageArrayNonUniformIndexingNative</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderStorageBufferArrayNonUniformIndexingNative</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderStorageImageArrayNonUniformIndexingNative</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderInputAttachmentArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxUpdateAfterBindDescriptorsInAllPools</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderUniformBufferArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderSampledImageArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderStorageBufferArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderStorageImageArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderInputAttachmentArrayNonUniformIndexingNative</name></member>
             <member limittype="bitmask"><type>VkBool32</type>               <name>robustBufferAccessUpdateAfterBind</name></member>
             <member limittype="bitmask"><type>VkBool32</type>               <name>quadDivergentImplicitLod</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindSamplers</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name><limit supported="12" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name><limit supported="4" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageUpdateAfterBindResources</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindSamplers</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name><limit supported="72" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name><limit supported="8" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name><limit supported="4" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindSampledImages</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageImages</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindInputAttachments</name><limit supported="4" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindSamplers</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageUpdateAfterBindResources</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindSamplers</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindSampledImages</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageImages</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindInputAttachments</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingPropertiesEXT"         alias="VkPhysicalDeviceDescriptorIndexingProperties"/>
         <type category="struct" name="VkDescriptorSetLayoutBindingFlagsCreateInfo" structextends="VkDescriptorSetLayoutCreateInfo">
@@ -3706,7 +3650,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceTimelineSemaphoreProperties" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint64_t</type>               <name>maxTimelineSemaphoreValueDifference</name><limit supported="2147483647" /></member>
+            <member limittype="max"><type>uint64_t</type>               <name>maxTimelineSemaphoreValueDifference</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTimelineSemaphorePropertiesKHR"          alias="VkPhysicalDeviceTimelineSemaphoreProperties"/>
         <type category="struct" name="VkSemaphoreTypeCreateInfo" structextends="VkSemaphoreCreateInfo,VkPhysicalDeviceExternalSemaphoreInfo">
@@ -3754,7 +3698,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexAttribDivisor</name><comment>max value of vertex attribute divisor</comment><limit supported="65535" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexAttribDivisor</name><comment>max value of vertex attribute divisor</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePCIBusInfoPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3921,16 +3865,16 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceTransformFeedbackPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackStreams</name><limit supported="1" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackBuffers</name><limit supported="1" /></member>
-            <member limittype="max"><type>VkDeviceSize</type>           <name>maxTransformFeedbackBufferSize</name><limit supported="134217728" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackStreamDataSize</name><limit supported="512" /></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackBufferDataSize</name><limit supported="512" /></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxTransformFeedbackBufferDataStride</name><limit supported="512" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackQueries</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackStreamsLinesTriangles</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackRasterizationStreamSelect</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackDraw</name><limit supported="false" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackStreams</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackBuffers</name></member>
+            <member limittype="max"><type>VkDeviceSize</type>           <name>maxTransformFeedbackBufferSize</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackStreamDataSize</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackBufferDataSize</name></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxTransformFeedbackBufferDataStride</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackQueries</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackStreamsLinesTriangles</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackRasterizationStreamSelect</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackDraw</name></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationStateStreamCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -4041,17 +3985,17 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMeshShaderPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                               <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxDrawMeshTasksCount</name><limit supported="65535" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskWorkGroupInvocations</name><limit supported="32" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskWorkGroupSize</name>[3]<limit supported="32" /><limit supported="1" /><limit supported="1" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskTotalMemorySize</name><limit supported="16384" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskOutputCount</name><limit supported="65535" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshWorkGroupInvocations</name><limit supported="32" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshWorkGroupSize</name>[3]<limit supported="32" /><limit supported="1" /><limit supported="1" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshTotalMemorySize</name><limit supported="16384" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshOutputVertices</name><limit supported="256" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshOutputPrimitives</name><limit supported="256" /></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshMultiviewViewCount</name><limit supported="1" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDrawMeshTasksCount</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskWorkGroupInvocations</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskWorkGroupSize</name>[3]</member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskTotalMemorySize</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskOutputCount</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshWorkGroupInvocations</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshWorkGroupSize</name>[3]</member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshTotalMemorySize</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshOutputVertices</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshOutputPrimitives</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshMultiviewViewCount</name></member>
             <member limittype="noauto"><type>uint32_t</type>                            <name>meshOutputPerVertexGranularity</name></member>
             <member limittype="noauto"><type>uint32_t</type>                            <name>meshOutputPerPrimitiveGranularity</name></member>
         </type>
@@ -4209,38 +4153,38 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceAccelerationStructurePropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*            <name>pNext</name></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxGeometryCount</name><limit supported="16777215" /></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxInstanceCount</name><limit supported="16777215" /></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxPrimitiveCount</name><limit supported="536870911" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorAccelerationStructures</name><limit supported="16" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindAccelerationStructures</name><limit supported="500000" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetAccelerationStructures</name><limit supported="16" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindAccelerationStructures</name><limit supported="500000" /></member>
-            <member limittype="min"><type>uint32_t</type>                         <name>minAccelerationStructureScratchOffsetAlignment</name><limit supported="256" /></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxGeometryCount</name></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxInstanceCount</name></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxPrimitiveCount</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorAccelerationStructures</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindAccelerationStructures</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetAccelerationStructures</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindAccelerationStructures</name></member>
+            <member limittype="min"><type>uint32_t</type>                         <name>minAccelerationStructureScratchOffsetAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*            <name>pNext</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleSize</name><limit supported="16" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxRayRecursionDepth</name><limit supported="31" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxShaderGroupStride</name><limit supported="4096" /></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupBaseAlignment</name><limit supported="64" /></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleCaptureReplaySize</name><limit supported="64" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxRayDispatchInvocationCount</name><limit supported="1073741824" /></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleAlignment</name><limit supported="32" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxRayHitAttributeSize</name><limit supported="32" /></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleSize</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxRayRecursionDepth</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxShaderGroupStride</name></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupBaseAlignment</name></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleCaptureReplaySize</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxRayDispatchInvocationCount</name></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleAlignment</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxRayHitAttributeSize</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRayTracingPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleSize</name><limit supported="16" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxRecursionDepth</name><limit supported="31" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxShaderGroupStride</name><limit supported="4096" /></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupBaseAlignment</name><limit supported="64" /></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxGeometryCount</name><limit supported="16777215" /></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxInstanceCount</name><limit supported="16777215" /></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxTriangleCount</name><limit supported="536870911" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetAccelerationStructures</name><limit supported="16" /></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleSize</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxRecursionDepth</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxShaderGroupStride</name></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupBaseAlignment</name></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxGeometryCount</name></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxInstanceCount</name></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxTriangleCount</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetAccelerationStructures</name></member>
         </type>
         <type category="struct" name="VkStridedDeviceAddressRegionKHR">
             <member optional="true"><type>VkDeviceAddress</type>  <name>deviceAddress</name></member>
@@ -4315,17 +4259,17 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceFragmentDensityMapPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="min"><type>VkExtent2D</type>                       <name>minFragmentDensityTexelSize</name><limit supported="1" /><limit supported="1" /></member>
-            <member limittype="max"><type>VkExtent2D</type>                       <name>maxFragmentDensityTexelSize</name><limit supported="1" /><limit supported="1" /></member>
+            <member limittype="min"><type>VkExtent2D</type>                       <name>minFragmentDensityTexelSize</name></member>
+            <member limittype="max"><type>VkExtent2D</type>                       <name>maxFragmentDensityTexelSize</name></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>fragmentDensityInvocations</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentDensityMap2PropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                          <name>pNext</name></member>
-            <member limittype="noauto"><type>VkBool32</type>                       <name>subsampledLoads</name><limit supported="false" unsupported="true" /></member>
-            <member limittype="noauto"><type>VkBool32</type>                       <name>subsampledCoarseReconstructionEarlyAccess</name><limit supported="false" unsupported="false" /></member>
-            <member limittype="max"><type>uint32_t</type>                       <name>maxSubsampledArrayLayers</name><limit supported="2" unsupported="2" /></member>
-            <member limittype="max"><type>uint32_t</type>                       <name>maxDescriptorSetSubsampledSamplers</name><limit supported="1" unsupported="1" /></member>
+            <member limittype="noauto"><type>VkBool32</type>                       <name>subsampledLoads</name></member>
+            <member limittype="noauto"><type>VkBool32</type>                       <name>subsampledCoarseReconstructionEarlyAccess</name></member>
+            <member limittype="max"><type>uint32_t</type>                       <name>maxSubsampledArrayLayers</name></member>
+            <member limittype="max"><type>uint32_t</type>                       <name>maxDescriptorSetSubsampledSamplers</name></member>
         </type>
         <type category="struct" name="VkRenderPassFragmentDensityMapCreateInfoEXT" structextends="VkRenderPassCreateInfo,VkRenderPassCreateInfo2">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -4803,7 +4747,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceSubpassShadingPropertiesHUAWEI" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxSubpassShadingWorkgroupSizeAspectRatio</name><limit supported="1" unsupported="0" /></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxSubpassShadingWorkgroupSizeAspectRatio</name></member>
         </type>
         <type category="struct" name="VkMemoryOpaqueCaptureAddressAllocateInfo" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -4830,7 +4774,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceLineRasterizationPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                               <name>pNext</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                            <name>lineSubPixelPrecisionBits</name><limit supported="4" /></member>
+            <member limittype="noauto"><type>uint32_t</type>                            <name>lineSubPixelPrecisionBits</name></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationLineStateCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -4874,19 +4818,11 @@ typedef void <name>CAMetalLayer</name>;
             <member limittype="bitmask" noautovalidity="true"><type>VkSubgroupFeatureFlags</type>        <name>subgroupSupportedOperations</name><comment>Bitfield of what subgroup operations are supported.</comment></member>
             <member limittype="bitmask" noautovalidity="true"><type>VkBool32</type>                      <name>subgroupQuadOperationsInAllStages</name><comment>Flag to specify whether quad operations are available in all stages.</comment></member>
             <member limittype="noauto"><type>VkPointClippingBehavior</type>          <name>pointClippingBehavior</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment>
-                <limit supported="6" />
-            </member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment>
-                <limit supported="13421771" />
-            </member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment></member>
             <member limittype="noauto"><type>VkBool32</type>                         <name>protectedNoFault</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerSetDescriptors</name>
-                <limit supported="1024" />
-            </member>
-            <member limittype="max"><type>VkDeviceSize</type>                     <name>maxMemoryAllocationSize</name>
-                <limit supported="1073741824" />
-            </member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerSetDescriptors</name></member>
+            <member limittype="max"><type>VkDeviceSize</type>                     <name>maxMemoryAllocationSize</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan12Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES"><type>VkStructureType</type><name>sType</name></member>
@@ -4963,37 +4899,37 @@ typedef void <name>CAMetalLayer</name>;
             <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTZFloat16</name><comment>An implementation can support RTZ</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTZFloat32</name><comment>An implementation can support RTZ</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTZFloat64</name><comment>An implementation can support RTZ</comment></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxUpdateAfterBindDescriptorsInAllPools</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderUniformBufferArrayNonUniformIndexingNative</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderSampledImageArrayNonUniformIndexingNative</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageBufferArrayNonUniformIndexingNative</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageImageArrayNonUniformIndexingNative</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderInputAttachmentArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxUpdateAfterBindDescriptorsInAllPools</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderUniformBufferArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderSampledImageArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageBufferArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageImageArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderInputAttachmentArrayNonUniformIndexingNative</name></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>robustBufferAccessUpdateAfterBind</name></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>quadDivergentImplicitLod</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSamplers</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name><limit supported="12" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name><limit supported="4" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageUpdateAfterBindResources</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSamplers</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name><limit supported="72" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name><limit supported="8" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name><limit supported="4" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSampledImages</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageImages</name><limit supported="500000" unsupported="0" /></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindInputAttachments</name><limit supported="4" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSamplers</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageUpdateAfterBindResources</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSamplers</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSampledImages</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageImages</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindInputAttachments</name></member>
             <member limittype="bitmask"><type>VkResolveModeFlags</type>               <name>supportedDepthResolveModes</name><comment>supported depth resolve modes</comment></member>
             <member limittype="bitmask"><type>VkResolveModeFlags</type>               <name>supportedStencilResolveModes</name><comment>supported stencil resolve modes</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>independentResolveNone</name><comment>depth and stencil resolve modes can be set independently if one of them is none</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>independentResolve</name><comment>depth and stencil resolve modes can be set independently</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxSingleComponentFormats</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxImageComponentMapping</name><limit supported="false" /></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxTimelineSemaphoreValueDifference</name><limit supported="2147483647" /></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type> <name>framebufferIntegerColorSampleCounts</name><limit supported="VK_SAMPLE_COUNT_1_BIT" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxSingleComponentFormats</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxImageComponentMapping</name></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxTimelineSemaphoreValueDifference</name></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type> <name>framebufferIntegerColorSampleCounts</name></member>
         </type>
         <type category="struct" name="VkPipelineCompilerControlCreateInfoAMD" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD"><type>VkStructureType</type>   <name>sType</name></member>
@@ -5023,7 +4959,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                                                                   <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                                                                                      <name>maxCustomBorderColorSamplers</name><limit supported="32" /></member>
+            <member limittype="max"><type>uint32_t</type>                                                                                      <name>maxCustomBorderColorSamplers</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -5227,8 +5163,8 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceRobustness2PropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>                       <name>robustStorageBufferAccessSizeAlignment</name><limit supported="4" /></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>                       <name>robustUniformBufferAccessSizeAlignment</name><limit supported="256" /></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>                       <name>robustStorageBufferAccessSizeAlignment</name></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>                       <name>robustUniformBufferAccessSizeAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceImageRobustnessFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -5265,7 +5201,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDevicePortabilitySubsetPropertiesKHR" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                           <name>minVertexInputBindingStrideAlignment</name></member>
+            <member limittype="min"><type>uint32_t</type>                           <name>minVertexInputBindingStrideAlignment</name></member>
         </type>
         <type category="struct" name="VkPhysicalDevice4444FormatsFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -5406,23 +5342,23 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="min"><type>VkExtent2D</type>             <name>minFragmentShadingRateAttachmentTexelSize</name><limit supported="32" unsupported="0" /><limit supported="32" unsupported="0" /></member>
-            <member limittype="max"><type>VkExtent2D</type>             <name>maxFragmentShadingRateAttachmentTexelSize</name><limit supported="8" unsupported="0" /><limit supported="8" unsupported="0" /></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentShadingRateAttachmentTexelSizeAspectRatio</name><limit supported="1" unsupported="0" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>primitiveFragmentShadingRateWithMultipleViewports</name><limit supported="false" unsupported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>layeredShadingRateAttachments</name><limit supported="false" unsupported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateNonTrivialCombinerOps</name><limit supported="false" /></member>
-            <member limittype="max"><type>VkExtent2D</type>             <name>maxFragmentSize</name><limit supported="2" /><limit supported="2" /></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentSizeAspectRatio</name><limit supported="2" /></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentShadingRateCoverageSamples</name><limit supported="16" /></member>
-            <member limittype="max"><type>VkSampleCountFlagBits</type>  <name>maxFragmentShadingRateRasterizationSamples</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithShaderDepthStencilWrites</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithSampleMask</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithShaderSampleMask</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithConservativeRasterization</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithFragmentShaderInterlock</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithCustomSampleLocations</name><limit supported="false" /></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateStrictMultiplyCombiner</name><limit supported="false" /></member>
+            <member limittype="min"><type>VkExtent2D</type>             <name>minFragmentShadingRateAttachmentTexelSize</name></member>
+            <member limittype="max"><type>VkExtent2D</type>             <name>maxFragmentShadingRateAttachmentTexelSize</name></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentShadingRateAttachmentTexelSizeAspectRatio</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>primitiveFragmentShadingRateWithMultipleViewports</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>layeredShadingRateAttachments</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateNonTrivialCombinerOps</name></member>
+            <member limittype="max"><type>VkExtent2D</type>             <name>maxFragmentSize</name></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentSizeAspectRatio</name></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentShadingRateCoverageSamples</name></member>
+            <member limittype="max"><type>VkSampleCountFlagBits</type>  <name>maxFragmentShadingRateRasterizationSamples</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithShaderDepthStencilWrites</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithSampleMask</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithShaderSampleMask</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithConservativeRasterization</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithFragmentShaderInterlock</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithCustomSampleLocations</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateStrictMultiplyCombiner</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRateKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -5445,7 +5381,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                              <name>pNext</name></member>
-            <member limittype="bitmask"><type>VkSampleCountFlagBits</type>              <name>maxFragmentShadingRateInvocationCount</name><limit supported="VK_SAMPLE_COUNT_4_BIT" /></member>
+            <member limittype="bitmask"><type>VkSampleCountFlagBits</type>              <name>maxFragmentShadingRateInvocationCount</name></member>
         </type>
         <type category="struct" name="VkPipelineFragmentShadingRateEnumStateCreateInfoNV" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
@@ -17429,4 +17365,500 @@ typedef void <name>CAMetalLayer</name>;
             <enable struct="VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR" feature="shaderIntegerDotProduct" requires="VK_KHR_shader_integer_dot_product"/>
         </spirvcapability>
     </spirvcapabilities>
+    <requirements name="VK_MINIMUM_REQUIREMENTS">
+        <limit type="VkPhysicalDeviceLimits" name="maxImageDimension1D"><value supported="4096" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxImageDimension2D"><value supported="4096" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxImageDimension3D"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxImageDimensionCube"><value supported="4096" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxImageArrayLayers"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxTexelBufferElements"><value supported="65536" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxUniformBufferRange"><value supported="65536" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxStorageBufferRange"><value supported="134217728" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxPushConstantsSize"><value supported="128" /></limit>
+
+        <limit type="VkPhysicalDeviceLimits" name="maxMemoryAllocationCount"><value supported="4096" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxSamplerAllocationCount"><value supported="4000" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="bufferImageGranularity"><value supported="131072" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="sparseAddressSpaceSize"><value supported="2147483648"  unsupported="0" /></limit>
+
+        <limit type="VkPhysicalDeviceLimits" name="maxBoundDescriptorSets"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxPerStageDescriptorSamplers"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxPerStageDescriptorUniformBuffers"><value supported="12" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxPerStageDescriptorStorageBuffers"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxPerStageDescriptorSampledImages"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxPerStageDescriptorStorageImages"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxPerStageDescriptorInputAttachments"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxPerStageResources"><value supported="128" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDescriptorSetSamplers"><value supported="96" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDescriptorSetUniformBuffers"><value supported="72" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDescriptorSetUniformBuffersDynamic"><value supported="8" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDescriptorSetStorageBuffers"><value supported="24" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDescriptorSetStorageBuffersDynamic"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDescriptorSetSampledImages"><value supported="96" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDescriptorSetStorageImages"><value supported="24" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDescriptorSetInputAttachments"><value supported="4" /></limit>
+
+        <limit type="VkPhysicalDeviceLimits" name="maxVertexInputAttributes"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxVertexInputBindings"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxVertexInputAttributeOffset"><value supported="2047" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxVertexInputBindingStride"><value supported="2048" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxVertexOutputComponents"><value supported="64" /></limit>
+
+        <limit type="VkPhysicalDeviceLimits" name="maxTessellationGenerationLevel"><value supported="64" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxTessellationPatchSize"><value supported="32" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxTessellationControlPerVertexInputComponents"><value supported="64" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxTessellationControlPerVertexOutputComponents"><value supported="64" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxTessellationControlPerPatchOutputComponents"><value supported="120" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxTessellationControlTotalOutputComponents"><value supported="2048" unsupported="0" /></limit>
+
+        <limit type="VkPhysicalDeviceLimits" name="maxTessellationEvaluationInputComponents"><value supported="64" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxTessellationEvaluationOutputComponents"><value supported="64" unsupported="0" /></limit>
+
+        <limit type="VkPhysicalDeviceLimits" name="maxGeometryShaderInvocations"><value supported="32" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxGeometryInputComponents"><value supported="64" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxGeometryOutputComponents"><value supported="64" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxGeometryOutputVertices"><value supported="256" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxGeometryTotalOutputComponents"><value supported="1024" unsupported="0" /></limit>
+
+        <limit type="VkPhysicalDeviceLimits" name="maxFragmentInputComponents"><value supported="64" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxFragmentOutputAttachments"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxFragmentDualSrcAttachments"><value supported="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxFragmentCombinedOutputResources"><value supported="4" unsupported="0" /></limit>
+
+        <limit type="VkPhysicalDeviceLimits" name="maxComputeSharedMemorySize"><value supported="16384" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxComputeWorkGroupCount"><value supported="65536" index="0" /><value supported="65536" index="1" /><value supported="65536" index="2" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxComputeWorkGroupInvocations"><value supported="128" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxComputeWorkGroupSize"><value supported="128" index="0" /><value supported="128" index="1" /><value supported="64" index="2" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="subPixelPrecisionBits"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="subTexelPrecisionBits"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="mipmapPrecisionBits"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDrawIndexedIndexValue"><value supported="4294967295" unsupported="16777215" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxDrawIndirectCount"><value supported="65535" unsupported="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxSamplerLodBias"><value supported="2.0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxSamplerAnisotropy"><value supported="16.0" unsupported="1.0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxViewports"><value supported="16" unsupported="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxViewportDimensions"><value supported="4096" index="0" /><value supported="4096" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="viewportBoundsRange"><value supported="-8192.0" index="0" /><value supported="8192.0" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="viewportSubPixelBits"><value supported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="minMemoryMapAlignment"><value supported="64" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="minTexelBufferOffsetAlignment"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="minUniformBufferOffsetAlignment"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="minStorageBufferOffsetAlignment"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="minTexelOffset"><value supported="-8" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxTexelOffset"><value supported="7" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="minTexelGatherOffset"><value supported="-8" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxTexelGatherOffset"><value supported="7" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="minInterpolationOffset"><value supported="-0.5" unsupported="0.0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxInterpolationOffset"><value supported="0.5" unsupported="0.0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="subPixelInterpolationOffsetBits"><value supported="4" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxFramebufferWidth"><value supported="4096" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxFramebufferHeight"><value supported="4096" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxFramebufferLayers"><value supported="256" /></limit>
+
+        <limit type="VkPhysicalDeviceLimits" name="framebufferColorSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" index="0" /><value supported="VK_SAMPLE_COUNT_4_BIT" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="framebufferDepthSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" index="0" /><value supported="VK_SAMPLE_COUNT_4_BIT" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="framebufferStencilSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" index="0" /><value supported="VK_SAMPLE_COUNT_4_BIT" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="framebufferNoAttachmentsSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" index="0" /><value supported="VK_SAMPLE_COUNT_4_BIT" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxColorAttachments"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="sampledImageColorSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" index="0" /><value supported="VK_SAMPLE_COUNT_4_BIT" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="sampledImageIntegerSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" index="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="sampledImageDepthSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" index="0" /><value supported="VK_SAMPLE_COUNT_4_BIT" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="sampledImageStencilSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" index="0" /><value supported="VK_SAMPLE_COUNT_4_BIT" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="storageImageSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" unsupported="VK_SAMPLE_COUNT_1_BIT" index="0" /><value supported="VK_SAMPLE_COUNT_4_BIT" index="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxSampleMaskWords"><value supported="1" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxClipDistances"><value supported="8" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxCullDistances"><value supported="8" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="maxCombinedClipAndCullDistances"><value supported="8" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="discreteQueuePriorities"><value supported="2" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="pointSizeRange"><value supported="1.0" unsupported="1.0" /><value supported="64.0 - ULP" unsupported="1.0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="lineWidthRange"><value supported="1.0" unsupported="1.0" /><value supported="8.0 - ULP" unsupported="1.0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="pointSizeGranularity"><value supported="1.0" unsupported="0.0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="lineWidthGranularity"><value supported="1.0" unsupported="0.0" /></limit>
+        <limit type="VkPhysicalDeviceLimits" name="nonCoherentAtomSize"><value supported="256" /></limit>
+
+        <limit type="VkPhysicalDeviceSparseProperties" name="residencyStandard2DBlockShape"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceSparseProperties" name="residencyStandard2DMultisampleBlockShape"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceSparseProperties" name="residencyStandard3DBlockShape"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceSparseProperties" name="residencyAlignedMipSize"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceSparseProperties" name="residencyNonResidentStrict"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceMultiviewProperties" name="maxMultiviewViewCount"><value supported="6" /></limit>
+        <limit type="VkPhysicalDeviceMultiviewProperties" name="maxMultiviewInstanceIndex"><value supported="13421771" /></limit>
+
+        <limit type="VkPhysicalDeviceDriverProperties" name="driverID" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceDriverProperties" name="driverName" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceDriverProperties" name="driverInfo" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceDriverProperties" name="conformanceVersion" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceIDProperties" name="deviceUUID" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceIDProperties" name="driverUUID" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceIDProperties" name="deviceLUID" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceIDProperties" name="deviceNodeMask" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceIDProperties" name="deviceLUIDValid" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceSamplerFilterMinmaxProperties" name="filterMinmaxSingleComponentFormats"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceSamplerFilterMinmaxProperties" name="filterMinmaxImageComponentMapping"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="deviceUUID" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="driverUUID" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="deviceLUID" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="deviceNodeMask" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="deviceLUIDValid" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="subgroupSize" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="subgroupSupportedStages"><value supported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="subgroupSupportedOperations"><value supported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="subgroupQuadOperationsInAllStages"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="pointClippingBehavior" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="maxMultiviewViewCount"><value supported="6" /></limit>
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="maxMultiviewInstanceIndex"><value supported="13421771" /></limit>
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="protectedNoFault" implementation-dependent="true"></limit>
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="maxPerSetDescriptors"><value supported="1024" /></limit>
+        <limit type="VkPhysicalDeviceVulkan11Properties" name="maxMemoryAllocationSize"><value supported="1073741824" /></limit>
+
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="denormBehaviorIndependence" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="roundingModeIndependence" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderSignedZeroInfNanPreserveFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderSignedZeroInfNanPreserveFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderSignedZeroInfNanPreserveFloat64"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderDenormPreserveFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderDenormPreserveFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderDenormPreserveFloat64"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderDenormFlushToZeroFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderDenormFlushToZeroFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderDenormFlushToZeroFloat64"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderRoundingModeRTEFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderRoundingModeRTEFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderRoundingModeRTEFloat64"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderRoundingModeRTZFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderRoundingModeRTZFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderRoundingModeRTZFloat64"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxUpdateAfterBindDescriptorsInAllPools"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderUniformBufferArrayNonUniformIndexingNative"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderSampledImageArrayNonUniformIndexingNative"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderStorageBufferArrayNonUniformIndexingNative"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="shaderInputAttachmentArrayNonUniformIndexingNative"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="robustBufferAccessUpdateAfterBind"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="quadDivergentImplicitLod" implementation-dependent="true"></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxPerStageDescriptorUpdateAfterBindSamplers"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxPerStageDescriptorUpdateAfterBindUniformBuffers"><value supported="12" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxPerStageDescriptorUpdateAfterBindStorageBuffers"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxPerStageDescriptorUpdateAfterBindSampledImages"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxPerStageDescriptorUpdateAfterBindStorageImages"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxPerStageDescriptorUpdateAfterBindInputAttachments"><value supported="4" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxPerStageUpdateAfterBindResources"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxDescriptorSetUpdateAfterBindSamplers"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxDescriptorSetUpdateAfterBindUniformBuffers"><value supported="72" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxDescriptorSetUpdateAfterBindUniformBuffersDynamic"><value supported="8" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxDescriptorSetUpdateAfterBindStorageBuffers"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxDescriptorSetUpdateAfterBindStorageBuffersDynamic"><value supported="4" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxDescriptorSetUpdateAfterBindSampledImages"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxDescriptorSetUpdateAfterBindStorageImages"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxDescriptorSetUpdateAfterBindInputAttachments"><value supported="4" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="supportedDepthResolveModes"><value supported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="supportedStencilResolveModes"><value supported="0" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="independentResolveNone"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="independentResolve"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="filterMinmaxSingleComponentFormats"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="filterMinmaxImageComponentMapping"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="maxTimelineSemaphoreValueDifference"><value supported="2147483647" /></limit>
+        <limit type="VkPhysicalDeviceVulkan12Properties" name="framebufferIntegerColorSampleCounts"><value supported="VK_SAMPLE_COUNT_1_BIT" /></limit>
+
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="denormBehaviorIndependence" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="roundingModeIndependence" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderSignedZeroInfNanPreserveFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderSignedZeroInfNanPreserveFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderSignedZeroInfNanPreserveFloat64"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderDenormPreserveFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderDenormPreserveFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderDenormPreserveFloat64"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderDenormFlushToZeroFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderDenormFlushToZeroFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderDenormFlushToZeroFloat64"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderRoundingModeRTEFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderRoundingModeRTEFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderRoundingModeRTEFloat64"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderRoundingModeRTZFloat16"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderRoundingModeRTZFloat32"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFloatControlsProperties" name="shaderRoundingModeRTZFloat64"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceSubgroupProperties" name="subgroupSize" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceSubgroupProperties" name="supportedStages"><value supported="0" /></limit>
+        <limit type="VkPhysicalDeviceSubgroupProperties" name="supportedOperations"><value supported="0" /></limit>
+        <limit type="VkPhysicalDeviceSubgroupProperties" name="quadOperationsInAllStages"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDevicePointClippingProperties" name="pointClippingBehavior" implementation-dependent="true" />
+
+        <limit type="VkMemoryDedicatedRequirements" name="prefersDedicatedAllocation" implementation-dependent="true" />
+        <limit type="VkMemoryDedicatedRequirements" name="requiresDedicatedAllocation" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceMaintenance3Properties" name="maxPerSetDescriptors"><value supported="1024" /></limit>
+        <limit type="VkPhysicalDeviceMaintenance3Properties" name="maxMemoryAllocationSize"><value supported="1073741824" /></limit>
+
+        <limit type="VkPhysicalDeviceTimelineSemaphoreProperties" name="maxTimelineSemaphoreValueDifference"><value supported="2147483647" /></limit>
+
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxUpdateAfterBindDescriptorsInAllPools"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="shaderUniformBufferArrayNonUniformIndexingNative"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="shaderSampledImageArrayNonUniformIndexingNative"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="shaderStorageBufferArrayNonUniformIndexingNative"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="shaderInputAttachmentArrayNonUniformIndexingNative"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="robustBufferAccessUpdateAfterBind"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="quadDivergentImplicitLod" implementation-dependent="true"></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxPerStageDescriptorUpdateAfterBindSamplers"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxPerStageDescriptorUpdateAfterBindUniformBuffers"><value supported="12" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxPerStageDescriptorUpdateAfterBindStorageBuffers"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxPerStageDescriptorUpdateAfterBindSampledImages"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxPerStageDescriptorUpdateAfterBindStorageImages"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxPerStageDescriptorUpdateAfterBindInputAttachments"><value supported="4" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxPerStageUpdateAfterBindResources"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxDescriptorSetUpdateAfterBindSamplers"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxDescriptorSetUpdateAfterBindUniformBuffers"><value supported="72" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxDescriptorSetUpdateAfterBindUniformBuffersDynamic"><value supported="8" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxDescriptorSetUpdateAfterBindStorageBuffers"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxDescriptorSetUpdateAfterBindStorageBuffersDynamic"><value supported="4" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxDescriptorSetUpdateAfterBindSampledImages"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxDescriptorSetUpdateAfterBindStorageImages"><value supported="500000" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceDescriptorIndexingProperties" name="maxDescriptorSetUpdateAfterBindInputAttachments"><value supported="4" unsupported="0" /></limit>
+
+        <limit type="VkPhysicalDeviceDepthStencilResolveProperties" name="supportedDepthResolveModes"><value supported="0" /></limit>
+        <limit type="VkPhysicalDeviceDepthStencilResolveProperties" name="supportedStencilResolveModes"><value supported="0" /></limit>
+        <limit type="VkPhysicalDeviceDepthStencilResolveProperties" name="independentResolveNone"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceDepthStencilResolveProperties" name="independentResolve"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="minFragmentShadingRateAttachmentTexelSize"><value supported="32" unsupported="0" index="0" /><value supported="32" unsupported="0" index="1" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="maxFragmentShadingRateAttachmentTexelSize"><value supported="8" unsupported="0" index="0" /><value supported="8" unsupported="0" index="1" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="maxFragmentShadingRateAttachmentTexelSizeAspectRatio"><value supported="1" unsupported="0" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="primitiveFragmentShadingRateWithMultipleViewports"><value supported="false" unsupported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="layeredShadingRateAttachments"><value supported="false" unsupported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateNonTrivialCombinerOps"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="maxFragmentSize"><value supported="2" /><value supported="2" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="maxFragmentSizeAspectRatio"><value supported="2" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="maxFragmentShadingRateCoverageSamples"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="maxFragmentShadingRateRasterizationSamples"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateWithShaderDepthStencilWrites"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateWithSampleMask"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateWithShaderSampleMask"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateWithConservativeRasterization"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateWithFragmentShaderInterlock"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateWithCustomSampleLocations"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateStrictMultiplyCombiner"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateStrictMultiplyCombiner"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" name="fragmentShadingRateStrictMultiplyCombiner"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDevicePushDescriptorPropertiesKHR" name="maxPushDescriptors"><value supported="32" /></limit>
+
+        <limit type="VkPhysicalDeviceAccelerationStructurePropertiesKHR" name="maxGeometryCount"><value supported="16777215" /></limit>
+        <limit type="VkPhysicalDeviceAccelerationStructurePropertiesKHR" name="maxInstanceCount"><value supported="16777215" /></limit>
+        <limit type="VkPhysicalDeviceAccelerationStructurePropertiesKHR" name="maxPrimitiveCount"><value supported="536870911" /></limit>
+        <limit type="VkPhysicalDeviceAccelerationStructurePropertiesKHR" name="maxPerStageDescriptorAccelerationStructures"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceAccelerationStructurePropertiesKHR" name="maxPerStageDescriptorUpdateAfterBindAccelerationStructures"><value supported="500000" /></limit>
+        <limit type="VkPhysicalDeviceAccelerationStructurePropertiesKHR" name="maxDescriptorSetAccelerationStructures"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceAccelerationStructurePropertiesKHR" name="maxDescriptorSetUpdateAfterBindAccelerationStructures"><value supported="500000" /></limit>
+        <limit type="VkPhysicalDeviceAccelerationStructurePropertiesKHR" name="minAccelerationStructureScratchOffsetAlignment"><value supported="256" /></limit>
+
+        <limit type="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" name="shaderGroupHandleSize"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" name="maxRayRecursionDepth"><value supported="31" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" name="maxShaderGroupStride"><value supported="4096" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" name="shaderGroupBaseAlignment"><value supported="64" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" name="shaderGroupHandleCaptureReplaySize"><value supported="64" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" name="maxRayDispatchInvocationCount"><value supported="1073741824" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" name="shaderGroupHandleAlignment"><value supported="32" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" name="maxRayHitAttributeSize"><value supported="32" /></limit>
+
+        <limit type="VkPhysicalDevicePerformanceQueryPropertiesKHR" name="allowCommandBufferQueryCopies"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDevicePortabilitySubsetPropertiesKHR" name="minVertexInputBindingStrideAlignment"><value supported="4" /></limit>
+
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR" name="shaderIntegerDotProduct"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct8BitUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct8BitSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct8BitMixedSignednessAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct4x8BitPackedUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct4x8BitPackedSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct4x8BitPackedMixedSignednessAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct16BitUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct16BitSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct16BitMixedSignednessAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct32BitUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct32BitSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct32BitMixedSignednessAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct64BitUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct64BitSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProduct64BitMixedSignednessAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating8BitUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating8BitSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating16BitUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating16BitSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating32BitUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating32BitSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating64BitUnsignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating64BitSignedAccelerated"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR" name="integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceCustomBorderColorPropertiesEXT" name="maxCustomBorderColorSamplers"><value supported="32" /></limit>
+
+        <limit type="VkPhysicalDeviceRobustness2PropertiesEXT" name="robustStorageBufferAccessSizeAlignment"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceRobustness2PropertiesEXT" name="robustUniformBufferAccessSizeAlignment"><value supported="256" /></limit>
+
+        <limit type="VkPhysicalDeviceMultiDrawPropertiesEXT" name="maxMultiDrawCount"><value supported="1024" /></limit>
+
+        <limit type="VkPhysicalDeviceDiscardRectanglePropertiesEXT" name="maxDiscardRectangles"><value supported="4" unsupported="0" /></limit>
+
+        <limit type="VkPhysicalDeviceSampleLocationsPropertiesEXT" name="sampleLocationSampleCounts"><value supported="VK_SAMPLE_COUNT_4_BIT" /></limit>
+        <limit type="VkPhysicalDeviceSampleLocationsPropertiesEXT" name="maxSampleLocationGridSize"><value supported="1" index="0" /><value supported="1" index="1" /></limit>
+        <limit type="VkPhysicalDeviceSampleLocationsPropertiesEXT" name="sampleLocationCoordinateRange"><value supported="0.0" index="0" /><value supported="0.9375" index="1" /></limit>
+        <limit type="VkPhysicalDeviceSampleLocationsPropertiesEXT" name="sampleLocationSubPixelBits"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceSampleLocationsPropertiesEXT" name="variableSampleLocations"><value supported="false" /></limit>
+
+        <limit type="VkMultisamplePropertiesEXT" name="maxSampleLocationGridSize"><value supported="1" index="0" /><value supported="1" index="1" /></limit>
+
+        <limit type="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" name="advancedBlendMaxColorAttachments"><value supported="1" /></limit>
+        <limit type="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" name="advancedBlendIndependentBlend"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" name="advancedBlendNonPremultipliedSrcColor"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" name="advancedBlendNonPremultipliedDstColor"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" name="advancedBlendCorrelatedOverlap"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" name="advancedBlendAllOperations"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceInlineUniformBlockPropertiesEXT" name="maxInlineUniformBlockSize"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceInlineUniformBlockPropertiesEXT" name="maxPerStageDescriptorInlineUniformBlocks"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceInlineUniformBlockPropertiesEXT" name="maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceInlineUniformBlockPropertiesEXT" name="maxDescriptorSetInlineUniformBlocks"><value supported="4" /></limit>
+        <limit type="VkPhysicalDeviceInlineUniformBlockPropertiesEXT" name="maxDescriptorSetUpdateAfterBindInlineUniformBlocks"><value supported="4" /></limit>
+
+        <limit type="VkMemoryHostPointerPropertiesEXT" name="memoryTypeBits" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceDrmPropertiesEXT" name="hasPrimary" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceDrmPropertiesEXT" name="hasRender" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceDrmPropertiesEXT" name="primaryMajor" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceDrmPropertiesEXT" name="primaryMinor" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceDrmPropertiesEXT" name="renderMajor" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceDrmPropertiesEXT" name="renderMinor" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceExternalMemoryHostPropertiesEXT" name="minImportedHostPointerAlignment"><value supported="65536" /></limit>
+
+        <limit type="VkPhysicalDeviceFragmentDensityMapPropertiesEXT" name="minFragmentDensityTexelSize"><value supported="1" /><value supported="1" /></limit>
+        <limit type="VkPhysicalDeviceFragmentDensityMapPropertiesEXT" name="maxFragmentDensityTexelSize"><value supported="1" /><value supported="1" /></limit>
+        <limit type="VkPhysicalDeviceFragmentDensityMapPropertiesEXT" name="fragmentDensityInvocations"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceFragmentDensityMap2PropertiesEXT" name="subsampledLoads"><value supported="true" unsupported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentDensityMap2PropertiesEXT" name="subsampledCoarseReconstructionEarlyAccess"><value supported="false" unsupported="false" /></limit>
+        <limit type="VkPhysicalDeviceFragmentDensityMap2PropertiesEXT" name="maxSubsampledArrayLayers"><value supported="2" unsupported="2" /></limit>
+        <limit type="VkPhysicalDeviceFragmentDensityMap2PropertiesEXT" name="maxDescriptorSetSubsampledSamplers"><value supported="1" unsupported="1" /></limit>
+
+        <limit type="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" name="primitiveOverestimationSize"><value supported="0.0" /></limit>
+        <limit type="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" name="maxExtraPrimitiveOverestimationSize"><value supported="0.0" /></limit>
+        <limit type="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" name="extraPrimitiveOverestimationSizeGranularity"><value supported="0.0" /></limit>
+        <limit type="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" name="primitiveUnderestimation"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" name="conservativePointAndLineRasterization"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" name="degenerateTrianglesRasterized"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" name="degenerateLinesRasterized"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" name="fullyCoveredFragmentShaderInputVariable"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" name="conservativeRasterizationPostDepthCoverage"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT" name="conservativeRasterizationPostDepthCoverage"><value supported="65535" /></limit>
+
+        <limit type="VkPhysicalDevicePCIBusInfoPropertiesEXT" name="pciDomain" implementation-dependent="true" />
+        <limit type="VkPhysicalDevicePCIBusInfoPropertiesEXT" name="pciBus" implementation-dependent="true" />
+        <limit type="VkPhysicalDevicePCIBusInfoPropertiesEXT" name="pciDevice" implementation-dependent="true" />
+        <limit type="VkPhysicalDevicePCIBusInfoPropertiesEXT" name="pciFunction" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="maxTransformFeedbackStreams"><value supported="1" /></limit>
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="maxTransformFeedbackBuffers"><value supported="1" /></limit>
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="maxTransformFeedbackBufferSize"><value supported="134217728" /></limit>
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="maxTransformFeedbackStreamDataSize"><value supported="512" /></limit>
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="maxTransformFeedbackBufferDataSize"><value supported="512" /></limit>
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="maxTransformFeedbackBufferDataStride"><value supported="512" /></limit>
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="transformFeedbackQueries"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="transformFeedbackStreamsLinesTriangles"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="transformFeedbackRasterizationStreamSelect"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceTransformFeedbackPropertiesEXT" name="transformFeedbackDraw"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceProvokingVertexPropertiesEXT" name="provokingVertexModePerPipeline"><value supported="false" /></limit>
+        <limit type="VkPhysicalDeviceProvokingVertexPropertiesEXT" name="transformFeedbackPreservesTriangleFanProvokingVertex"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT" name="storageTexelBufferOffsetAlignmentBytes" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT" name="storageTexelBufferOffsetSingleTexelAlignment" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT" name="uniformTexelBufferOffsetAlignmentBytes" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT" name="uniformTexelBufferOffsetSingleTexelAlignment" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceSubgroupSizeControlPropertiesEXT" name="minSubgroupSize" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceSubgroupSizeControlPropertiesEXT" name="maxSubgroupSize" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceSubgroupSizeControlPropertiesEXT" name="maxComputeWorkgroupSubgroups" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceSubgroupSizeControlPropertiesEXT" name="requiredSubgroupSizeStages"><value supported="false" /></limit>
+        
+        <limit type="VkPhysicalDeviceLineRasterizationPropertiesEXT" name="lineSubPixelPrecisionBits"><value supported="4" /></limit>
+
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="shaderEngineCount" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="shaderArraysPerEngineCount" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="computeUnitsPerShaderArray" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="simdPerComputeUnit" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="wavefrontsPerSimd" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="wavefrontSize" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="sgprsPerSimd" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="minSgprAllocation" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="maxSgprAllocation" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="sgprAllocationGranularity" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="vgprsPerSimd" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="minVgprAllocation" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="maxVgprAllocation" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCorePropertiesAMD" name="vgprAllocationGranularity" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceShaderCoreProperties2AMD" name="shaderCoreFeatures" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderCoreProperties2AMD" name="activeComputeUnitCount" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceRayTracingPropertiesNV" name="shaderGroupHandleSize"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPropertiesNV" name="maxRecursionDepth"><value supported="31" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPropertiesNV" name="maxShaderGroupStride"><value supported="4096" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPropertiesNV" name="shaderGroupBaseAlignment"><value supported="64" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPropertiesNV" name="maxGeometryCount"><value supported="16777215" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPropertiesNV" name="maxInstanceCount"><value supported="16777215" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPropertiesNV" name="maxTriangleCount"><value supported="536870911" /></limit>
+        <limit type="VkPhysicalDeviceRayTracingPropertiesNV" name="maxDescriptorSetAccelerationStructures"><value supported="16" /></limit>
+
+        <limit type="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" name="maxGraphicsShaderGroupCount"><value supported="4096" /></limit>
+        <limit type="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" name="maxIndirectSequenceCount"><value supported="1048576" /></limit>
+        <limit type="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" name="maxIndirectCommandsTokenCount"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" name="maxIndirectCommandsStreamCount"><value supported="16" /></limit>
+        <limit type="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" name="maxIndirectCommandsTokenOffset"><value supported="2047" /></limit>
+        <limit type="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" name="maxIndirectCommandsStreamStride"><value supported="2048" /></limit>
+        <limit type="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" name="minSequencesCountBufferOffsetAlignment"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" name="minSequencesIndexBufferOffsetAlignment"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" name="minIndirectCommandsBufferOffsetAlignment"><value supported="256" /></limit>
+
+        <limit type="VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV" name="maxFragmentShadingRateInvocationCount"><value supported="VK_SAMPLE_COUNT_4_BIT" /></limit>
+
+        <limit type="VkPhysicalDeviceShadingRateImagePropertiesNV" name="shadingRateTexelSize" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShadingRateImagePropertiesNV" name="shadingRatePaletteSize" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShadingRateImagePropertiesNV" name="shadingRateMaxCoarseSamples" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxDrawMeshTasksCount"><value supported="65535" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxTaskWorkGroupInvocations"><value supported="32" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxTaskWorkGroupSize"><value supported="32" index="0" /><value supported="1" index="1" /><value supported="1" index="2" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxTaskTotalMemorySize"><value supported="16384" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxTaskOutputCount"><value supported="65535" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxMeshWorkGroupInvocations"><value supported="32" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxMeshWorkGroupSize"><value supported="32" index="0" /><value supported="1" index="1" /><value supported="1" index="2" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxMeshTotalMemorySize"><value supported="16384" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxMeshOutputVertices"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxMeshOutputPrimitives"><value supported="256" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="maxMeshMultiviewViewCount"><value supported="1" /></limit>
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="meshOutputPerVertexGranularity" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceMeshShaderPropertiesNV" name="meshOutputPerPrimitiveGranularity" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceCooperativeMatrixPropertiesNV" name="cooperativeMatrixSupportedStages"><value supported="0" /></limit>
+
+        <limit type="VkPhysicalDeviceShaderSMBuiltinsPropertiesNV" name="shaderSMCount" implementation-dependent="true" />
+        <limit type="VkPhysicalDeviceShaderSMBuiltinsPropertiesNV" name="shaderWarpsPerSM" implementation-dependent="true" />
+
+        <limit type="VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX" name="perViewPositionAllComponents"><value supported="false" /></limit>
+
+        <limit type="VkPhysicalDeviceSubpassShadingPropertiesHUAWEI" name="maxSubpassShadingWorkgroupSizeAspectRatio"><value supported="1" index="0" /></limit>
+    </requirements>
 </registry>

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -1600,120 +1600,152 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkPhysicalDeviceLimits" returnedonly="true">
                 <comment>resource maximum sizes</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension1D</name><comment>max 1D image dimension</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension2D</name><comment>max 2D image dimension</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension3D</name><comment>max 3D image dimension</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimensionCube</name><comment>max cubemap image dimension</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxImageArrayLayers</name><comment>max layers for image arrays</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTexelBufferElements</name><comment>max texel buffer size (fstexels)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxUniformBufferRange</name><comment>max uniform buffer range (bytes)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxStorageBufferRange</name><comment>max storage buffer range (bytes)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPushConstantsSize</name><comment>max size of the push constants pool (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension1D</name><limit supported="4096" /><comment>max 1D image dimension</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension2D</name><limit supported="4096" /><comment>max 2D image dimension</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimension3D</name><limit supported="256" /><comment>max 3D image dimension</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageDimensionCube</name><limit supported="4096" /><comment>max cubemap image dimension</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxImageArrayLayers</name><limit supported="256" /><comment>max layers for image arrays</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTexelBufferElements</name><limit supported="65536" /><comment>max texel buffer size (fstexels)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxUniformBufferRange</name><limit supported="65536" /><comment>max uniform buffer range (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxStorageBufferRange</name><limit supported="134217728" /><comment>max storage buffer range (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPushConstantsSize</name><limit supported="128" /><comment>max size of the push constants pool (bytes)</comment></member>
                 <comment>memory limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxMemoryAllocationCount</name><comment>max number of device memory allocations supported</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxSamplerAllocationCount</name><comment>max number of samplers that can be allocated on a device</comment></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>           <name>bufferImageGranularity</name><comment>Granularity (in bytes) at which buffers and images can be bound to adjacent memory for simultaneous usage</comment></member>
-            <member limittype="max"><type>VkDeviceSize</type>           <name>sparseAddressSpaceSize</name><comment>Total address space available for sparse allocations (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxMemoryAllocationCount</name><limit supported="4096" /><comment>max number of device memory allocations supported</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxSamplerAllocationCount</name><limit supported="4000" /><comment>max number of samplers that can be allocated on a device</comment></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>           <name>bufferImageGranularity</name><limit supported="131072" /><comment>Granularity (in bytes) at which buffers and images can be bound to adjacent memory for simultaneous usage</comment></member>
+            <member limittype="max"><type>VkDeviceSize</type>           <name>sparseAddressSpaceSize</name><limit supported="2147483648" unsupported="0" /><comment>Total address space available for sparse allocations (bytes)</comment></member>
                 <comment>descriptor set limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxBoundDescriptorSets</name><comment>max number of descriptors sets that can be bound to a pipeline</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorSamplers</name><comment>max number of samplers allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUniformBuffers</name><comment>max number of uniform buffers allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorStorageBuffers</name><comment>max number of storage buffers allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorSampledImages</name><comment>max number of sampled images allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorStorageImages</name><comment>max number of storage images allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorInputAttachments</name><comment>max number of input attachments allowed per-stage in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageResources</name><comment>max number of resources allowed by a single stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetSamplers</name><comment>max number of samplers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffers</name><comment>max number of uniform buffers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffersDynamic</name><comment>max number of dynamic uniform buffers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffers</name><comment>max number of storage buffers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffersDynamic</name><comment>max number of dynamic storage buffers allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetSampledImages</name><comment>max number of sampled images allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageImages</name><comment>max number of storage images allowed in all stages in a descriptor set</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetInputAttachments</name><comment>max number of input attachments allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxBoundDescriptorSets</name><limit supported="4" /><comment>max number of descriptors sets that can be bound to a pipeline</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorSamplers</name><limit supported="16" /><comment>max number of samplers allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUniformBuffers</name><limit supported="12" /><comment>max number of uniform buffers allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorStorageBuffers</name><limit supported="4" /><comment>max number of storage buffers allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorSampledImages</name><limit supported="16" /><comment>max number of sampled images allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorStorageImages</name><limit supported="4" /><comment>max number of storage images allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorInputAttachments</name><limit supported="4" /><comment>max number of input attachments allowed per-stage in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageResources</name><limit supported="128" /><comment>max number of resources allowed by a single stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetSamplers</name><limit supported="96" /><comment>max number of samplers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffers</name><limit supported="72" /><comment>max number of uniform buffers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUniformBuffersDynamic</name><limit supported="8" /><comment>max number of dynamic uniform buffers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffers</name><limit supported="24" /><comment>max number of storage buffers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageBuffersDynamic</name><limit supported="4" /><comment>max number of dynamic storage buffers allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetSampledImages</name><limit supported="96" /><comment>max number of sampled images allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetStorageImages</name><limit supported="24" /><comment>max number of storage images allowed in all stages in a descriptor set</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetInputAttachments</name><limit supported="4" /><comment>max number of input attachments allowed in all stages in a descriptor set</comment></member>
                 <comment>vertex stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputAttributes</name><comment>max number of vertex input attribute slots</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputBindings</name><comment>max number of vertex input binding slots</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputAttributeOffset</name><comment>max vertex input attribute offset added to vertex buffer offset</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputBindingStride</name><comment>max vertex input binding stride</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexOutputComponents</name><comment>max number of output components written by vertex shader</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputAttributes</name><limit supported="16" /><comment>max number of vertex input attribute slots</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputBindings</name><limit supported="16" /><comment>max number of vertex input binding slots</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputAttributeOffset</name><limit supported="2047" /><comment>max vertex input attribute offset added to vertex buffer offset</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexInputBindingStride</name><limit supported="2048" /><comment>max vertex input binding stride</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexOutputComponents</name><limit supported="64" /><comment>max number of output components written by vertex shader</comment></member>
                 <comment>tessellation control stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationGenerationLevel</name><comment>max level supported by tessellation primitive generator</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationPatchSize</name><comment>max patch size (vertices)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerVertexInputComponents</name><comment>max number of input components per-vertex in TCS</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerVertexOutputComponents</name><comment>max number of output components per-vertex in TCS</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerPatchOutputComponents</name><comment>max number of output components per-patch in TCS</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlTotalOutputComponents</name><comment>max total number of per-vertex and per-patch output components in TCS</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationGenerationLevel</name><limit supported="64" unsupported="0" /><comment>max level supported by tessellation primitive generator</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationPatchSize</name><limit supported="32" unsupported="0" /><comment>max patch size (vertices)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerVertexInputComponents</name><limit supported="64" unsupported="0" /><comment>max number of input components per-vertex in TCS</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerVertexOutputComponents</name><limit supported="64" unsupported="0" /><comment>max number of output components per-vertex in TCS</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlPerPatchOutputComponents</name><limit supported="120" unsupported="0" /><comment>max number of output components per-patch in TCS</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationControlTotalOutputComponents</name><limit supported="2048" unsupported="0" /><comment>max total number of per-vertex and per-patch output components in TCS</comment></member>
                 <comment>tessellation evaluation stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationEvaluationInputComponents</name><comment>max number of input components per vertex in TES</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationEvaluationOutputComponents</name><comment>max number of output components per vertex in TES</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationEvaluationInputComponents</name><limit supported="64" unsupported="0" /><comment>max number of input components per vertex in TES</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTessellationEvaluationOutputComponents</name><limit supported="64" unsupported="0" /><comment>max number of output components per vertex in TES</comment></member>
                 <comment>geometry stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryShaderInvocations</name><comment>max invocation count supported in geometry shader</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryInputComponents</name><comment>max number of input components read in geometry stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryOutputComponents</name><comment>max number of output components written in geometry stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryOutputVertices</name><comment>max number of vertices that can be emitted in geometry stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryTotalOutputComponents</name><comment>max total number of components (all vertices) written in geometry stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryShaderInvocations</name><limit supported="32" unsupported="0" /><comment>max invocation count supported in geometry shader</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryInputComponents</name><limit supported="64" unsupported="0" /><comment>max number of input components read in geometry stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryOutputComponents</name><limit supported="64" unsupported="0" /><comment>max number of output components written in geometry stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryOutputVertices</name><limit supported="256" unsupported="0" /><comment>max number of vertices that can be emitted in geometry stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxGeometryTotalOutputComponents</name><limit supported="1024" unsupported="0" /><comment>max total number of components (all vertices) written in geometry stage</comment></member>
                 <comment>fragment stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentInputComponents</name><comment>max number of input components read in fragment stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentOutputAttachments</name><comment>max number of output attachments written in fragment stage</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentDualSrcAttachments</name><comment>max number of output attachments written when using dual source blending</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentCombinedOutputResources</name><comment>max total number of storage buffers, storage images and output buffers</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentInputComponents</name><limit supported="64" /><comment>max number of input components read in fragment stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentOutputAttachments</name><limit supported="4" /><comment>max number of output attachments written in fragment stage</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentDualSrcAttachments</name><limit supported="1" unsupported="0" /><comment>max number of output attachments written when using dual source blending</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFragmentCombinedOutputResources</name><limit supported="4" /><comment>max total number of storage buffers, storage images and output buffers</comment></member>
                 <comment>compute stage limits</comment>
-            <member limittype="max"><type>uint32_t</type>               <name>maxComputeSharedMemorySize</name><comment>max total storage size of work group local storage (bytes)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupCount</name>[3]<comment>max num of compute work groups that may be dispatched by a single command (x,y,z)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupInvocations</name><comment>max total compute invocations in a single local work group</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupSize</name>[3]<comment>max local size of a compute work group (x,y,z)</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>subPixelPrecisionBits</name><comment>number bits of subpixel precision in screen x and y</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>subTexelPrecisionBits</name><comment>number bits of precision for selecting texel weights</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>mipmapPrecisionBits</name><comment>number bits of precision for selecting mipmap weights</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDrawIndexedIndexValue</name><comment>max index value for indexed draw calls (for 32-bit indices)</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDrawIndirectCount</name><comment>max draw count for indirect draw calls</comment></member>
-            <member limittype="max"><type>float</type>                  <name>maxSamplerLodBias</name><comment>max absolute sampler LOD bias</comment></member>
-            <member limittype="max"><type>float</type>                  <name>maxSamplerAnisotropy</name><comment>max degree of sampler anisotropy</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxViewports</name><comment>max number of active viewports</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxViewportDimensions</name>[2]<comment>max viewport dimensions (x,y)</comment></member>
-            <member limittype="range"><type>float</type>                  <name>viewportBoundsRange</name>[2]<comment>viewport bounds range (min,max)</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>viewportSubPixelBits</name><comment>number bits of subpixel precision for viewport</comment></member>
-            <member limittype="noauto"><type>size_t</type>                 <name>minMemoryMapAlignment</name><comment>min required alignment of pointers returned by MapMemory (bytes)</comment></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minTexelBufferOffsetAlignment</name><comment>min required alignment for texel buffer offsets (bytes) </comment></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minUniformBufferOffsetAlignment</name><comment>min required alignment for uniform buffer sizes and offsets (bytes)</comment></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minStorageBufferOffsetAlignment</name><comment>min required alignment for storage buffer offsets (bytes)</comment></member>
-            <member limittype="min"><type>int32_t</type>                <name>minTexelOffset</name><comment>min texel offset for OpTextureSampleOffset</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTexelOffset</name><comment>max texel offset for OpTextureSampleOffset</comment></member>
-            <member limittype="min"><type>int32_t</type>                <name>minTexelGatherOffset</name><comment>min texel offset for OpTextureGatherOffset</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTexelGatherOffset</name><comment>max texel offset for OpTextureGatherOffset</comment></member>
-            <member limittype="min"><type>float</type>                  <name>minInterpolationOffset</name><comment>furthest negative offset for interpolateAtOffset</comment></member>
-            <member limittype="max"><type>float</type>                  <name>maxInterpolationOffset</name><comment>furthest positive offset for interpolateAtOffset</comment></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>subPixelInterpolationOffsetBits</name><comment>number of subpixel bits for interpolateAtOffset</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferWidth</name><comment>max width for a framebuffer</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferHeight</name><comment>max height for a framebuffer</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferLayers</name><comment>max layer count for a layered framebuffer</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferColorSampleCounts</name><comment>supported color sample counts for a framebuffer</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferDepthSampleCounts</name><comment>supported depth sample counts for a framebuffer</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferStencilSampleCounts</name><comment>supported stencil sample counts for a framebuffer</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferNoAttachmentsSampleCounts</name><comment>supported sample counts for a subpass which uses no attachments</comment></member>
-            <member limittype="bitmask"><type>uint32_t</type>               <name>maxColorAttachments</name><comment>max number of color attachments per subpass</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageColorSampleCounts</name><comment>supported color sample counts for a non-integer sampled image</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageIntegerSampleCounts</name><comment>supported sample counts for an integer image</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageDepthSampleCounts</name><comment>supported depth sample counts for a sampled image</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageStencilSampleCounts</name><comment>supported stencil sample counts for a sampled image</comment></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>storageImageSampleCounts</name><comment>supported sample counts for a storage image</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxSampleMaskWords</name><comment>max number of sample mask words</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxComputeSharedMemorySize</name><limit supported="16384" /><comment>max total storage size of work group local storage (bytes)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupCount</name>[3]<limit supported="65536" /><limit supported="65536" /><limit supported="65536" /><comment>max num of compute work groups that may be dispatched by a single command (x,y,z)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupInvocations</name><limit supported="128" /><comment>max total compute invocations in a single local work group</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxComputeWorkGroupSize</name>[3]<limit supported="128" /><limit supported="128" /><limit supported="64" /><comment>max local size of a compute work group (x,y,z)</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>subPixelPrecisionBits</name><limit supported="4" /><comment>number bits of subpixel precision in screen x and y</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>subTexelPrecisionBits</name><limit supported="4" /><comment>number bits of precision for selecting texel weights</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>mipmapPrecisionBits</name><limit supported="4" /><comment>number bits of precision for selecting mipmap weights</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDrawIndexedIndexValue</name><limit supported="4294967295" unsupported="16777215" /><comment>max index value for indexed draw calls (for 32-bit indices)</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDrawIndirectCount</name><limit supported="65535" unsupported="1" /><comment>max draw count for indirect draw calls</comment></member>
+            <member limittype="max"><type>float</type>                  <name>maxSamplerLodBias</name><limit supported="2.0" /><comment>max absolute sampler LOD bias</comment></member>
+            <member limittype="max"><type>float</type>                  <name>maxSamplerAnisotropy</name><limit supported="16.0" unsupported="1.0" /><comment>max degree of sampler anisotropy</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxViewports</name><limit supported="16" unsupported="1" /><comment>max number of active viewports</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxViewportDimensions</name>[2]<limit supported="4096" /><limit supported="4096" /><comment>max viewport dimensions (x,y)</comment></member>
+            <member limittype="range"><type>float</type>                  <name>viewportBoundsRange</name>[2]<limit supported="-8192.0" /><limit supported="8192.0" /><comment>viewport bounds range (min,max)</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>viewportSubPixelBits</name><limit supported="0" /><comment>number bits of subpixel precision for viewport</comment></member>
+            <member limittype="noauto"><type>size_t</type>                 <name>minMemoryMapAlignment</name><limit supported="64" /><comment>min required alignment of pointers returned by MapMemory (bytes)</comment></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minTexelBufferOffsetAlignment</name><limit supported="256" /><comment>min required alignment for texel buffer offsets (bytes) </comment></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minUniformBufferOffsetAlignment</name><limit supported="256" /><comment>min required alignment for uniform buffer sizes and offsets (bytes)</comment></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>           <name>minStorageBufferOffsetAlignment</name><limit supported="256" /><comment>min required alignment for storage buffer offsets (bytes)</comment></member>
+            <member limittype="min"><type>int32_t</type>                <name>minTexelOffset</name><limit supported="-8" /><comment>min texel offset for OpTextureSampleOffset</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTexelOffset</name><limit supported="7" /><comment>max texel offset for OpTextureSampleOffset</comment></member>
+            <member limittype="min"><type>int32_t</type>                <name>minTexelGatherOffset</name><limit supported="-8" unsupported="0" /><comment>min texel offset for OpTextureGatherOffset</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTexelGatherOffset</name><limit supported="7" unsupported="0" /><comment>max texel offset for OpTextureGatherOffset</comment></member>
+            <member limittype="min"><type>float</type>                  <name>minInterpolationOffset</name><limit supported="-0.5" unsupported="0.0" /><comment>furthest negative offset for interpolateAtOffset</comment></member>
+            <member limittype="max"><type>float</type>                  <name>maxInterpolationOffset</name><limit supported="0.5" unsupported="0.0" /><comment>furthest positive offset for interpolateAtOffset</comment></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>subPixelInterpolationOffsetBits</name><limit supported="4" unsupported="0" /><comment>number of subpixel bits for interpolateAtOffset</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferWidth</name><limit supported="4096" /><comment>max width for a framebuffer</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferHeight</name><limit supported="4096" /><comment>max height for a framebuffer</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxFramebufferLayers</name><limit supported="256" /><comment>max layer count for a layered framebuffer</comment></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferColorSampleCounts</name><comment>supported color sample counts for a framebuffer</comment>
+                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
+            </member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferDepthSampleCounts</name><comment>supported depth sample counts for a framebuffer</comment>
+                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
+            </member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferStencilSampleCounts</name><comment>supported stencil sample counts for a framebuffer</comment>
+                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
+            </member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>framebufferNoAttachmentsSampleCounts</name><comment>supported sample counts for a subpass which uses no attachments</comment>
+                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
+            </member>
+            <member limittype="bitmask"><type>uint32_t</type>               <name>maxColorAttachments</name><comment>max number of color attachments per subpass</comment><limit supported="4" /></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageColorSampleCounts</name><comment>supported color sample counts for a non-integer sampled image</comment>
+                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
+            </member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageIntegerSampleCounts</name><comment>supported sample counts for an integer image</comment>
+                <limit supported="VK_SAMPLE_COUNT_1_BIT" />
+            </member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageDepthSampleCounts</name><comment>supported depth sample counts for a sampled image</comment>
+                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
+            </member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>sampledImageStencilSampleCounts</name><comment>supported stencil sample counts for a sampled image</comment>
+                <limit supported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
+            </member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type>     <name>storageImageSampleCounts</name><comment>supported sample counts for a storage image</comment>
+                <limit supported="VK_SAMPLE_COUNT_1_BIT" unsupported="VK_SAMPLE_COUNT_1_BIT" /><limit supported="VK_SAMPLE_COUNT_4_BIT" />
+            </member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxSampleMaskWords</name><comment>max number of sample mask words</comment><limit supported="1" /></member>
             <member limittype="bitmask"><type>VkBool32</type>               <name>timestampComputeAndGraphics</name><comment>timestamps on graphics and compute queues</comment></member>
             <member limittype="noauto"><type>float</type>                  <name>timestampPeriod</name><comment>number of nanoseconds it takes for timestamp query value to increment by 1</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxClipDistances</name><comment>max number of clip distances</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxCullDistances</name><comment>max number of cull distances</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxCombinedClipAndCullDistances</name><comment>max combined number of user clipping</comment></member>
-            <member limittype="max"><type>uint32_t</type>               <name>discreteQueuePriorities</name><comment>distinct queue priorities available </comment></member>
-            <member limittype="range"><type>float</type>                  <name>pointSizeRange</name>[2]<comment>range (min,max) of supported point sizes</comment></member>
-            <member limittype="range"><type>float</type>                  <name>lineWidthRange</name>[2]<comment>range (min,max) of supported line widths</comment></member>
-            <member limittype="max"><type>float</type>                  <name>pointSizeGranularity</name><comment>granularity of supported point sizes</comment></member>
-            <member limittype="max"><type>float</type>                  <name>lineWidthGranularity</name><comment>granularity of supported line widths</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxClipDistances</name><comment>max number of clip distances</comment>
+                <limit supported="8" unsupported="0" />
+            </member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxCullDistances</name><comment>max number of cull distances</comment>
+                <limit supported="8" unsupported="0" />
+            </member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxCombinedClipAndCullDistances</name><comment>max combined number of user clipping</comment>
+                <limit supported="8" unsupported="0" />
+            </member>
+            <member limittype="max"><type>uint32_t</type>               <name>discreteQueuePriorities</name><comment>distinct queue priorities available </comment><limit supported="2" /></member>
+            <member limittype="range"><type>float</type>                  <name>pointSizeRange</name>[2]<comment>range (min,max) of supported point sizes</comment>
+                <limit supported="1.0" unsupported="1.0" /><limit supported="64.0 - ULP" unsupported="1.0" />
+            </member>
+            <member limittype="range"><type>float</type>                  <name>lineWidthRange</name>[2]<comment>range (min,max) of supported line widths</comment>
+                <limit supported="1.0" unsupported="1.0" /><limit supported="8.0 - ULP" unsupported="1.0" />
+            </member>
+            <member limittype="max"><type>float</type>                  <name>pointSizeGranularity</name><comment>granularity of supported point sizes</comment>
+                <limit supported="1.0" unsupported="0.0" />
+            </member>
+            <member limittype="max"><type>float</type>                  <name>lineWidthGranularity</name><comment>granularity of supported line widths</comment>
+                <limit supported="1.0" unsupported="0.0" />
+            </member>
             <member limittype="noauto"><type>VkBool32</type>               <name>strictLines</name><comment>line rasterization follows preferred rules</comment></member>
             <member limittype="noauto"><type>VkBool32</type>               <name>standardSampleLocations</name><comment>supports standard sample locations for all supported sample counts</comment></member>
             <member limittype="noauto"><type>VkDeviceSize</type>           <name>optimalBufferCopyOffsetAlignment</name><comment>optimal offset of buffer copies</comment></member>
             <member limittype="noauto"><type>VkDeviceSize</type>           <name>optimalBufferCopyRowPitchAlignment</name><comment>optimal pitch of buffer copies</comment></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>           <name>nonCoherentAtomSize</name><comment>minimum size and alignment for non-coherent host-mapped device memory access</comment></member>
+            <member limittype="min"><type>VkDeviceSize</type>           <name>nonCoherentAtomSize</name><comment>minimum size and alignment for non-coherent host-mapped device memory access</comment><limit supported="256" /></member>
         </type>
         <type category="struct" name="VkSemaphoreCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -2073,15 +2105,15 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*    <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxGraphicsShaderGroupCount</name></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectSequenceCount</name></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsTokenCount</name></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsStreamCount</name></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsTokenOffset</name></member>
-            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsStreamStride</name></member>
-            <member limittype="noauto"><type>uint32_t</type>         <name>minSequencesCountBufferOffsetAlignment</name></member>
-            <member limittype="noauto"><type>uint32_t</type>         <name>minSequencesIndexBufferOffsetAlignment</name></member>
-            <member limittype="noauto"><type>uint32_t</type>         <name>minIndirectCommandsBufferOffsetAlignment</name></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxGraphicsShaderGroupCount</name><limit supported="4096" /></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectSequenceCount</name><limit supported="1048576" /></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsTokenCount</name><limit supported="16" /></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsStreamCount</name><limit supported="16" /></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsTokenOffset</name><limit supported="2047" /></member>
+            <member limittype="max"><type>uint32_t</type>         <name>maxIndirectCommandsStreamStride</name><limit supported="2048" /></member>
+            <member limittype="noauto"><type>uint32_t</type>         <name>minSequencesCountBufferOffsetAlignment</name><limit supported="256" /></member>
+            <member limittype="noauto"><type>uint32_t</type>         <name>minSequencesIndexBufferOffsetAlignment</name><limit supported="256" /></member>
+            <member limittype="noauto"><type>uint32_t</type>         <name>minIndirectCommandsBufferOffsetAlignment</name><limit supported="256" /></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiDrawPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -2241,7 +2273,9 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDevicePushDescriptorPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPushDescriptors</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPushDescriptors</name>
+                <limit supported="32" />
+            </member>
         </type>
         <type category="struct" name="VkConformanceVersion">
             <member><type>uint8_t</type>                          <name>major</name></member>
@@ -2558,8 +2592,12 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMultiviewProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment>
+                <limit supported="6" />
+            </member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment>
+                <limit supported="13421771" />
+            </member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewPropertiesKHR"                  alias="VkPhysicalDeviceMultiviewProperties"/>
         <type category="struct" name="VkRenderPassMultiviewCreateInfo" structextends="VkRenderPassCreateInfo">
@@ -2864,7 +2902,9 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDiscardRectanglePropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDiscardRectangles</name><comment>max number of active discard rectangles</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDiscardRectangles</name><comment>max number of active discard rectangles</comment>
+                <limit supported="4" unsupported="0" />
+            </member>
         </type>
         <type category="struct" name="VkPipelineDiscardRectangleStateCreateInfoEXT" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -2877,7 +2917,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>perViewPositionAllComponents</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>perViewPositionAllComponents</name><limit supported="false" /></member>
         </type>
         <type category="struct" name="VkInputAttachmentAspectReference">
             <member><type>uint32_t</type>                        <name>subpass</name></member>
@@ -3110,8 +3150,8 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceSamplerFilterMinmaxProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>filterMinmaxSingleComponentFormats</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>filterMinmaxImageComponentMapping</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>filterMinmaxSingleComponentFormats</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>filterMinmaxImageComponentMapping</name><limit supported="false" /></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT" alias="VkPhysicalDeviceSamplerFilterMinmaxProperties"/>
         <type category="struct" name="VkSampleLocationEXT">
@@ -3151,11 +3191,21 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceSampleLocationsPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="bitmask"><type>VkSampleCountFlags</type>               <name>sampleLocationSampleCounts</name></member>
-            <member limittype="max"><type>VkExtent2D</type>                       <name>maxSampleLocationGridSize</name></member>
-            <member limittype="range"><type>float</type>                            <name>sampleLocationCoordinateRange</name>[2]</member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>sampleLocationSubPixelBits</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>variableSampleLocations</name></member>
+            <member limittype="bitmask"><type>VkSampleCountFlags</type>               <name>sampleLocationSampleCounts</name>
+                <limit supported="VK_SAMPLE_COUNT_4_BIT" />
+            </member>
+            <member limittype="max"><type>VkExtent2D</type>                       <name>maxSampleLocationGridSize</name>
+                <limit supported="1" /><limit supported="1" />
+            </member>
+            <member limittype="range"><type>float</type>                            <name>sampleLocationCoordinateRange</name>[2]
+                <limit supported="0.0" /><limit supported="0.9375" />
+            </member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>sampleLocationSubPixelBits</name>
+                <limit supported="4" />
+            </member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>variableSampleLocations</name>
+                <limit supported="false" />
+            </member>
         </type>
         <type category="struct" name="VkMultisamplePropertiesEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3181,12 +3231,12 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>advancedBlendMaxColorAttachments</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendIndependentBlend</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedSrcColor</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedDstColor</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendCorrelatedOverlap</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendAllOperations</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>advancedBlendMaxColorAttachments</name><limit supported="1" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendIndependentBlend</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedSrcColor</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendNonPremultipliedDstColor</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendCorrelatedOverlap</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>advancedBlendAllOperations</name><limit supported="false" /></member>
         </type>
         <type category="struct" name="VkPipelineColorBlendAdvancedStateCreateInfoEXT" structextends="VkPipelineColorBlendStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3204,11 +3254,11 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceInlineUniformBlockPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxInlineUniformBlockSize</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorInlineUniformBlocks</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetInlineUniformBlocks</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindInlineUniformBlocks</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxInlineUniformBlockSize</name><limit supported="256" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorInlineUniformBlocks</name><limit supported="4" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks</name><limit supported="4" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetInlineUniformBlocks</name><limit supported="4" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindInlineUniformBlocks</name><limit supported="4" /></member>
         </type>
         <type category="struct" name="VkWriteDescriptorSetInlineUniformBlockEXT" structextends="VkWriteDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3252,8 +3302,12 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMaintenance3Properties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerSetDescriptors</name></member>
-            <member limittype="max"><type>VkDeviceSize</type>                     <name>maxMemoryAllocationSize</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerSetDescriptors</name>
+                <limit supported="1024" />
+            </member>
+            <member limittype="max"><type>VkDeviceSize</type>                     <name>maxMemoryAllocationSize</name>
+                <limit supported="1073741824" />
+            </member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMaintenance3PropertiesKHR"               alias="VkPhysicalDeviceMaintenance3Properties"/>
         <type category="struct" name="VkDescriptorSetLayoutSupport" returnedonly="true">
@@ -3441,20 +3495,22 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceExternalMemoryHostPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>* <name>pNext</name></member>
-            <member limittype="noauto"><type>VkDeviceSize</type> <name>minImportedHostPointerAlignment</name></member>
+            <member limittype="noauto"><type>VkDeviceSize</type> <name>minImportedHostPointerAlignment</name>
+                <limit supported="65536" />
+            </member>
         </type>
         <type category="struct" name="VkPhysicalDeviceConservativeRasterizationPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="noauto"><type>float</type>                  <name>primitiveOverestimationSize</name><comment>The size in pixels the primitive is enlarged at each edge during conservative rasterization</comment></member>
-            <member limittype="max"><type>float</type>                  <name>maxExtraPrimitiveOverestimationSize</name><comment>The maximum additional overestimation the client can specify in the pipeline state</comment></member>
-            <member limittype="noauto"><type>float</type>                  <name>extraPrimitiveOverestimationSizeGranularity</name><comment>The granularity of extra overestimation sizes the implementations supports between 0 and maxExtraOverestimationSize</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>primitiveUnderestimation</name><comment>true if the implementation supports conservative rasterization underestimation mode</comment></member>
-            <member limittype="noauto"><type>VkBool32</type>               <name>conservativePointAndLineRasterization</name><comment>true if conservative rasterization also applies to points and lines</comment></member>
-            <member limittype="noauto"><type>VkBool32</type>               <name>degenerateTrianglesRasterized</name><comment>true if degenerate triangles (those with zero area after snap) are rasterized</comment></member>
-            <member limittype="noauto"><type>VkBool32</type>               <name>degenerateLinesRasterized</name><comment>true if degenerate lines (those with zero length after snap) are rasterized</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fullyCoveredFragmentShaderInputVariable</name><comment>true if the implementation supports the FullyCoveredEXT SPIR-V builtin fragment shader input variable</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>conservativeRasterizationPostDepthCoverage</name><comment>true if the implementation supports both conservative rasterization and post depth coverage sample coverage mask</comment></member>
+            <member limittype="noauto"><type>float</type>                  <name>primitiveOverestimationSize</name><comment>The size in pixels the primitive is enlarged at each edge during conservative rasterization</comment><limit supported="0.0" /></member>
+            <member limittype="max"><type>float</type>                  <name>maxExtraPrimitiveOverestimationSize</name><comment>The maximum additional overestimation the client can specify in the pipeline state</comment><limit supported="0.0" /></member>
+            <member limittype="noauto"><type>float</type>                  <name>extraPrimitiveOverestimationSizeGranularity</name><comment>The granularity of extra overestimation sizes the implementations supports between 0 and maxExtraOverestimationSize</comment><limit supported="0.0" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>primitiveUnderestimation</name><comment>true if the implementation supports conservative rasterization underestimation mode</comment><limit supported="false" /></member>
+            <member limittype="noauto"><type>VkBool32</type>               <name>conservativePointAndLineRasterization</name><comment>true if conservative rasterization also applies to points and lines</comment><limit supported="false" /></member>
+            <member limittype="noauto"><type>VkBool32</type>               <name>degenerateTrianglesRasterized</name><comment>true if degenerate triangles (those with zero area after snap) are rasterized</comment><limit supported="false" /></member>
+            <member limittype="noauto"><type>VkBool32</type>               <name>degenerateLinesRasterized</name><comment>true if degenerate lines (those with zero length after snap) are rasterized</comment><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fullyCoveredFragmentShaderInputVariable</name><comment>true if the implementation supports the FullyCoveredEXT SPIR-V builtin fragment shader input variable</comment><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>conservativeRasterizationPostDepthCoverage</name><comment>true if the implementation supports both conservative rasterization and post depth coverage sample coverage mask</comment><limit supported="false" /></member>
         </type>
         <type category="struct" name="VkCalibratedTimestampInfoEXT">
             <member values="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3520,29 +3576,29 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingProperties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxUpdateAfterBindDescriptorsInAllPools</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderUniformBufferArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderSampledImageArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderStorageBufferArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderStorageImageArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderInputAttachmentArrayNonUniformIndexingNative</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxUpdateAfterBindDescriptorsInAllPools</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderUniformBufferArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderSampledImageArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderStorageBufferArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderStorageImageArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>shaderInputAttachmentArrayNonUniformIndexingNative</name><limit supported="false" /></member>
             <member limittype="bitmask"><type>VkBool32</type>               <name>robustBufferAccessUpdateAfterBind</name></member>
             <member limittype="bitmask"><type>VkBool32</type>               <name>quadDivergentImplicitLod</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindSamplers</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageUpdateAfterBindResources</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindSamplers</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindSampledImages</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageImages</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindInputAttachments</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindSamplers</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name><limit supported="12" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name><limit supported="4" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxPerStageUpdateAfterBindResources</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindSamplers</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name><limit supported="72" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name><limit supported="8" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name><limit supported="4" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindSampledImages</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindStorageImages</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxDescriptorSetUpdateAfterBindInputAttachments</name><limit supported="4" unsupported="0" /></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDescriptorIndexingPropertiesEXT"         alias="VkPhysicalDeviceDescriptorIndexingProperties"/>
         <type category="struct" name="VkDescriptorSetLayoutBindingFlagsCreateInfo" structextends="VkDescriptorSetLayoutCreateInfo">
@@ -3650,7 +3706,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceTimelineSemaphoreProperties" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint64_t</type>               <name>maxTimelineSemaphoreValueDifference</name></member>
+            <member limittype="max"><type>uint64_t</type>               <name>maxTimelineSemaphoreValueDifference</name><limit supported="2147483647" /></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceTimelineSemaphorePropertiesKHR"          alias="VkPhysicalDeviceTimelineSemaphoreProperties"/>
         <type category="struct" name="VkSemaphoreTypeCreateInfo" structextends="VkSemaphoreCreateInfo,VkPhysicalDeviceExternalSemaphoreInfo">
@@ -3698,7 +3754,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxVertexAttribDivisor</name><comment>max value of vertex attribute divisor</comment></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexAttribDivisor</name><comment>max value of vertex attribute divisor</comment><limit supported="65535" /></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePCIBusInfoPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3865,16 +3921,16 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceTransformFeedbackPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackStreams</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackBuffers</name></member>
-            <member limittype="max"><type>VkDeviceSize</type>           <name>maxTransformFeedbackBufferSize</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackStreamDataSize</name></member>
-            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackBufferDataSize</name></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxTransformFeedbackBufferDataStride</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackQueries</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackStreamsLinesTriangles</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackRasterizationStreamSelect</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackDraw</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackStreams</name><limit supported="1" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackBuffers</name><limit supported="1" /></member>
+            <member limittype="max"><type>VkDeviceSize</type>           <name>maxTransformFeedbackBufferSize</name><limit supported="134217728" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackStreamDataSize</name><limit supported="512" /></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxTransformFeedbackBufferDataSize</name><limit supported="512" /></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxTransformFeedbackBufferDataStride</name><limit supported="512" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackQueries</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackStreamsLinesTriangles</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackRasterizationStreamSelect</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>transformFeedbackDraw</name><limit supported="false" /></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationStateStreamCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3985,17 +4041,17 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceMeshShaderPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                               <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxDrawMeshTasksCount</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskWorkGroupInvocations</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskWorkGroupSize</name>[3]</member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskTotalMemorySize</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskOutputCount</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshWorkGroupInvocations</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshWorkGroupSize</name>[3]</member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshTotalMemorySize</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshOutputVertices</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshOutputPrimitives</name></member>
-            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshMultiviewViewCount</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDrawMeshTasksCount</name><limit supported="65535" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskWorkGroupInvocations</name><limit supported="32" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskWorkGroupSize</name>[3]<limit supported="32" /><limit supported="1" /><limit supported="1" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskTotalMemorySize</name><limit supported="16384" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxTaskOutputCount</name><limit supported="65535" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshWorkGroupInvocations</name><limit supported="32" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshWorkGroupSize</name>[3]<limit supported="32" /><limit supported="1" /><limit supported="1" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshTotalMemorySize</name><limit supported="16384" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshOutputVertices</name><limit supported="256" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshOutputPrimitives</name><limit supported="256" /></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxMeshMultiviewViewCount</name><limit supported="1" /></member>
             <member limittype="noauto"><type>uint32_t</type>                            <name>meshOutputPerVertexGranularity</name></member>
             <member limittype="noauto"><type>uint32_t</type>                            <name>meshOutputPerPrimitiveGranularity</name></member>
         </type>
@@ -4153,38 +4209,38 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceAccelerationStructurePropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*            <name>pNext</name></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxGeometryCount</name></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxInstanceCount</name></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxPrimitiveCount</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorAccelerationStructures</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindAccelerationStructures</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetAccelerationStructures</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindAccelerationStructures</name></member>
-            <member limittype="min"><type>uint32_t</type>                         <name>minAccelerationStructureScratchOffsetAlignment</name></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxGeometryCount</name><limit supported="16777215" /></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxInstanceCount</name><limit supported="16777215" /></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxPrimitiveCount</name><limit supported="536870911" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorAccelerationStructures</name><limit supported="16" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindAccelerationStructures</name><limit supported="500000" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetAccelerationStructures</name><limit supported="16" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindAccelerationStructures</name><limit supported="500000" /></member>
+            <member limittype="min"><type>uint32_t</type>                         <name>minAccelerationStructureScratchOffsetAlignment</name><limit supported="256" /></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRayTracingPipelinePropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*            <name>pNext</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleSize</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxRayRecursionDepth</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxShaderGroupStride</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupBaseAlignment</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleCaptureReplaySize</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxRayDispatchInvocationCount</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleAlignment</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxRayHitAttributeSize</name></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleSize</name><limit supported="16" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxRayRecursionDepth</name><limit supported="31" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxShaderGroupStride</name><limit supported="4096" /></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupBaseAlignment</name><limit supported="64" /></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleCaptureReplaySize</name><limit supported="64" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxRayDispatchInvocationCount</name><limit supported="1073741824" /></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleAlignment</name><limit supported="32" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxRayHitAttributeSize</name><limit supported="32" /></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRayTracingPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleSize</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxRecursionDepth</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxShaderGroupStride</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupBaseAlignment</name></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxGeometryCount</name></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxInstanceCount</name></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxTriangleCount</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetAccelerationStructures</name></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupHandleSize</name><limit supported="16" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxRecursionDepth</name><limit supported="31" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxShaderGroupStride</name><limit supported="4096" /></member>
+            <member limittype="noauto"><type>uint32_t</type>                         <name>shaderGroupBaseAlignment</name><limit supported="64" /></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxGeometryCount</name><limit supported="16777215" /></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxInstanceCount</name><limit supported="16777215" /></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxTriangleCount</name><limit supported="536870911" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetAccelerationStructures</name><limit supported="16" /></member>
         </type>
         <type category="struct" name="VkStridedDeviceAddressRegionKHR">
             <member optional="true"><type>VkDeviceAddress</type>  <name>deviceAddress</name></member>
@@ -4259,17 +4315,17 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceFragmentDensityMapPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
-            <member limittype="min"><type>VkExtent2D</type>                       <name>minFragmentDensityTexelSize</name></member>
-            <member limittype="max"><type>VkExtent2D</type>                       <name>maxFragmentDensityTexelSize</name></member>
+            <member limittype="min"><type>VkExtent2D</type>                       <name>minFragmentDensityTexelSize</name><limit supported="1" /><limit supported="1" /></member>
+            <member limittype="max"><type>VkExtent2D</type>                       <name>maxFragmentDensityTexelSize</name><limit supported="1" /><limit supported="1" /></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>fragmentDensityInvocations</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentDensityMap2PropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                          <name>pNext</name></member>
-            <member limittype="noauto"><type>VkBool32</type>                       <name>subsampledLoads</name></member>
-            <member limittype="noauto"><type>VkBool32</type>                       <name>subsampledCoarseReconstructionEarlyAccess</name></member>
-            <member limittype="max"><type>uint32_t</type>                       <name>maxSubsampledArrayLayers</name></member>
-            <member limittype="max"><type>uint32_t</type>                       <name>maxDescriptorSetSubsampledSamplers</name></member>
+            <member limittype="noauto"><type>VkBool32</type>                       <name>subsampledLoads</name><limit supported="false" unsupported="true" /></member>
+            <member limittype="noauto"><type>VkBool32</type>                       <name>subsampledCoarseReconstructionEarlyAccess</name><limit supported="false" unsupported="false" /></member>
+            <member limittype="max"><type>uint32_t</type>                       <name>maxSubsampledArrayLayers</name><limit supported="2" unsupported="2" /></member>
+            <member limittype="max"><type>uint32_t</type>                       <name>maxDescriptorSetSubsampledSamplers</name><limit supported="1" unsupported="1" /></member>
         </type>
         <type category="struct" name="VkRenderPassFragmentDensityMapCreateInfoEXT" structextends="VkRenderPassCreateInfo,VkRenderPassCreateInfo2">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -4747,7 +4803,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceSubpassShadingPropertiesHUAWEI" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxSubpassShadingWorkgroupSizeAspectRatio</name></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxSubpassShadingWorkgroupSizeAspectRatio</name><limit supported="1" unsupported="0" /></member>
         </type>
         <type category="struct" name="VkMemoryOpaqueCaptureAddressAllocateInfo" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -4774,7 +4830,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceLineRasterizationPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                               <name>pNext</name></member>
-            <member limittype="noauto"><type>uint32_t</type>                            <name>lineSubPixelPrecisionBits</name></member>
+            <member limittype="noauto"><type>uint32_t</type>                            <name>lineSubPixelPrecisionBits</name><limit supported="4" /></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationLineStateCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -4818,11 +4874,19 @@ typedef void <name>CAMetalLayer</name>;
             <member limittype="bitmask" noautovalidity="true"><type>VkSubgroupFeatureFlags</type>        <name>subgroupSupportedOperations</name><comment>Bitfield of what subgroup operations are supported.</comment></member>
             <member limittype="bitmask" noautovalidity="true"><type>VkBool32</type>                      <name>subgroupQuadOperationsInAllStages</name><comment>Flag to specify whether quad operations are available in all stages.</comment></member>
             <member limittype="noauto"><type>VkPointClippingBehavior</type>          <name>pointClippingBehavior</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewViewCount</name><comment>max number of views in a subpass</comment>
+                <limit supported="6" />
+            </member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment>
+                <limit supported="13421771" />
+            </member>
             <member limittype="noauto"><type>VkBool32</type>                         <name>protectedNoFault</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerSetDescriptors</name></member>
-            <member limittype="max"><type>VkDeviceSize</type>                     <name>maxMemoryAllocationSize</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerSetDescriptors</name>
+                <limit supported="1024" />
+            </member>
+            <member limittype="max"><type>VkDeviceSize</type>                     <name>maxMemoryAllocationSize</name>
+                <limit supported="1073741824" />
+            </member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan12Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES"><type>VkStructureType</type><name>sType</name></member>
@@ -4899,37 +4963,37 @@ typedef void <name>CAMetalLayer</name>;
             <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTZFloat16</name><comment>An implementation can support RTZ</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTZFloat32</name><comment>An implementation can support RTZ</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTZFloat64</name><comment>An implementation can support RTZ</comment></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxUpdateAfterBindDescriptorsInAllPools</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderUniformBufferArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderSampledImageArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageBufferArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageImageArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderInputAttachmentArrayNonUniformIndexingNative</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxUpdateAfterBindDescriptorsInAllPools</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderUniformBufferArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderSampledImageArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageBufferArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageImageArrayNonUniformIndexingNative</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderInputAttachmentArrayNonUniformIndexingNative</name><limit supported="false" /></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>robustBufferAccessUpdateAfterBind</name></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>quadDivergentImplicitLod</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSamplers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageUpdateAfterBindResources</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSamplers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSampledImages</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageImages</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindInputAttachments</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSamplers</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name><limit supported="12" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name><limit supported="4" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageUpdateAfterBindResources</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSamplers</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name><limit supported="72" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name><limit supported="8" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name><limit supported="4" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSampledImages</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageImages</name><limit supported="500000" unsupported="0" /></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindInputAttachments</name><limit supported="4" unsupported="0" /></member>
             <member limittype="bitmask"><type>VkResolveModeFlags</type>               <name>supportedDepthResolveModes</name><comment>supported depth resolve modes</comment></member>
             <member limittype="bitmask"><type>VkResolveModeFlags</type>               <name>supportedStencilResolveModes</name><comment>supported stencil resolve modes</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>independentResolveNone</name><comment>depth and stencil resolve modes can be set independently if one of them is none</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>                         <name>independentResolve</name><comment>depth and stencil resolve modes can be set independently</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxSingleComponentFormats</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxImageComponentMapping</name></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxTimelineSemaphoreValueDifference</name></member>
-            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type> <name>framebufferIntegerColorSampleCounts</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxSingleComponentFormats</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxImageComponentMapping</name><limit supported="false" /></member>
+            <member limittype="max"><type>uint64_t</type>                         <name>maxTimelineSemaphoreValueDifference</name><limit supported="2147483647" /></member>
+            <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type> <name>framebufferIntegerColorSampleCounts</name><limit supported="VK_SAMPLE_COUNT_1_BIT" /></member>
         </type>
         <type category="struct" name="VkPipelineCompilerControlCreateInfoAMD" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD"><type>VkStructureType</type>   <name>sType</name></member>
@@ -4959,7 +5023,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                                                                   <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                                                                                      <name>maxCustomBorderColorSamplers</name></member>
+            <member limittype="max"><type>uint32_t</type>                                                                                      <name>maxCustomBorderColorSamplers</name><limit supported="32" /></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -5163,8 +5227,8 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceRobustness2PropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>                       <name>robustStorageBufferAccessSizeAlignment</name></member>
-            <member limittype="noauto"><type>VkDeviceSize</type>                       <name>robustUniformBufferAccessSizeAlignment</name></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>                       <name>robustStorageBufferAccessSizeAlignment</name><limit supported="4" /></member>
+            <member limittype="noauto"><type>VkDeviceSize</type>                       <name>robustUniformBufferAccessSizeAlignment</name><limit supported="256" /></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceImageRobustnessFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -5342,23 +5406,23 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRatePropertiesKHR" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
-            <member limittype="min"><type>VkExtent2D</type>             <name>minFragmentShadingRateAttachmentTexelSize</name></member>
-            <member limittype="max"><type>VkExtent2D</type>             <name>maxFragmentShadingRateAttachmentTexelSize</name></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentShadingRateAttachmentTexelSizeAspectRatio</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>primitiveFragmentShadingRateWithMultipleViewports</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>layeredShadingRateAttachments</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateNonTrivialCombinerOps</name></member>
-            <member limittype="max"><type>VkExtent2D</type>             <name>maxFragmentSize</name></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentSizeAspectRatio</name></member>
-            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentShadingRateCoverageSamples</name></member>
-            <member limittype="max"><type>VkSampleCountFlagBits</type>  <name>maxFragmentShadingRateRasterizationSamples</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithShaderDepthStencilWrites</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithSampleMask</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithShaderSampleMask</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithConservativeRasterization</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithFragmentShaderInterlock</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithCustomSampleLocations</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateStrictMultiplyCombiner</name></member>
+            <member limittype="min"><type>VkExtent2D</type>             <name>minFragmentShadingRateAttachmentTexelSize</name><limit supported="32" unsupported="0" /><limit supported="32" unsupported="0" /></member>
+            <member limittype="max"><type>VkExtent2D</type>             <name>maxFragmentShadingRateAttachmentTexelSize</name><limit supported="8" unsupported="0" /><limit supported="8" unsupported="0" /></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentShadingRateAttachmentTexelSizeAspectRatio</name><limit supported="1" unsupported="0" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>primitiveFragmentShadingRateWithMultipleViewports</name><limit supported="false" unsupported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>layeredShadingRateAttachments</name><limit supported="false" unsupported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateNonTrivialCombinerOps</name><limit supported="false" /></member>
+            <member limittype="max"><type>VkExtent2D</type>             <name>maxFragmentSize</name><limit supported="2" /><limit supported="2" /></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentSizeAspectRatio</name><limit supported="2" /></member>
+            <member limittype="noauto"><type>uint32_t</type>               <name>maxFragmentShadingRateCoverageSamples</name><limit supported="16" /></member>
+            <member limittype="max"><type>VkSampleCountFlagBits</type>  <name>maxFragmentShadingRateRasterizationSamples</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithShaderDepthStencilWrites</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithSampleMask</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithShaderSampleMask</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithConservativeRasterization</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithFragmentShaderInterlock</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateWithCustomSampleLocations</name><limit supported="false" /></member>
+            <member limittype="bitmask"><type>VkBool32</type>               <name>fragmentShadingRateStrictMultiplyCombiner</name><limit supported="false" /></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRateKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -5381,7 +5445,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                              <name>pNext</name></member>
-            <member limittype="bitmask"><type>VkSampleCountFlagBits</type>              <name>maxFragmentShadingRateInvocationCount</name></member>
+            <member limittype="bitmask"><type>VkSampleCountFlagBits</type>              <name>maxFragmentShadingRateInvocationCount</name><limit supported="VK_SAMPLE_COUNT_4_BIT" /></member>
         </type>
         <type category="struct" name="VkPipelineFragmentShadingRateEnumStateCreateInfoNV" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>


### PR DESCRIPTION
Hi,

The goal of this PR is to ensure tool chain could use the limit values without having to hand picked each limits from the spec when they are added or eventually raised.

All the limits are added at the end of the files so that there is no conflict with the spec tool chains.

Feedback is very welcome!

Some inconsistency between vk.xml and the spec:
- minSequencesCountBufferOffsetAlignment is noauto in vk.xml but set to min in the spec
- minSequencesIndexBufferOffsetAlignment is noauto in vk.xml but set to min in the spec
- minIndirectCommandsBufferOffsetAlignment is noauto in vk.xml but set to min in the spec
- nonCoherentAtomSize is noauto in vk.xml but is max in the spec
- primitiveOverestimationSize is noauto in vk.xml but is min in the spec
- extraPrimitiveOverestimationSizeGranularity is noauto in vk.xml but is min in the spec
- shaderGroupHandleAlignment is noauto in vk.xml but is min in the spec
- shaderGroupHandleCaptureReplaySize is noauto in vk.xml but is min in the spec
- shaderGroupBaseAlignment is noauto in vk.xml but is max in the spec
- robustStorageBufferAccessSizeAlignment is noauto in vk.xml but is max in the spec
- robustUniformBufferAccessSizeAlignment is noauto in vk.xml but is max in the spec
- fragmentDensityInvocations is "bitmask" in vk.xml but is "implementation-dependent" in the spec

Some properties are not listed in the limit table in the spec, is there a reason?
- robustBufferAccessUpdateAfterBind
- quadDivergentImplicitLod

There is inconsistency across limits using VkBool32/bitmask type in the spec. There are marked as "implementation-dependent" with or without "supported limits"
- timestampComputeAndGraphics
- timestampPeriod
- strictLines
- standardSampleLocations
- variableSampleLocations
- perViewPositionAllComponents
- filterMinmaxSingleComponentFormats
- filterMinmaxImageComponentMapping

It seems to me that we could clarify the limit type using "boolean" instead of "implementation-dependent" and setting systematically a value to "Supported Limit", "false" by default or "true" if the feature is required. (This seems to be the most common behavior but maybe I am missing something)
