### PR TITLE
Simplify example to non-extension elements

### DIFF
--- a/chapters/fundamentals.txt
+++ b/chapters/fundamentals.txt
@@ -1706,11 +1706,9 @@ indefinitely.
 [NOTE]
 .Note
 ====
-An example of a typo alias is from the type elink:VkColorSpaceKHR,
-introduced by the apiext:VK_KHR_surface extension.
-The enumerant ename:VK_COLORSPACE_SRGB_NONLINEAR_KHR was initially defined
-as part of elink:VkColorSpaceKHR.
+An example of a typo alias, ename:VK_STENCIL_FRONT_AND_BACK was initially
+defined as part of elink:VkStencilFaceFlagBits.
 Once the naming inconsistency was noticed, it was renamed to
-ename:VK_COLOR_SPACE_SRGB_NONLINEAR_KHR, and the old name aliased to the
+ename:VK_STENCIL_FACE_FRONT_AND_BACK, and the old name aliased to the
 correct name.
 ====


### PR DESCRIPTION
Simplify typo alias example to non-extension elements 

avoids 1.0 build warning