### PR TITLE
Typos

### DIFF
--- a/appendices/VK_KHR_display_swapchain.txt
+++ b/appendices/VK_KHR_display_swapchain.txt
@@ -101,7 +101,7 @@ https://github.com/KhronosGroup/Vulkan-Tools/blob/master/cube/cube.c).
 
  * Revision 4, 2015-09-08 (James Jones)
    - Allow creating multiple swap chains that share the same images using a
-     single call to vkCreateSwapChainKHR().
+     single call to vkCreateSwapchainKHR().
 
  * Revision 5, 2015-09-10 (Alon Or-bach)
    - Removed underscores from SWAP_CHAIN in two enums.

--- a/chapters/VK_KHR_present_wait/WaitForPresent.txt
+++ b/chapters/VK_KHR_present_wait/WaitForPresent.txt
@@ -33,7 +33,7 @@ with such an image must: be signaled no later than a wait associated with
 the replacing image would be signaled.
 
 When the presentation has completed, the presentId associated with the
-related pname:pSwapChains entry will be increased in value so that it is at
+related pname:pSwapchains entry will be increased in value so that it is at
 least equal to the value provided in the sname:VkPresentIdKHR structure.
 
 There is no requirement for any precise timing relationship between the

--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -869,7 +869,7 @@ ename:VkResult code.
 .Note
 ====
 Returning a result in finite time guarantees that the implementation cannot
-deadlock an application, or suspend its execution indefintely with correct
+deadlock an application, or suspend its execution indefinitely with correct
 API usage.
 Acquiring too many images at once may block indefinitely, which is covered
 by valid usage when attempting to use code:UINT64_MAX.


### PR DESCRIPTION
Hey there!

I'm just learning Vulkan (with Win32) and found these three typos in the PDF version of "Vulkan® 1.2.189 - A Specification (with KHR extensions)".
Thanks for this awesome documentation. :)

-Hai