### PR TITLE
Clean up links to GLSL and SPIR-V extensions

### DIFF
--- a/appendices/VK_AMD_gcn_shader.txt
+++ b/appendices/VK_AMD_gcn_shader.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_AMD_gcn_shader.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/AMD/SPV_AMD_gcn_shader.html[`SPV_AMD_gcn_shader`]
+  - This extension provides API support for
+    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_gcn_shader.txt[`GL_AMD_gcn_shader`]
 *Contributors*::
   - Dominik Witczak, AMD
   - Daniel Rakos, AMD

--- a/appendices/VK_AMD_gpu_shader_half_float.txt
+++ b/appendices/VK_AMD_gpu_shader_half_float.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_AMD_gpu_shader_half_float.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/AMD/SPV_AMD_gpu_shader_half_float.html[`SPV_AMD_gpu_shader_half_float`]
+  - This extension provides API support for
+    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_gpu_shader_half_float.txt[`GL_AMD_gpu_shader_half_float`]
 *Contributors*::
   - Daniel Rakos, AMD
   - Dominik Witczak, AMD

--- a/appendices/VK_AMD_gpu_shader_int16.txt
+++ b/appendices/VK_AMD_gpu_shader_int16.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_AMD_gpu_shader_int16.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/AMD/SPV_AMD_gpu_shader_int16.html[`SPV_AMD_gpu_shader_int16`]
+  - This extension provides API support for
+    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_gpu_shader_int16.txt[`GL_AMD_gpu_shader_int16`]
 *Contributors*::
   - Daniel Rakos, AMD
   - Dominik Witczak, AMD
@@ -20,8 +22,6 @@ include::{generated}/meta/{refprefix}VK_AMD_gpu_shader_int16.txt[]
   - Rex Xu, AMD
   - Timothy Lottes, AMD
   - Zhi Cai, AMD
-*External Dependencies*::
-  - {spirv}/AMD/SPV_AMD_gpu_shader_int16.html[`SPV_AMD_gpu_shader_int16`]
 
 === Description
 

--- a/appendices/VK_AMD_shader_ballot.txt
+++ b/appendices/VK_AMD_shader_ballot.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_AMD_shader_ballot.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/AMD/SPV_AMD_shader_ballot.html[`SPV_AMD_shader_ballot`]
+  - This extension provides API support for
+    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_shader_ballot.txt[`GL_AMD_shader_ballot`]
 *Contributors*::
   - Qun Lin, AMD
   - Graham Sellers, AMD

--- a/appendices/VK_AMD_shader_explicit_vertex_parameter.txt
+++ b/appendices/VK_AMD_shader_explicit_vertex_parameter.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_AMD_shader_explicit_vertex_parameter.txt
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/AMD/SPV_AMD_shader_explicit_vertex_parameter.html[`SPV_AMD_shader_explicit_vertex_parameter`]
+  - This extension provides API support for
+    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_shader_explicit_vertex_parameter.txt[`GL_AMD_shader_explicit_vertex_parameter`]
 *Contributors*::
   - Matthaeus G. Chajdas, AMD
   - Qun Lin, AMD

--- a/appendices/VK_AMD_shader_fragment_mask.txt
+++ b/appendices/VK_AMD_shader_fragment_mask.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_AMD_shader_fragment_mask.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/AMD/SPV_AMD_shader_fragment_mask.html[`SPV_AMD_shader_fragment_mask`]
+  - This extension provides API support for
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/amd/GL_AMD_shader_fragment_mask.txt[`GL_AMD_shader_fragment_mask`]
 *Contributors*::
   - Aaron Hagan, AMD
   - Daniel Rakos, AMD

--- a/appendices/VK_AMD_shader_trinary_minmax.txt
+++ b/appendices/VK_AMD_shader_trinary_minmax.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_AMD_shader_trinary_minmax.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/AMD/SPV_AMD_shader_trinary_minmax.html[`SPV_AMD_shader_trinary_minmax`]
+  - This extension provides API support for
+    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_shader_trinary_minmax.txt[`GL_AMD_shader_trinary_minmax`]
 *Contributors*::
   - Matthaeus G. Chajdas, AMD
   - Qun Lin, AMD

--- a/appendices/VK_AMD_texture_gather_bias_lod.txt
+++ b/appendices/VK_AMD_texture_gather_bias_lod.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_AMD_texture_gather_bias_lod.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/AMD/SPV_AMD_texture_gather_bias_lod.html[`SPV_AMD_texture_gather_bias_lod`]
+  - This extension provides API support for
+    https://www.khronos.org/registry/OpenGL/extensions/AMD/AMD_texture_gather_bias_lod.txt[`GL_AMD_texture_gather_bias_lod`]
 *Contributors*::
   - Dominik Witczak, AMD
   - Daniel Rakos, AMD

