### PR TITLE
Replace manual github links for SPIR-V and GLSL extensions

### DIFF
--- a/appendices/VK_KHR_multiview.txt
+++ b/appendices/VK_KHR_multiview.txt
@@ -15,7 +15,7 @@ include::{generated}/meta/{refprefix}VK_KHR_multiview.txt[]
   - This extension requires
     {spirv}/KHR/SPV_KHR_multiview.html[`SPV_KHR_multiview`]
   - This extension provides API support for
-    https://raw.githubusercontent.com/KhronosGroup/GLSL/master/extensions/ext/GL_EXT_multiview.txt[`GL_EXT_multiview`]
+    {GLSLregistry}/ext/GL_EXT_multiview.txt[`GL_EXT_multiview`]
 *Contributors*::
   - Jeff Bolz, NVIDIA
 
@@ -39,7 +39,7 @@ This extension enables the use of the
 which adds a new `ViewIndex` built-in type that allows shaders to control
 what to do for each view.
 If using GLSL there is also the
-https://raw.githubusercontent.com/KhronosGroup/GLSL/master/extensions/ext/GL_EXT_multiview.txt[`GL_EXT_multiview`]
+{GLSLregistry}/ext/GL_EXT_multiview.txt[`GL_EXT_multiview`]
 extension that introduces a `highp int gl_ViewIndex;` built-in variable for
 vertex, tessellation, geometry, and fragment shaders.
 

--- a/appendices/VK_KHR_ray_query.txt
+++ b/appendices/VK_KHR_ray_query.txt
@@ -10,7 +10,7 @@ include::{generated}/meta/{refprefix}VK_KHR_ray_query.txt[]
     2020-11-12
 *Interactions and External Dependencies*::
   - This extension requires
-    https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_ray_query.html[`SPV_KHR_ray_query`]
+    {spirv}/KHR/SPV_KHR_ray_query.html[`SPV_KHR_ray_query`]
   - This extension provides API support for
     {GLSLregistry}/ext/GLSL_EXT_ray_query.txt[`GLSL_EXT_ray_query`]
 *Contributors*::

--- a/appendices/VK_KHR_ray_tracing_pipeline.txt
+++ b/appendices/VK_KHR_ray_tracing_pipeline.txt
@@ -10,7 +10,7 @@ include::{generated}/meta/{refprefix}VK_KHR_ray_tracing_pipeline.txt[]
     2020-11-12
 *Interactions and External Dependencies*::
   - This extension requires
-    https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_ray_tracing.html[`SPV_KHR_ray_tracing`]
+    {spirv}/KHR/SPV_KHR_ray_tracing.html[`SPV_KHR_ray_tracing`]
   - This extension provides API support for
     {GLSLregistry}/ext/GLSL_EXT_ray_tracing.txt[`GLSL_EXT_ray_tracing`]
   - This extension interacts with <<versions-1.2, Vulkan 1.2>> and

--- a/appendices/VK_KHR_shader_atomic_int64.txt
+++ b/appendices/VK_KHR_shader_atomic_int64.txt
@@ -10,10 +10,9 @@ include::{generated}/meta/{refprefix}VK_KHR_shader_atomic_int64.txt[]
     2018-07-05
 *Interactions and External Dependencies*::
   - Promoted to Vulkan 1.2 Core
-  - This extension enables
+  - This extension provides API support for
     {GLregistry}/ARB/ARB_gpu_shader_int64.txt[`GL_ARB_gpu_shader_int64`] and
     {GLSLregistry}/ext/GL_EXT_shader_atomic_int64.txt[`GL_EXT_shader_atomic_int64`]
-    for GLSL source languages.
 *Contributors*::
   - Aaron Hagan, AMD
   - Daniel Rakos, AMD

--- a/appendices/VK_KHR_shader_atomic_int64.txt
+++ b/appendices/VK_KHR_shader_atomic_int64.txt
@@ -12,7 +12,7 @@ include::{generated}/meta/{refprefix}VK_KHR_shader_atomic_int64.txt[]
   - Promoted to Vulkan 1.2 Core
   - This extension enables
     {GLregistry}/ARB/ARB_gpu_shader_int64.txt[`GL_ARB_gpu_shader_int64`] and
-    https://raw.githubusercontent.com/KhronosGroup/GLSL/master/extensions/ext/GL_EXT_shader_atomic_int64.txt[`GL_EXT_shader_atomic_int64`]
+    {GLSLregistry}/ext/GL_EXT_shader_atomic_int64.txt[`GL_EXT_shader_atomic_int64`]
     for GLSL source languages.
 *Contributors*::
   - Aaron Hagan, AMD


### PR DESCRIPTION
These were missed in the last spec update.