### PR TITLE
vk.xml: Adding len attribute to VkCuModuleCreateInfoNVX struct member pData.

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -5957,7 +5957,7 @@ typedef void <name>CAMetalLayer</name>;
             <member values="VK_STRUCTURE_TYPE_CU_MODULE_CREATE_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*            <name>pNext</name></member>
             <member><type>size_t</type>                 <name>dataSize</name></member>
-            <member>const <type>void</type>*            <name>pData</name></member>
+            <member len="dataSize">const <type>void</type>*            <name>pData</name></member>
         </type>
         <type category="struct" name="VkCuFunctionCreateInfoNVX">
             <member values="VK_STRUCTURE_TYPE_CU_FUNCTION_CREATE_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>


### PR DESCRIPTION
Utilizing the python scripts for code generation that was dependent on the len attribute, I found the pData member did not have a len attribute and seemed to be related to the dataSize member though I did not see any official documentation on the matter.