### PR TITLE
Fix order of swapchain vs device destruction.

### DIFF
--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -161,7 +161,7 @@ Vulkan swapchains have been destroyed.
 
 fname:vkCreateSwapchainKHR will return ename:VK_ERROR_DEVICE_LOST if the
 logical device was lost.
-The sname:VkSwapchainKHR is a child of the pname:device, and must: not be
+The sname:VkSwapchainKHR is a child of the pname:device, and must: be
 destroyed before the pname:device.
 However, sname:VkSurfaceKHR is not a child of any sname:VkDevice and is not
 affected by the lost device.


### PR DESCRIPTION
Reading the swapchain specs, I was surprised to stumble across [the following](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreateSwapchainKHR.html#:~:text=The%20VkSwapchainKHR%20is%20a%20child%20of%20the%20device%2C%20and%20must%20not%20be%20destroyed%20before%20the%20device.):

> The `VkSwapchainKHR` is a child of the `device`, and **must** not be destroyed before the `device`.

My understanding is that children of a device must be destroyed before the device itself, so I'm tempted to assume this sentence is mistaken. If it's not, perhaps some additional explanation might be helpful.
