### PR TITLE
Make VkImageResolve2 appear right after VkImageResolve

### DIFF
--- a/chapters/copies.txt
+++ b/chapters/copies.txt
@@ -1550,10 +1550,6 @@ include::{chapters}/commonvalidity/image_resolve_common.txt[]
 include::{generated}/validity/structs/VkImageResolve.txt[]
 --
 
-ifdef::VK_AMD_buffer_marker[]
-include::{chapters}/VK_AMD_buffer_marker/copies.txt[]
-endif::VK_AMD_buffer_marker[]
-
 ifdef::VK_VERSION_1_3,VK_KHR_copy_commands2[]
 
 A more extensible version of the resolve image command is defined below.
@@ -1663,3 +1659,7 @@ include::{chapters}/commonvalidity/image_resolve_common.txt[]
 include::{generated}/validity/structs/VkImageResolve2.txt[]
 --
 endif::VK_VERSION_1_3,VK_KHR_copy_commands2[]
+
+ifdef::VK_AMD_buffer_marker[]
+include::{chapters}/VK_AMD_buffer_marker/copies.txt[]
+endif::VK_AMD_buffer_marker[]


### PR DESCRIPTION
As described in #1855 part about ```vkCmdResolveImage2``` is at the end of sub-chapter 20.6 ("Buffer Markers") while it should be after ```vkCmdResolveImage``` so at the end of sub-chapter 20.5 ("Resloving Multisample Images").