### PR TITLE
A handful of AsciiDoc "If" and punctuation fixes

### DIFF
--- a/chapters/clears.txt
+++ b/chapters/clears.txt
@@ -511,7 +511,7 @@ include::{generated}/api/protos/vkCmdFillBuffer.txt[]
     pname:size bytes of data.
     The data word is written to memory according to the host endianness.
 
-fname:vkCmdFillBuffer is treated as "`transfer`" operation for the purposes
+fname:vkCmdFillBuffer is treated as a "`transfer`" operation for the purposes
 of synchronization barriers.
 The ename:VK_BUFFER_USAGE_TRANSFER_DST_BIT must: be specified in pname:usage
 of slink:VkBufferCreateInfo in order for the buffer to be compatible with
@@ -604,7 +604,7 @@ The source data is copied from the user pointer to the command buffer when
 the command is called.
 
 fname:vkCmdUpdateBuffer is only allowed outside of a render pass.
-This command is treated as "`transfer`" operation, for the purposes of
+This command is treated as a "`transfer`" operation for the purposes of
 synchronization barriers.
 The ename:VK_BUFFER_USAGE_TRANSFER_DST_BIT must: be specified in pname:usage
 of slink:VkBufferCreateInfo in order for the buffer to be compatible with

--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -4753,11 +4753,11 @@ range of some buffer.
 
 If the buffer was created with a non-zero value of
 ifdef::VK_VERSION_1_2,VK_KHR_buffer_device_address[]
-slink:VkBufferOpaqueCaptureAddressCreateInfo::pname:opaqueCaptureAddress
-ifdef::VK_EXT_buffer_device_address[or]
+ifdef::VK_EXT_buffer_device_address[slink:VkBufferOpaqueCaptureAddressCreateInfo::pname:opaqueCaptureAddress or]
+ifndef::VK_EXT_buffer_device_address[slink:VkBufferOpaqueCaptureAddressCreateInfo::pname:opaqueCaptureAddress,]
 endif::VK_VERSION_1_2,VK_KHR_buffer_device_address[]
 ifdef::VK_EXT_buffer_device_address[]
-slink:VkBufferDeviceAddressCreateInfoEXT::pname:deviceAddress
+slink:VkBufferDeviceAddressCreateInfoEXT::pname:deviceAddress,
 endif::VK_EXT_buffer_device_address[]
 the return value will be the same address that was returned at capture time.
 

--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -8,7 +8,7 @@
 A _descriptor_ is an opaque data structure representing a shader resource
 such as a buffer, buffer view, image view, sampler, or combined image
 sampler.
-Descriptors are organised into _descriptor sets_, which are bound during
+Descriptors are organized into _descriptor sets_, which are bound during
 command recording for use in subsequent drawing commands.
 The arrangement of content in each descriptor set is determined by a
 _descriptor set layout_, which determines what descriptors can be stored

--- a/chapters/descriptorsets.txt
+++ b/chapters/descriptorsets.txt
@@ -1940,7 +1940,7 @@ any shader source.
 
 [[descriptorsets-pipelinelayout-consistency]]
 All resource variables <<shaders-staticuse,statically used>> in all shaders
-in a pipeline must: be declared with a (set,binding,arrayElement) that
+in a pipeline must: be declared with a (set, binding, arrayElement) that
 exists in the corresponding descriptor set layout and is of an appropriate
 descriptor type and includes the set of shader stages it is used by in
 pname:stageFlags.

--- a/chapters/primsrast.txt
+++ b/chapters/primsrast.txt
@@ -2167,7 +2167,7 @@ endif::VK_NV_shading_rate_image[]
 
 Sample shading can: be used to specify a minimum number of unique samples to
 process for each fragment.
-If sample shading is enabled an implementation must: provide a minimum of
+If sample shading is enabled, an implementation must: provide a minimum of
 [eq]#max({lceil} pname:minSampleShadingFactor {times} pname:totalSamples
 {rceil}, 1)# unique associated data for each fragment, where
 pname:minSampleShadingFactor is the minimum fraction of sample shading.

--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -3176,9 +3176,11 @@ sname:VkDescriptorImageInfo structure (see <<descriptorsets-updates>>).
 
 At the time that any command buffer command accessing an image executes on
 any queue, the layouts of the image subresources that are accessed must: all
-match exactly the layout specified via the API controlling those accesses
+match exactly the layout specified via the API controlling those
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[accesses,]
+ifndef::VK_VERSION_1_1,VK_KHR_maintenance2[accesses.]
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]
-, except in case of accesses to an image with a depth/stencil format
+except in case of accesses to an image with a depth/stencil format
 performed through descriptors referring to only a single aspect of the
 image, where the following relaxed matching rules apply:
 
@@ -3191,9 +3193,8 @@ image, where the following relaxed matching rules apply:
     image only need to match in the image layout of the stencil aspect, thus
     ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL and
     ename:VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL are
-    considered to match
+    considered to match.
 endif::VK_VERSION_1_1,VK_KHR_maintenance2[]
-.
 
 When performing a layout transition on an image subresource, the old layout
 value must: either equal the current layout of the image subresource (at the


### PR DESCRIPTION
This
- fixes AsciiDoc "If" usage in two places to fix spaces, one with comma, in the rendered PDF
- adds two commas in total
- adds missing spaces in a comma-separated list

Sorry for not using the commit titles properly - For 3 of 4, it's detailed in the descriptions instead.
