### PR TITLE
[RFC] add VK_MESA_rect_list extension

### DIFF
--- a/appendices/VK_MESA_rect_list.txt
+++ b/appendices/VK_MESA_rect_list.txt
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Clément Guérin
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_MESA_rect_list.txt[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2021-11-15
+*Contributors*::
+  - Clément Guérin
+
+=== Description
+
+This extension adds a new elink:VkPrimitiveTopology code:enum where rectangles
+can be generated from a series of 3 axis-aligned vertices.
+This can be useful for drawing a rectangle without being split into two
+triangles with an internal edge.
+It is also useful to minimize the number of primitives that need to be
+drawn, particularly for a user interface.
+
+include::{generated}/interfaces/VK_MESA_rect_list.txt[]
+
+=== Version History
+
+  * Revision 1, 2021-11-15 (Clément Guérin)
+    - Internal revisions

--- a/chapters/drawing.txt
+++ b/chapters/drawing.txt
@@ -222,6 +222,10 @@ endif::VK_KHR_portability_subset[]
     with adjacency>>, with consecutive triangles sharing an edge.
   * ename:VK_PRIMITIVE_TOPOLOGY_PATCH_LIST specifies
     <<drawing-patch-lists,separate patch primitives>>.
+ifdef::VK_MESA_rect_list[]
+  * ename:VK_PRIMITIVE_TOPOLOGY_RECT_LIST_MESA specifies a series of
+    <<drawing-rect-lists,separate rectangle primitives>>.
+endif::VK_MESA_rect_list[]
 
 Each primitive topology, and its construction from a list of vertices, is
 described in detail below with a supporting diagram, according to the
@@ -320,6 +324,9 @@ The primitive topologies are grouped into the following topology classes:
                     ename:VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY,
                     ename:VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY
 | Patch           | ename:VK_PRIMITIVE_TOPOLOGY_PATCH_LIST
+ifdef::VK_MESA_rect_list[]
+| Rectangle       | ename:VK_PRIMITIVE_TOPOLOGY_RECT_LIST_MESA
+endif::VK_MESA_rect_list[]
 |===
 endif::VK_EXT_extended_dynamic_state[]
 
@@ -710,6 +717,21 @@ The vertices comprising a patch have no implied geometry, and are used as
 inputs to tessellation shaders and the fixed-function tessellator to
 generate new point, line, or triangle primitives.
 
+ifdef::VK_MESA_rect_list[]
+[[drawing-rect-lists]]
+=== Rectangle Lists
+
+When the primitive topology is ename:VK_PRIMITIVE_TOPOLOGY_RECT_LIST_MESA,
+each consecutive set of three vertices defines a single rectangle primitive,
+according to the equation:
+
+  {empty}:: [eq]#p~i~ = {v~3i~, v~3i+1~, v~3i+2~}#
+
+The number of primitives generated is equal to
+[eq]#{lfloor}pname:vertexCount/3{rfloor}#.
+
+They cannot be clipped, must be axis aligned, and cannot have depth gradient.
+endif::VK_MESA_rect_list[]
 
 [[drawing-primitive-order]]
 == Primitive Order

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -17450,6 +17450,13 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_NV_extension_433&quot;"           name="VK_NV_EXTENSION_433_EXTENSION_NAME"/>
             </require>
         </extension>
+        <extension name="VK_MESA_rect_list" number="434" type="device" author="MESA" contact="Clément Guérin @libcg" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_MESA_RECT_LIST_SPEC_VERSION"/>
+                <enum value="&quot;VK_MESA_rect_list&quot;"             name="VK_MESA_RECT_LIST_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkPrimitiveTopology"          name="VK_PRIMITIVE_TOPOLOGY_RECT_LIST_MESA"/>
+            </require>
+        </extension>
     </extensions>
     <spirvextensions comment="SPIR-V Extensions allowed in Vulkan and what is required to use it">
         <spirvextension name="SPV_KHR_variable_pointers">


### PR DESCRIPTION
`VK_MESA_rect_list` adds a new RECT_LIST primitive topology to rasterize rectangles from a list of 3 axis-aligned vertices.

The main motivation is to support emulation of AMD's Mantle API (precursor to Vulkan). Battlefield 4 is one game that uses this primitive topology.

It could also be useful for general API emulation, internal blitting operations can use this topology in place of triangle strips or triangle lists. Zink could benefit from this in particular.

This is my first extension, let me know if I missed anything. Thanks.