### PR TITLE
Require Wayland WSI implementations to send wl_surface.commit in

### DIFF
--- a/chapters/VK_KHR_wayland_surface/platformCreateSurface_wayland.txt
+++ b/chapters/VK_KHR_wayland_surface/platformCreateSurface_wayland.txt
@@ -68,10 +68,8 @@ objects created from a particular code:wl_display and code:wl_surface.
 Also, calling flink:vkQueuePresentKHR will result in Vulkan sending
 code:wl_surface.commit requests to the underlying code:wl_surface of each
 sname:VkSwapchainKHR objects referenced by pname:pPresentInfo.
-If the swapchain is created with a present mode of
-ename:VK_PRESENT_MODE_MAILBOX_KHR or ename:VK_PRESENT_MODE_IMMEDIATE_KHR,
-then the corresponding code:wl_surface.attach, code:wl_surface.damage, and
-code:wl_surface.commit request must: be issued by the implementation during
+The code:wl_surface.attach, code:wl_surface.damage, and
+code:wl_surface.commit requests must: be issued by the implementation during
 the call to flink:vkQueuePresentKHR and must: not be issued by the
 implementation outside of flink:vkQueuePresentKHR.
 This ensures that any Wayland requests sent by the client after the call to
@@ -87,9 +85,6 @@ by the use of Wayland proxy object wrappers, to avoid race conditions.
 If the application wishes to synchronize any window changes with a
 particular frame, such requests must: be sent to the Wayland display server
 prior to calling flink:vkQueuePresentKHR.
-For full control over interactions between Vulkan rendering and other
-Wayland protocol requests and events, a present mode of
-ename:VK_PRESENT_MODE_MAILBOX_KHR should: be used.
 
 [open,refpage='VkWaylandSurfaceCreateFlagsKHR',desc='Reserved for future use',type='flags']
 --


### PR DESCRIPTION
vkQueuePresentKHR for all present modes. Clients already rely on this
behavior and the change merely syncs the spec to reality.

Context: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/15786#note_1337125