### PR TITLE
Add VK_EXT_non_seamless_cube_map

### DIFF
--- a/appendices/VK_EXT_non_seamless_cube_map.txt
+++ b/appendices/VK_EXT_non_seamless_cube_map.txt
@@ -1,0 +1,29 @@
+// Copyright 2021 Georg Lehmann
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_non_seamless_cube_map.txt[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2021-09-04
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Georg Lehmann
+
+=== Description
+
+This extension provides functionality to disable <<textures-cubemapedge, cube map edge handling>>
+on a per sampler level which matches the behavior of other graphics APIs.
+
+This extension may be useful for building translation layers for those APIs
+or for porting applications that rely on this cube map behavior.
+
+include::{generated}/interfaces/VK_EXT_non_seamless_cube_map.txt[]
+
+=== Version History
+
+  * Revision 1, 2021-09-04 (Georg Lehmann)
+    - First Version

--- a/chapters/features.txt
+++ b/chapters/features.txt
@@ -5238,6 +5238,24 @@ include::{generated}/validity/structs/VkPhysicalDeviceShaderEarlyAndLateFragment
 --
 endif::VK_AMD_shader_early_and_late_fragment_tests[]
 
+ifdef::VK_EXT_non_seamless_cube_map[]
+[open,refpage='VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT',desc='Structure describing features to disable seamless cube maps',type='structs']
+--
+The sname:VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT structure is defined as:
+
+include::{generated}/api/structs/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT.txt[]
+
+This structure describes the following feature:
+
+  * [[features-nonSeamlessCubeMap]] pname:nonSeamlessCubeMap indicates that the
+    implementation supports ename:VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT.
+
+:refpage: VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT
+include::{chapters}/features.txt[tag=features]
+
+include::{generated}/validity/structs/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT.txt[]
+--
+endif::VK_EXT_non_seamless_cube_map[]
 
 [[features-requirements]]
 == Feature Requirements
@@ -5726,6 +5744,10 @@ ifdef::VK_AMD_shader_early_and_late_fragment_tests[]
     `apiext:VK_AMD_shader_early_and_late_fragment_tests` extension is
     supported.
 endif::VK_AMD_shader_early_and_late_fragment_tests[]
+ifdef::VK_EXT_non_seamless_cube_map[]
+  * <<features-nonSeamlessCubeMap, pname:nonSeamlessCubeMap>>, if the
+    `<<VK_EXT_non_seamless_cube_map>>` extension is supported.
+endif::VK_EXT_non_seamless_cube_map[]
 
 All other features defined in the Specification are optional:.
 

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -296,6 +296,11 @@ ifdef::VK_EXT_fragment_density_map[]
     If pname:flags includes ename:VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, then
     pname:unnormalizedCoordinates must: be ename:VK_FALSE
 endif::VK_EXT_fragment_density_map[]
+ifdef::VK_EXT_non_seamless_cube_map[]
+  * If the <<features-nonSeamlessCubeMap, pname:nonSeamlessCubeMap>> feature
+    is not enabled, pname:flags must: not include
+    ename:VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT
+endif::VK_EXT_non_seamless_cube_map[]
 ifdef::VK_EXT_custom_border_color[]
   * [[VUID-VkSamplerCreateInfo-borderColor-04011]]
     If pname:borderColor is one of ename:VK_BORDER_COLOR_FLOAT_CUSTOM_EXT or
@@ -351,7 +356,14 @@ ifdef::VK_EXT_fragment_density_map[]
     specifies that the implementation may: use approximations when
     reconstructing a full color value for texture access from a subsampled
     image.
+endif::VK_EXT_fragment_density_map[]
+ifdef::VK_EXT_non_seamless_cube_map[]
+  * ename:VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT
+    specifies that <<textures-cubemapedge, cube map edge handling>> is not
+    performed.
+endif::VK_EXT_non_seamless_cube_map[]
 
+ifdef::VK_EXT_fragment_density_map[]
 [NOTE]
 .Note
 ====

--- a/chapters/textures.txt
+++ b/chapters/textures.txt
@@ -603,6 +603,11 @@ then the texel value comes from the value in image memory.
   * If the read is the result of an image sample instruction or image gather
     instruction, and
   * If the image is not a cube image,
+ifdef::VK_EXT_non_seamless_cube_map[]
+    or if a sampler created with
+    ename:VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT is used,
+endif::VK_EXT_non_seamless_cube_map[]
+
 +
 then the texel is a border texel and <<textures-texel-replacement,texel
 replacement>> is performed.
@@ -627,7 +632,8 @@ is performed.
 ==== Cube Map Edge Handling
 
 If the texel coordinates lie beyond the edges or corners of the selected
-cube map face, the following steps are performed.
+cube map face (as described in the prior section), the following steps are
+performed.
 Note that this does not occur when using ename:VK_FILTER_NEAREST filtering
 within a mip level, since ename:VK_FILTER_NEAREST is treated as using
 ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE.
@@ -2320,6 +2326,10 @@ endif::VK_EXT_image_view_min_lod[]
 [[textures-wrapping-operation]]
 === Wrapping Operation
 
+ifdef::VK_EXT_non_seamless_cube_map[]
+If the used sampler was created without
+ename:VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT
+endif::VK_EXT_non_seamless_cube_map[]
 code:Cube images ignore the wrap modes specified in the sampler.
 Instead, if ename:VK_FILTER_NEAREST is used within a mip level then
 ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE is used, and if

--- a/proposals/VK_EXT_non_seamless_cube_map.asciidoc
+++ b/proposals/VK_EXT_non_seamless_cube_map.asciidoc
@@ -1,0 +1,56 @@
+// Copyright 2022 Georg Lehmann
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+= VK_EXT_non_seamless_cube_map
+:toc: left
+:refpage: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/
+:sectnums:
+
+== Problem Statement
+
+Other graphics APIs, such as OpenGL and D3D9, have cube maps without seamless edge handling.
+When sampling near an edge, instead of interpolating between two texels on the neighboring cube map faces the usual sampler address modes are applied within a single face.
+Vulkan only has cube maps with seamless edge handling.
+
+This proposal aims to provide functionality to support non seamless cube maps.
+
+== Solution Space
+
+=== Emulation With 2D Array Textures
+
+The idea behind this solution is to represent cube map textures as 2D array textures with 6 layers, one for each cube map face.
+Cube map coordinates can then be transformed to a face index and a 2D coordinate within this face, so that then the fixed function sampling takes care of applying the sampler address modes.
+A problem is correct LOD selection while preserving anisotropic filtering. Emulation of implicit derivatives with LOD offset can't be easily emulated with explicit derivatives.
+Additionally, having pipeline variants depending on if seamless cube sampling is used prevents precompiling pipelines if any cubes are used as this information is only known at draw time.
+With advanced OpenGL features it is also not possible to know if a sampling operation is seamless even at draw time, so emulation needs extra descriptors, uniforms and branches.
+
+
+=== A Per Sampler Seamless Setting
+
+A new per sampler setting to allow to select if cube map edge sampling is seamless can be introduced.
+This can commonly be handled by fixed function hardware, which allows identical behavior to the other graphics APIs.
+
+This solution is adopted for this problem.
+
+== Proposal
+
+```c
+typedef struct VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           nonSeamlessCubeMap;
+} VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT;
+```
+
+`nonSeamlessCubeMap` is the feature enabling this extension’s functionality.
+
+Using `VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT` disables seamless cube map edge handling.
+
+== Example
+
+As an example, if an application creates a cube map and wants to always clamp to the edge within the selected cube face, `VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT` together with `VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE` can be used.
+
+== Issues
+
+No known issues.

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -6871,6 +6871,11 @@ typedef void <name>CAMetalLayer</name>;
             <member noautovalidity="true" optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>shaderEarlyAndLateFragmentTests</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*                                                   <name>pNext</name></member>
+            <member><type>VkBool32</type>                                                                                      <name>nonSeamlessCubeMap</name></member>
+        </type>
     </types>
     <comment>Vulkan enumerant (token) definitions</comment>
 
@@ -18490,11 +18495,13 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_EXT_extension_422&quot;"              name="VK_EXT_EXTENSION_422_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_disable_cube_map_wrap" number="423" author="EXT" contact="Georg Lehmann @DadSchoorse" supported="disabled">
+        <extension name="VK_EXT_non_seamless_cube_map" number="423" author="EXT" type="device" contact="Georg Lehmann @DadSchoorse" specialuse="d3demulation,glemulation" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_DISABLE_CUBE_MAP_WRAP_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_disable_cube_map_wrap&quot;"      name="VK_EXT_DISABLE_CUBE_MAP_WRAP_EXTENSION_NAME"/>
-                <enum bitpos="2"  extends="VkSamplerCreateFlagBits"         name="VK_SAMPLER_CREATE_RESERVED_2_BIT_EXT"/>
+                <enum value="1"                                             name="VK_EXT_NON_SEAMLESS_CUBE_MAP_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_non_seamless_cube_map&quot;"      name="VK_EXT_NON_SEAMLESS_CUBE_MAP_EXTENSION_NAME"/>
+                <enum bitpos="2" extends="VkSamplerCreateFlagBits"          name="VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT"/>
+                <type name="VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"/>
             </require>
         </extension>
         <extension name="VK_ARM_extension_424" number="424" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="disabled">


### PR DESCRIPTION
Core Vulkan always uses seamless cube map edge wrapping. Out of bounds accesses select texels from the neighboring face with linear filter, or get clamp to edge behavior with nearest filter. D3D9 has no seamless cube maps, the sampler wrap modes apply within the selected face. OpenGL has a global toggle with ARB_seamless_cube_map and a per texture toggle with ARB_seamless_cubemap_per_texture.

For DXVK (D3D9 to Vulkan translation) we need D3D9 cube map behavior since games were designed with it in mind and some don't look correct with seamless cube map edge handling. Zink or other OpenGL translation layers might also be interested in non-seamless cube maps to implement the previously mentioned OpenGL extensions.

anv implementation: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/12730
radv implementation: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/12729
some basic CTS tests: https://github.com/KhronosGroup/VK-GL-CTS/pull/286