--- a/appendices/VK_EXT_buffer_device_address.txt
+++ b/appendices/VK_EXT_buffer_device_address.txt
@@ -13,6 +13,10 @@ include::{generated}/meta/{refprefix}VK_EXT_buffer_device_address.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/EXT/SPV_EXT_physical_storage_buffer.html[`SPV_EXT_physical_storage_buffer`]
+  - This extension provides API support for
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_buffer_reference.txt[`GLSL_EXT_buffer_reference`]
+    and
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_buffer_reference_uvec2.txt[`GLSL_EXT_buffer_reference_uvec2`]
 *Contributors*::
   - Jeff Bolz, NVIDIA
   - Neil Henning, AMD

--- a/appendices/VK_EXT_descriptor_indexing.txt
+++ b/appendices/VK_EXT_descriptor_indexing.txt
@@ -10,6 +10,10 @@ include::{generated}/meta/{refprefix}VK_EXT_descriptor_indexing.txt[]
     2017-10-02
 *Interactions and External Dependencies*::
   - Promoted to Vulkan 1.2 Core
+  - This extension requires
+    {spirv}/EXT/SPV_EXT_descriptor_indexing.html[`SPV_EXT_descriptor_indexing`]
+  - This extension provides API support for
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_nonuniform_qualifier.txt[`GL_EXT_nonuniform_qualifier`]
 *Contributors*::
   - Jeff Bolz, NVIDIA
   - Daniel Rakos, AMD

--- a/appendices/VK_EXT_fragment_density_map.txt
+++ b/appendices/VK_EXT_fragment_density_map.txt
@@ -11,6 +11,8 @@ include::{generated}/meta/{refprefix}VK_EXT_fragment_density_map.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/EXT/SPV_EXT_fragment_invocation_density.html[`SPV_EXT_fragment_invocation_density`]
+  - This extension provides API support for
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_fragment_invocation_density.txt[`GL_EXT_fragment_invocation_density`]
 *Contributors*::
   - Matthew Netsch, Qualcomm Technologies, Inc.
   - Robert VanReenen, Qualcomm Technologies, Inc.

--- a/appendices/VK_EXT_shader_demote_to_helper_invocation.txt
+++ b/appendices/VK_EXT_shader_demote_to_helper_invocation.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_EXT_shader_demote_to_helper_invocation.t
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/EXT/SPV_EXT_demote_to_helper_invocation.html[`SPV_EXT_demote_to_helper_invocation`]
+  - This extension provides API support for
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_demote_to_helper_invocation.txt[`GL_EXT_demote_to_helper_invocation`]
 *Contributors*::
   - Jeff Bolz, NVIDIA
 

--- a/appendices/VK_EXT_shader_image_atomic_int64.txt
+++ b/appendices/VK_EXT_shader_image_atomic_int64.txt
@@ -10,19 +10,17 @@ include::{generated}/meta/{refprefix}VK_EXT_shader_image_atomic_int64.txt[]
     2020-07-14
 *IP Status*::
     No known IP claims.
+*Interactions and External Dependencies*::
+  - This extension requires
+    {spirv}/EXT/SPV_EXT_shader_image_int64.html[`SPV_EXT_shader_image_int64`]
+  - This extension provides API support for
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_shader_image_int64.txt[`GLSL_EXT_shader_image_int64`]
 *Contributors*::
   - Matthaeus Chajdas, AMD
   - Graham Wihlidal, Epic Games
   - Tobias Hector, AMD
   - Jeff Bolz, Nvidia
   - Jason Ekstrand, Intel
-*Interactions and External Dependencies*::
-  - This extension requires the
-    {spirv}/EXT/SPV_EXT_shader_image_int64.html[`SPV_EXT_shader_image_int64`]
-    SPIR-V extension.
-  - This extension requires the
-    https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_shader_image_int64.txt[`GLSL_EXT_shader_image_int64`]
-    extension for GLSL source languages.
 
 === Description
 

--- a/appendices/VK_HUAWEI_subpass_shading.txt
+++ b/appendices/VK_HUAWEI_subpass_shading.txt
@@ -10,9 +10,9 @@ include::{generated}/meta/{refprefix}VK_HUAWEI_subpass_shading.txt[]
     2021-06-01
 *Interactions and External Dependencies*::
   - This extension requires
-    https://github.com/KhronosGroup/GLSL/blob/master/extensions/huawei/GLSL_HUAWEI_subpass_shading.txt[`GL_HUAWEI_subpass_shading`].
-  - This extension requires
     {spirv}/HUAWEI/SPV_HUAWEI_subpass_shading.html[`SPV_HUAWEI_subpass_shading`].
