### PR TITLE
Remove reference to nonexistent parameter.

### DIFF
--- a/chapters/shaders.txt
+++ b/chapters/shaders.txt
@@ -677,8 +677,7 @@ instructions and process the results.
 One ray generation shader is executed per ray tracing dispatch.
 Its location in the shader binding table (see <<shader-binding-table,Shader
 Binding Table>> for details) is passed directly into fname:vkCmdTraceRaysKHR
-using the pname:raygenShaderBindingTableBuffer and
-pname:raygenShaderBindingOffset parameters.
+using the pname:raygenShaderBindingTableBuffer parameter.
 
 
 [[shaders-intersection]]


### PR DESCRIPTION
Removed a mention of `raygenShaderBindingOffset` that incorrectly referred to it as a parameter of `vkCmdTraceRaysKHR`. It is a parameter of `vkCmdTraceRaysNV`.