### PR TITLE
minor fixes for 1.3.213 spec

### DIFF
--- a/chapters/VK_EXT_pipeline_properties/pipeline_properties.txt
+++ b/chapters/VK_EXT_pipeline_properties/pipeline_properties.txt
@@ -31,6 +31,8 @@ identifier is implementation specific.
   * [[VUID-vkGetPipelinePropertiesEXT-pPipelineProperties-06739]]
     pname:pPipelineProperties must: be a valid pointer to a
     slink:VkPipelinePropertiesIdentifierEXT structure
+  * The <<features-pipelinePropertiesIdentifier,pipelinePropertiesIdentifier>>
+    feature must: be enabled
 ****
 
 include::{generated}/validity/protos/vkGetPipelinePropertiesEXT.txt[]

--- a/chapters/VK_KHR_surface/wsi.txt
+++ b/chapters/VK_KHR_surface/wsi.txt
@@ -984,8 +984,9 @@ ifndef::VK_EXT_image_compression_control_swapchain[]
 endif::VK_EXT_image_compression_control_swapchain[]
 ifdef::VK_EXT_image_compression_control_swapchain[]
   * [[VUID-VkSurfaceFormat2KHR-pNext-06750]]
-    If the `apiext:VK_EXT_image_compression_control_swapchain` extension is
-    not enabled, the pname:pNext chain must: not include an
+    If the
+    <<features-imageCompressionControlSwapchain,imageCompressionControlSwapchain>>
+    feature is not enabled, the pname:pNext chain must: not include an
     slink:VkImageCompressionPropertiesEXT structure
 endif::VK_EXT_image_compression_control_swapchain[]
 ****
@@ -996,7 +997,7 @@ include::{generated}/validity/structs/VkSurfaceFormat2KHR.txt[]
 
 ifdef::VK_EXT_image_compression_control[]
 ifdef::VK_EXT_image_compression_control_swapchain[]
-If the <<features-imageCompressionControl-swapchain,
+If the <<features-imageCompressionControlSwapchain,
 pname:imageCompressionControlSwapchain>> feature is supported and a
 slink:VkImageCompressionPropertiesEXT structure is included in the
 pname:pNext chain of this structure, then it will be filled with the

--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -521,8 +521,9 @@ ifndef::VK_EXT_image_compression_control_swapchain[]
 endif::VK_EXT_image_compression_control_swapchain[]
 ifdef::VK_EXT_image_compression_control_swapchain[]
   * [[VUID-VkSwapchainCreateInfoKHR-pNext-06752]]
-    If the `apiext:VK_EXT_image_compression_control_swapchain` extension is
-    not enabled, the pname:pNext chain must: not include an
+    If the
+    <<features-imageCompressionControlSwapchain,imageCompressionControlSwapchain>>
+    feature is not enabled, the pname:pNext chain must: not include an
     slink:VkImageCompressionControlEXT structure
 endif::VK_EXT_image_compression_control_swapchain[]
 endif::VK_EXT_image_compression_control[]

--- a/chapters/features.txt
+++ b/chapters/features.txt
@@ -5198,7 +5198,7 @@ The members of the
 sname:VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT structure
 describe the following features:
 
- * [[features-imageCompressionControl-swapchain]]
+ * [[features-imageCompressionControlSwapchain]]
     pname:imageCompressionControlSwapchain indicates that the implementation
     supports controlling image controls per swapchain and querying image
     compression properties per surface.
@@ -5673,7 +5673,7 @@ ifdef::VK_VERSION_1_3,VK_KHR_dynamic_rendering[]
     the `apiext:VK_KHR_dynamic_rendering` extension is supported.
 endif::VK_VERSION_1_3,VK_KHR_dynamic_rendering[]
 ifdef::VK_EXT_subpass_merge_feedback[]
-  * <<features-subpassMergeFeedback, pname::subpassMergeFeedback>>, if the
+  * <<features-subpassMergeFeedback, pname:subpassMergeFeedback>>, if the
     `apiext:VK_EXT_subpass_merge_feedback` extension is supported.
 endif::VK_EXT_subpass_merge_feedback[]
 ifdef::VK_KHR_ray_tracing_maintenance1[]


### PR DESCRIPTION
- Add VU for `pipelinePropertiesIdentifier` feature
- change VU from when `VK_EXT_image_compression_control_swapchain` is enable to `imageCompressionControlSwapchain` feature bit is enabled (unless there is some hidden reason why it shouldn't use the feature bit here)