### PR TITLE
vk.xml: Reorder `VkFormatFeatureFlags2KHR` xml attributes for alignment

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -310,7 +310,7 @@ typedef void <name>CAMetalLayer</name>;
         <type bitvalues="VkPipelineStageFlagBits2KHR"      category="bitmask">typedef <type>VkFlags64</type> <name>VkPipelineStageFlags2KHR</name>;</type>
         <type                                              category="bitmask">typedef <type>VkFlags</type> <name>VkAccelerationStructureMotionInfoFlagsNV</name>;</type>
         <type                                              category="bitmask">typedef <type>VkFlags</type> <name>VkAccelerationStructureMotionInstanceFlagsNV</name>;</type>
-        <type                                              category="bitmask"  bitvalues="VkFormatFeatureFlagBits2KHR">typedef <type>VkFlags64</type> <name>VkFormatFeatureFlags2KHR</name>;</type>
+        <type bitvalues="VkFormatFeatureFlagBits2KHR"      category="bitmask">typedef <type>VkFlags64</type> <name>VkFormatFeatureFlags2KHR</name>;</type>
 
             <comment>WSI extensions</comment>
         <type requires="VkCompositeAlphaFlagBitsKHR"      category="bitmask">typedef <type>VkFlags</type> <name>VkCompositeAlphaFlagsKHR</name>;</type>


### PR DESCRIPTION
Just like the other two users of `bitvalues=` right above, provide this as the first attribute to maintain consistent alignment.
