### PR TITLE
VkRenderingAttachmentInfo VU using wrong field name

### DIFF
--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -653,7 +653,7 @@ endif::VK_KHR_depth_stencil_resolve,VK_VERSION_1_2[]
     not ename:VK_RESOLVE_MODE_NONE, pname:imageView and
     pname:resolveImageView must: have the same elink:VkFormat
   * [[VUID-VkRenderingAttachmentInfo-imageView-06135]]
-    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:layout must: not
+    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:imageLayout must: not
     be ename:VK_IMAGE_LAYOUT_UNDEFINED,
     ename:VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
@@ -677,7 +677,7 @@ ifdef::VK_KHR_separate_depth_stencil_layouts,VK_VERSION_1_2[]
 endif::VK_KHR_separate_depth_stencil_layouts,VK_VERSION_1_2[]
 ifdef::VK_NV_shading_rate_image[]
   * [[VUID-VkRenderingAttachmentInfo-imageView-06138]]
-    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:layout must: not
+    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:imageLayout must: not
     be ename:VK_IMAGE_LAYOUT_SHADING_RATE_OPTIMAL_NV
   * [[VUID-VkRenderingAttachmentInfo-imageView-06139]]
     If pname:imageView is not dlink:VK_NULL_HANDLE and pname:resolveMode is
@@ -686,7 +686,7 @@ ifdef::VK_NV_shading_rate_image[]
 endif::VK_NV_shading_rate_image[]
 ifdef::VK_EXT_fragment_density_map[]
   * [[VUID-VkRenderingAttachmentInfo-imageView-06140]]
-    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:layout must: not
+    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:imageLayout must: not
     be ename:VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT
   * [[VUID-VkRenderingAttachmentInfo-imageView-06141]]
     If pname:imageView is not dlink:VK_NULL_HANDLE and pname:resolveMode is
@@ -701,7 +701,7 @@ ifdef::VK_VERSION_1_3,VK_KHR_synchronization2[]
 endif::VK_VERSION_1_3,VK_KHR_synchronization2[]
 ifdef::VK_KHR_fragment_shading_rate[]
   * [[VUID-VkRenderingAttachmentInfo-imageView-06143]]
-    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:layout must: not
+    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:imageLayout must: not
     be ename:VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR
   * [[VUID-VkRenderingAttachmentInfo-imageView-06144]]
     If pname:imageView is not dlink:VK_NULL_HANDLE and pname:resolveMode is
@@ -710,7 +710,7 @@ ifdef::VK_KHR_fragment_shading_rate[]
 endif::VK_KHR_fragment_shading_rate[]
 ifdef::VK_KHR_swapchain[]
   * [[VUID-VkRenderingAttachmentInfo-imageView-06145]]
-    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:layout must: not
+    If pname:imageView is not dlink:VK_NULL_HANDLE, pname:imageLayout must: not
     be ename:VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
   * [[VUID-VkRenderingAttachmentInfo-imageView-06146]]
     If pname:imageView is not dlink:VK_NULL_HANDLE and pname:resolveMode is


### PR DESCRIPTION
There is a `VkRenderingAttachmentInfo::imageLayout` and is what the Validation Layers are using for these VUs, think this is a simple typo