### PR TITLE
Clarify that an acceleration structure can be updated in-place by setting `srcAccelerationStructure` and `dstAccelerationStructure` to the same structure

### DIFF
--- a/chapters/accelstructures.txt
+++ b/chapters/accelstructures.txt
@@ -459,6 +459,11 @@ include::{generated}/api/structs/VkAccelerationStructureBuildGeometryInfoKHR.txt
   * pname:scratchData is the device or host address to memory that will be
     used as scratch memory for the build.
 
+If pname:mode is ename:VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, an
+acceleration structure can be updated in-place by setting
+pname:srcAccelerationStructure and pname:dstAccelerationStructure to the same
+structure.
+
 Only one of pname:pGeometries or pname:ppGeometries can: be a valid pointer,
 the other must: be `NULL`.
 Each element of the non-`NULL` array describes the data used to build each


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-Docs/issues/1641.