### PR TITLE
Register remaining newly introduced `vk_video` types in vk.xml

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -5776,6 +5776,8 @@ typedef void <name>CAMetalLayer</name>;
         <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265SubLayerHrdParameters"/>
         <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265HrdFlags"/>
         <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265SpsVuiFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265SliceType"/>
+        <type requires="vk_video/vulkan_video_codec_h265std.h" name="StdVideoH265PictureType"/>
         <type category="include" name="vk_video/vulkan_video_codec_h265std_decode.h">#include "vk_video/vulkan_video_codec_h265std_decode.h"</type>
         <type requires="vk_video/vulkan_video_codec_h265std_decode.h" name="StdVideoDecodeH265PictureInfo"/>
         <type requires="vk_video/vulkan_video_codec_h265std_decode.h" name="StdVideoDecodeH265ReferenceInfo"/>
@@ -6010,6 +6012,9 @@ typedef void <name>CAMetalLayer</name>;
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265SliceHeader"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceInfo"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceModifications"/>
+        <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265SliceHeaderFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceInfoFlags"/>
+        <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceModificationFlags"/>
         <type category="struct" name="VkVideoEncodeH265SessionParametersAddInfoEXT" structextends="VkVideoSessionParametersUpdateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_EXT"><type>VkStructureType</type><name>sType</name></member>
             <member optional="true">const <type>void</type>*                                               <name>pNext</name></member>


### PR DESCRIPTION
This is a follow-up to #1515, adding all the newly introduced types that are defined in `vk_video` but have not been referenced in vk.xml. I am using this information for the generation of bindings.
