### PR TITLE
Minor changes about separate depth or stencil readonly image layout

### DIFF
--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1611,19 +1611,23 @@ attachments on multiple uses via ename:VK_ATTACHMENT_LOAD_OP_CLEAR.
     ename:VK_IMAGE_LAYOUT_PREINITIALIZED
   * [[VUID-VkAttachmentDescription-format-03280]]
     If pname:format is a color format, pname:initialLayout must: not be
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
-    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
   * [[VUID-VkAttachmentDescription-format-03281]]
     If pname:format is a depth/stencil format, pname:initialLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
   * [[VUID-VkAttachmentDescription-format-03282]]
     If pname:format is a color format, pname:finalLayout must: not be
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
-    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
   * [[VUID-VkAttachmentDescription-format-03283]]
     If pname:format is a depth/stencil format, pname:finalLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1609,37 +1609,35 @@ attachments on multiple uses via ename:VK_ATTACHMENT_LOAD_OP_CLEAR.
   * [[VUID-VkAttachmentDescription-finalLayout-00843]]
     pname:finalLayout must: not be ename:VK_IMAGE_LAYOUT_UNDEFINED or
     ename:VK_IMAGE_LAYOUT_PREINITIALIZED
-ifndef::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
+ifndef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03280]]
     If pname:format is a color format, pname:initialLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
-endif::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
-ifdef::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
-  * [[VUID-VkAttachmentDescription-format-03280]]
-    If pname:format is a color format, pname:initialLayout must: not be
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+  * If pname:format is a color format, pname:initialLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
     ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
-endif::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03281]]
     If pname:format is a depth/stencil format, pname:initialLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-ifndef::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
+ifndef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03282]]
     If pname:format is a color format, pname:finalLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
-endif::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
-ifdef::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
-  * [[VUID-VkAttachmentDescription-format-03282]]
-    If pname:format is a color format, pname:finalLayout must: not be
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+  * If pname:format is a color format, pname:finalLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
     ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
-endif::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03283]]
     If pname:format is a depth/stencil format, pname:finalLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1616,7 +1616,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
     ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, or
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
   * [[VUID-VkAttachmentDescription-format-03281]]
     If pname:format is a depth/stencil format, pname:initialLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
@@ -1627,7 +1627,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
     ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, or
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
   * [[VUID-VkAttachmentDescription-format-03283]]
     If pname:format is a depth/stencil format, pname:finalLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1609,25 +1609,37 @@ attachments on multiple uses via ename:VK_ATTACHMENT_LOAD_OP_CLEAR.
   * [[VUID-VkAttachmentDescription-finalLayout-00843]]
     pname:finalLayout must: not be ename:VK_IMAGE_LAYOUT_UNDEFINED or
     ename:VK_IMAGE_LAYOUT_PREINITIALIZED
+ifndef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03280]]
     If pname:format is a color format, pname:initialLayout must: not be
-ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
-    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
-    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
-endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, or
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+  * [[VUID-VkAttachmentDescription-format-03280]]
+    If pname:format is a color format, pname:initialLayout must: not be
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
+    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03281]]
     If pname:format is a depth/stencil format, pname:initialLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+ifndef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03282]]
     If pname:format is a color format, pname:finalLayout must: not be
-ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
-    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
-    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
-endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, or
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+  * [[VUID-VkAttachmentDescription-format-03282]]
+    If pname:format is a color format, pname:finalLayout must: not be
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
+    ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
+endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03283]]
     If pname:format is a depth/stencil format, pname:finalLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1609,33 +1609,25 @@ attachments on multiple uses via ename:VK_ATTACHMENT_LOAD_OP_CLEAR.
   * [[VUID-VkAttachmentDescription-finalLayout-00843]]
     pname:finalLayout must: not be ename:VK_IMAGE_LAYOUT_UNDEFINED or
     ename:VK_IMAGE_LAYOUT_PREINITIALIZED
-ifndef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03280]]
     If pname:format is a color format, pname:initialLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
-endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * If pname:format is a color format, pname:initialLayout must: not be
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
+    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03281]]
     If pname:format is a depth/stencil format, pname:initialLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-ifndef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03282]]
     If pname:format is a color format, pname:finalLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
-endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * If pname:format is a color format, pname:finalLayout must: not be
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
+    ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03283]]

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1609,37 +1609,37 @@ attachments on multiple uses via ename:VK_ATTACHMENT_LOAD_OP_CLEAR.
   * [[VUID-VkAttachmentDescription-finalLayout-00843]]
     pname:finalLayout must: not be ename:VK_IMAGE_LAYOUT_UNDEFINED or
     ename:VK_IMAGE_LAYOUT_PREINITIALIZED
-ifndef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+ifndef::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03280]]
     If pname:format is a color format, pname:initialLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
-endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
-ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+endif::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
+ifdef::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03280]]
     If pname:format is a color format, pname:initialLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
     ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
-endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
+endif::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03281]]
     If pname:format is a depth/stencil format, pname:initialLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-ifndef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+ifndef::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03282]]
     If pname:format is a color format, pname:finalLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
-endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
-ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
+endif::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
+ifdef::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03282]]
     If pname:format is a color format, pname:finalLayout must: not be
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL, or
     ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
-endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
+endif::VK_VERSION_1_1,VK_VERSION_1_2,VK_KHR_maintenance2[]
   * [[VUID-VkAttachmentDescription-format-03283]]
     If pname:format is a depth/stencil format, pname:finalLayout must: not
     be ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL


### PR DESCRIPTION
Separate depth or stencil readonly image layouts only exist in
Vulkan 1.1+ or via extension. It should not apprear at VUID 03280
and 03282 in 1.0.

The impacted image layouts are:
  - VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
  - VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL