### PR TITLE
Fix missing structextends=VkRenderPassCreateInfo2 cases in XML

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -2365,7 +2365,7 @@ typedef void <name>CAMetalLayer</name>;
             <member><type>uint32_t</type>                         <name>maxMultiviewInstanceIndex</name><comment>max instance index for a draw in a multiview subpass</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewPropertiesKHR"                  alias="VkPhysicalDeviceMultiviewProperties"/>
-        <type category="struct" name="VkRenderPassMultiviewCreateInfo" structextends="VkRenderPassCreateInfo">
+        <type category="struct" name="VkRenderPassMultiviewCreateInfo" structextends="VkRenderPassCreateInfo,VkRenderPassCreateInfo2">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO"><type>VkStructureType</type>        <name>sType</name></member>
             <member>const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>               <name>subpassCount</name></member>
@@ -2672,7 +2672,7 @@ typedef void <name>CAMetalLayer</name>;
             <member><type>VkImageAspectFlags</type>              <name>aspectMask</name></member>
         </type>
         <type category="struct" name="VkInputAttachmentAspectReferenceKHR"                     alias="VkInputAttachmentAspectReference"/>
-        <type category="struct" name="VkRenderPassInputAttachmentAspectCreateInfo" structextends="VkRenderPassCreateInfo">
+        <type category="struct" name="VkRenderPassInputAttachmentAspectCreateInfo" structextends="VkRenderPassCreateInfo,VkRenderPassCreateInfo2">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*                     <name>pNext</name></member>
             <member><type>uint32_t</type>                        <name>aspectReferenceCount</name></member>


### PR DESCRIPTION
These are (presumably) intended to be useable through the newer `VkRenderPassCreateInfo2` interface, but that was not expressed in the XML.