### PR TITLE
Add VK_KHR_maintenance4 relaxed interface VUID

### DIFF
--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -1223,9 +1223,9 @@ ifndef::VK_VERSION_1_3,VK_KHR_maintenance4[]
 endif::VK_VERSION_1_3,VK_KHR_maintenance4[]
 ifdef::VK_VERSION_1_3,VK_KHR_maintenance4[]
   * [[VUID-{refpage}-LocalSizeId-06434]]
-    if execution mode code:LocalSizeId is used, <<features-maintenance4,
+    If execution mode code:LocalSizeId is used, <<features-maintenance4,
     pname:maintenance4>> must: be enabled
-  * if <<features-maintenance4, pname:maintenance4>> is not enabled, any
+  * If <<features-maintenance4, pname:maintenance4>> is not enabled, any
     code:OpTypeVector output interface variables must: not have a higher
     code:Component code:Count than a matching code:OpTypeVector input
     interface variable

--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -1217,11 +1217,18 @@ endif::VK_NV_ray_tracing_motion_blur[]
 ifndef::VK_VERSION_1_3,VK_KHR_maintenance4[]
   * [[VUID-{refpage}-LocalSizeId-06433]]
     The execution mode code:LocalSizeId must: not be used
+  * Any code:OpTypeVector output interface variables must: not have a higher
+    code:Component code:Count than a matching code:OpTypeVector input
+    interface variable
 endif::VK_VERSION_1_3,VK_KHR_maintenance4[]
 ifdef::VK_VERSION_1_3,VK_KHR_maintenance4[]
   * [[VUID-{refpage}-LocalSizeId-06434]]
     if execution mode code:LocalSizeId is used, <<features-maintenance4,
     pname:maintenance4>> must: be enabled
+  * if <<features-maintenance4, pname:maintenance4>> is not enabled, any
+    code:OpTypeVector output interface variables must: not have a higher
+    code:Component code:Count than a matching code:OpTypeVector input
+    interface variable
 endif::VK_VERSION_1_3,VK_KHR_maintenance4[]
   * [[VUID-{refpage}-Workgroup-06530]]
     The sum of size in bytes for variables and


### PR DESCRIPTION
This came up in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4148

The description of ` maintenance4` feature says

> The interface matching rules allow a larger output vector to match with a smaller input vector, with additional values being discarded.

and there is language in the [interface matching section](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#interfaces-iointerfaces-matching) but there is no explicit VUID to assign to this.

Open as always to suggestions on wording or placement of the VU