### PR TITLE
Fix typo for VK_REMAINING_MIP_LEVELS.

### DIFF
--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -3231,7 +3231,7 @@ layer should be included in the view.
 include::{generated}/api/enums/VK_REMAINING_ARRAY_LAYERS.txt[]
 --
 
-[open,refpage='VK_REMAINING_MIP_LEVELS',desc='Sentinel for all remaining array layers',type='consts']
+[open,refpage='VK_REMAINING_MIP_LEVELS',desc='Sentinel for all remaining mipmap levels',type='consts']
 --
 ename:VK_REMAINING_MIP_LEVELS is a special constant value used for image
 views to indicate that all remaining mipmap levels in an image after the


### PR DESCRIPTION
Speaks for itself.