### PR TITLE
Fixed formula for "Texel Anisotropic Filtering"

### DIFF
--- a/chapters/textures.txt
+++ b/chapters/textures.txt
@@ -2749,16 +2749,14 @@ The sum [eq]#{tau}~2Daniso~# is defined using the single isotropic
      \frac{1}{N}\sum_{i=1}^{N}
      {\tau_{2D}\left (
        u \left ( x - \frac{1}{2} + \frac{i}{N+1} , y \right ),
-         \left ( v \left (x-\frac{1}{2}+\frac{i}{N+1}, y \right ),
-\right )
+       v \left (x-\frac{1}{2}+\frac{i}{N+1}, y \right )
      \right )},
      & \text{when}\  \rho_{x} > \rho_{y} \\
 \tau_{2Daniso} &=
      \frac{1}{N}\sum_{i=1}^{N}
      {\tau_{2D}\left (
-        u \left  ( x, y - \frac{1}{2} + \frac{i}{N+1} \right ),
-          \left ( v \left (x,y-\frac{1}{2}+\frac{i}{N+1} \right )
-\right )
+        u \left ( x, y - \frac{1}{2} + \frac{i}{N+1} \right ),
+        v \left (x,y-\frac{1}{2}+\frac{i}{N+1} \right )
      \right )},
      & \text{when}\  \rho_{y} \geq \rho_{x}
 \end{aligned}


### PR DESCRIPTION
This removes a syntax-breaking comma and wrong extra parentheses in the formula for "Texel Anisotropic Filtering" through minimal changes, and I've checked the rendering of the fix using LyX.
I think the original error came from copy-pasting formula parts from u for v.