+  - This extension provides API support for
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/huawei/GLSL_HUAWEI_subpass_shading.txt[`GL_HUAWEI_subpass_shading`].
 *Contributors*::
   - Hueilong Wang
 

--- a/appendices/VK_INTEL_shader_integer_functions2.txt
+++ b/appendices/VK_INTEL_shader_integer_functions2.txt
@@ -10,6 +10,11 @@ include::{generated}/meta/{refprefix}VK_INTEL_shader_integer_functions2.txt[]
     2019-04-30
 *IP Status*::
     No known IP claims.
+*Interactions and External Dependencies*::
+  - This extension requires
+    {spirv}/INTEL/SPV_INTEL_shader_integer_functions2.html[`SPV_INTEL_shader_integer_functions2`].
+  - This extension provides API support for
+    https://www.khronos.org/registry/OpenGL/extensions/INTEL/INTEL_shader_integer_functions2.txt[`GL_INTEL_shader_integer_functions2`].
 *Contributors*::
   - Ian Romanick, Intel
   - Ben Ashbaugh, Intel

--- a/appendices/VK_KHR_fragment_shading_rate.txt
+++ b/appendices/VK_KHR_fragment_shading_rate.txt
@@ -11,6 +11,8 @@ include::{generated}/meta/{refprefix}VK_KHR_fragment_shading_rate.txt[]
 *Interactions and External Dependencies*::
   - This extension requires
     {spirv}/KHR/SPV_KHR_fragment_shading_rate.html[`SPV_KHR_fragment_shading_rate`].
+  - This extension provides API support for
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_fragment_shading_rate.txt[`GL_EXT_fragment_shading_rate`]
 *Contributors*::
   - Tobias Hector, AMD
   - Guennadi Riguer, AMD

--- a/appendices/VK_KHR_shader_subgroup_uniform_control_flow.txt
+++ b/appendices/VK_KHR_shader_subgroup_uniform_control_flow.txt
@@ -14,6 +14,8 @@ include::{generated}/meta/{refprefix}VK_KHR_shader_subgroup_uniform_control_flow
   - Requires SPIR-V 1.3.
   - This extension requires
     {spirv}/KHR/SPV_KHR_subgroup_uniform_control_flow.html[`SPV_KHR_subgroup_uniform_control_flow`]
+  - This extension provides API support for
+    https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_subgroupuniform_qualifier.txt[`GL_EXT_subgroupuniform_qualifier`]
 *Contributors*::
   - Alan Baker, Google
   - Jeff Bolz, NVIDIA

--- a/appendices/VK_KHR_workgroup_memory_explicit_layout.txt
+++ b/appendices/VK_KHR_workgroup_memory_explicit_layout.txt
@@ -13,6 +13,8 @@ include::{generated}/meta/{refprefix}VK_KHR_workgroup_memory_explicit_layout.txt
 *Interactions and External Dependencies*::
  - This extension requires
    {spirv}/KHR/SPV_KHR_workgroup_memory_explicit_layout.html[`SPV_KHR_workgroup_memory_explicit_layout`]
+ - This extension provides API support for
+   https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_shared_memory_block.txt[`GL_EXT_shared_memory_block`]
 *Contributors*::
  - Caio Marcelo de Oliveira Filho, Intel
  - Jeff Bolz, NVIDIA

--- a/appendices/VK_NV_shader_sm_builtins.txt
+++ b/appendices/VK_NV_shader_sm_builtins.txt
@@ -11,9 +11,8 @@ include::{generated}/meta/{refprefix}VK_NV_shader_sm_builtins.txt[]
 *Interactions and External Dependencies*::
  - This extension requires
    {spirv}/NV/SPV_NV_shader_sm_builtins.html[`SPV_NV_shader_sm_builtins`].
- - This extension enables
+ - This extension provides API support for
    https://github.com/KhronosGroup/GLSL/blob/master/extensions/nv/GLSL_NV_shader_sm_builtins.txt[`GL_NV_shader_sm_builtins`]
-   for GLSL source languages.
 *Contributors*::
   - Jeff Bolz, NVIDIA
   - Eric Werness, NVIDIA


### PR DESCRIPTION
There is still some inconsistency with GLSL, some extensions use `GL_...`  and others `GLSL_...`. E.g. `VK_EXT_shader_atomic_float` uses `GL_EXT_shader_atomic_float` but `VK_EXT_shader_atomic_float2` `GLSL_EXT_shader_atomic_float2`. But I'm not sure which option is preferred there.