### PR TITLE
Using different (less confusing) variable names to describe VkCompareOp

### DIFF
--- a/chapters/fragops.txt
+++ b/chapters/fragops.txt
@@ -1211,16 +1211,16 @@ stencil comparison function, are:
 include::{generated}/api/enums/VkCompareOp.txt[]
 
   * ename:VK_COMPARE_OP_NEVER specifies that the test evaluates to false.
-  * ename:VK_COMPARE_OP_LESS specifies that the test evaluates [eq]#A < B#.
-  * ename:VK_COMPARE_OP_EQUAL specifies that the test evaluates [eq]#A = B#.
+  * ename:VK_COMPARE_OP_LESS specifies that the test evaluates [eq]#F < A#.
+  * ename:VK_COMPARE_OP_EQUAL specifies that the test evaluates [eq]#F = A#.
   * ename:VK_COMPARE_OP_LESS_OR_EQUAL specifies that the test evaluates
-    [eq]#A {leq} B#.
-  * ename:VK_COMPARE_OP_GREATER specifies that the test evaluates [eq]#A >
-    B#.
-  * ename:VK_COMPARE_OP_NOT_EQUAL specifies that the test evaluates [eq]#A
-    {neq} B#.
+    [eq]#F {leq} A#.
+  * ename:VK_COMPARE_OP_GREATER specifies that the test evaluates [eq]#F >
+    A#.
+  * ename:VK_COMPARE_OP_NOT_EQUAL specifies that the test evaluates [eq]#F
+    {neq} A#.
   * ename:VK_COMPARE_OP_GREATER_OR_EQUAL specifies that the test evaluates
-    [eq]#A {geq} B#.
+    [eq]#F {geq} A#.
   * ename:VK_COMPARE_OP_ALWAYS specifies that the test evaluates to true.
 --
 
@@ -1303,7 +1303,7 @@ flink:vkCmdSetDepthCompareOp or
 endif::VK_VERSION_1_3,VK_EXT_extended_dynamic_state[]
 slink:VkPipelineDepthStencilStateCreateInfo::pname:depthCompareOp during
 pipeline creation.
-[eq]#z~f~# and [eq]#z~a~# are used as [eq]#A# and [eq]#B#, respectively, in
+[eq]#z~f~# and [eq]#z~a~# are used as [eq]#F# and [eq]#A#, respectively, in
 the operation specified by the elink:VkCompareOp.
 
 If the comparison evaluates to false, the coverage for the sample is set to


### PR DESCRIPTION
Found myself being confused by the used variable names `A` and `B`, where further below it is stated that `A`  corresponds to `z_f` (_not_ to `z_a`!) and `B` corresponds to `z_a`. 

`A` and `B` are just some variable names -- why not use different variable names, say, `F` and `A`?! Then the "f" variables would always refer to fragments, and the "a" variables would always refer to the (depth) attachment.