### PR TITLE
Fix two typos in Feature Requirements section

### DIFF
--- a/chapters/features.txt
+++ b/chapters/features.txt
@@ -5034,7 +5034,7 @@ ifdef::VK_KHR_8bit_storage[]
     the `apiext:VK_KHR_8bit_storage` extension is supported.
 endif::VK_KHR_8bit_storage[]
 ifdef::VK_VERSION_1_2,VK_KHR_8bit_storage[]
-  * <<features-storageBuffer8BitAccess, pname:StorageBuffer8BitAccess>>, if
+  * <<features-storageBuffer8BitAccess, pname:storageBuffer8BitAccess>>, if
     <<features-uniformAndStorageBuffer8BitAccess,
     pname:uniformAndStorageBuffer8BitAccess>> is enabled.
 endif::VK_VERSION_1_2,VK_KHR_8bit_storage[]
@@ -5364,7 +5364,7 @@ ifdef::VK_VERSION_1_3,VK_KHR_shader_terminate_invocation[]
 endif::VK_VERSION_1_3,VK_KHR_shader_terminate_invocation[]
 ifdef::VK_VERSION_1_3,VK_KHR_zero_initialize_workgroup_memory[]
   * <<features-shaderZeroInitializeWorkgroupMemory,
-    pname:shaderZeroInitializeWorkgroupMem>>, if Vulkan 1.3 or the
+    pname:shaderZeroInitializeWorkgroupMemory>>, if Vulkan 1.3 or the
     `apiext:VK_KHR_zero_initialize_workgroup_memory` extension is supported.
 endif::VK_VERSION_1_3,VK_KHR_zero_initialize_workgroup_memory[]
 ifdef::VK_KHR_workgroup_memory_explicit_layout[]


### PR DESCRIPTION
This fixes two minor typos in the Feature Requirements section, noticed with #1747.