### PR TITLE
xml/vk: Reference underlying type instead of typedef in `structextends`

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -3181,7 +3181,7 @@ typedef void <name>CAMetalLayer</name>;
             <member><type>float</type>                            <name>x</name></member>
             <member><type>float</type>                            <name>y</name></member>
         </type>
-        <type category="struct" name="VkSampleLocationsInfoEXT" structextends="VkImageMemoryBarrier,VkImageMemoryBarrier2KHR">
+        <type category="struct" name="VkSampleLocationsInfoEXT" structextends="VkImageMemoryBarrier,VkImageMemoryBarrier2">
             <member values="VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
             <member noautovalidity="true"><type>VkSampleCountFlagBits</type>  <name>sampleLocationsPerPixel</name></member>
@@ -5315,7 +5315,7 @@ typedef void <name>CAMetalLayer</name>;
             <member optional="true"><type>void</type>*                           <name>pNext</name><comment>Pointer to next structure</comment></member>
             <member noautovalidity="true"><type>VkSurfaceTransformFlagBitsKHR</type>   <name>transform</name></member>
         </type>
-        <type category="struct" name="VkCopyCommandTransformInfoQCOM" structextends="VkBufferImageCopy2KHR,VkImageBlit2KHR">
+        <type category="struct" name="VkCopyCommandTransformInfoQCOM" structextends="VkBufferImageCopy2,VkImageBlit2">
             <member values="VK_STRUCTURE_TYPE_COPY_COMMAND_TRANSFORM_INFO_QCOM"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true" noautovalidity="true">const <type>void</type>*     <name>pNext</name></member>
             <member noautovalidity="true"><type>VkSurfaceTransformFlagBitsKHR</type>   <name>transform</name></member>


### PR DESCRIPTION
Thus far `structextends` has always noted the name of the struct it extends directly, not one of the aliases redirecting to it.  Our generator gets "confused" by this because we haven't taught it to perform an alias lookup here, and it seems cleaner to solve it in vk.xml directly.  After all, many more structs that were stabilized in 1.3 had `structextends` references to it changed to drop the (`KHR`) extension suffix.
