### PR TITLE
add author id for NZXT Inc.

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -56,6 +56,7 @@ branch of the member gitlab server.
         <tag name="GOOGLE"      author="Google LLC"                    contact="Jesse Hall @critsec"/>
         <tag name="QCOM"        author="Qualcomm Technologies, Inc."   contact="Jeff Leger @jackohounhd"/>
         <tag name="LUNARG"      author="LunarG, Inc."                  contact="Karen Ghavam @karenghavam-lunarg"/>
+        <tag name="NZXT"        author="NZXT Inc."                     contact="Jacob Kiesel @xaeroxe"/>
         <tag name="SAMSUNG"     author="Samsung Electronics Co., Ltd." contact="Alon Or-bach @alonorbach"/>
         <tag name="SEC"         author="Samsung Electronics Co., Ltd." contact="Alon Or-bach @alonorbach"/>
         <tag name="TIZEN"       author="Samsung Electronics Co., Ltd." contact="Alon Or-bach @alonorbach"/>


### PR DESCRIPTION
NZXT is working on software for gamers which will require us to build a vulkan layer. Additional details on this software cannot be made public at this time.