### PR TITLE
Revise image layout matching rules

### DIFF
--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -3158,12 +3158,16 @@ performed through descriptors referring to only a single aspect of the
 image, where the following relaxed matching rules apply:
 
   * Descriptors referring just to the depth aspect of a depth/stencil image
-    only need to match in the image layout of the depth aspect, thus
+    only need to match in the image layout of the depth aspect. It is also
+    allowed to sample from the image in shader. Thus
+    ename:VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL and
     ename:VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL are
     considered to match.
   * Descriptors referring just to the stencil aspect of a depth/stencil
-    image only need to match in the image layout of the stencil aspect, thus
+    image only need to match in the image layout of the stencil aspect.
+    It is also allowed to sample from the image in shader. Thus
+    ename:VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL and
     ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL are
     considered to match


### PR DESCRIPTION
In the depth/stencil readonly image layout definition, it says that
VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL specifies a layout
for both the depth and stencil aspects of a depth/stencil format
image allowing read only access as a depth/stencil attachment or
in shaders as a sampled image.

So we should say that VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL is
compatible with depth/stencil readonly image layout.