### PR TITLE
Mitigate misuse of contact links

### DIFF
--- a/scripts/extensionmetadocgenerator.py
+++ b/scripts/extensionmetadocgenerator.py
@@ -332,7 +332,9 @@ class Extension:
                 if handle.startswith('gitlab:'):
                     prettyHandle = 'icon:gitlab[alt=GitLab, role="red"]' + handle.replace('gitlab:@', '')
                 elif handle.startswith('@'):
-                    trackerLink = 'link:++https://github.com/KhronosGroup/Vulkan-Docs/issues/new?title=' + self.name + ':%20&body=' + handle + '%20++'
+                    issuePlaceholderText = '[' + self.name + '] ' + handle
+                    issuePlaceholderText += '%0A<<Here describe the issue or question you have about the ' + self.name + ' extension>>'
+                    trackerLink = 'link:++https://github.com/KhronosGroup/Vulkan-Docs/issues/new?body=' + issuePlaceholderText + '++'
                     prettyHandle = trackerLink + '[icon:github[alt=GitHub, role="black"]' + handle[1:] + ']'
                 else:
                     prettyHandle = handle
@@ -362,7 +364,7 @@ class ExtensionMetaDocOutputGenerator(OutputGenerator):
 
     - name          extension name string
     - number        extension number (optional)
-    - contact       name and github login or email address (optional)
+    - contact       name and GitHub login or email address (optional)
     - type          'instance' | 'device' (optional)
     - requires      list of comma-separated required API extensions (optional)
     - requiresCore  required core version of API (optional)

--- a/scripts/extensionmetadocgenerator.py
+++ b/scripts/extensionmetadocgenerator.py
@@ -335,7 +335,7 @@ class Extension:
                     issuePlaceholderText = '[' + self.name + '] ' + handle
                     issuePlaceholderText += '%0A<<Here describe the issue or question you have about the ' + self.name + ' extension>>'
                     trackerLink = 'link:++https://github.com/KhronosGroup/Vulkan-Docs/issues/new?body=' + issuePlaceholderText + '++'
-                    prettyHandle = trackerLink + '[icon:github[alt=GitHub, role="black"]' + handle[1:] + ']'
+                    prettyHandle = trackerLink + '[icon:github[alt=GitHub,role="black"]' + handle[1:] + ', window=_blank]'
                 else:
                     prettyHandle = handle
 


### PR DESCRIPTION
Remove Issue title which will cause GitHub Issue opening button to be disabled

Plus make the contact links open in new window for convenience.