### PR TITLE
Remove redundant layout from dynamic rendering VU

### DIFF
--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -663,7 +663,6 @@ endif::VK_KHR_depth_stencil_resolve,VK_VERSION_1_2[]
     If pname:imageView is not dlink:VK_NULL_HANDLE and pname:resolveMode is
     not ename:VK_RESOLVE_MODE_NONE, pname:resolveImageLayout must: not be
     ename:VK_IMAGE_LAYOUT_UNDEFINED,
-    ename:VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
     ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, or


### PR DESCRIPTION
While writing Validation Layers tests ran into this that there is already `VUID-VkRenderingInfo-colorAttachmentCount-06091`

> If `colorAttachmentCount` is not 0 and the `imageView` member of an element of `pColorAttachments` is not [VK_NULL_HANDLE](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VK_NULL_HANDLE), if the `resolveMode` member of that element of `pColorAttachments` is not `VK_RESOLVE_MODE_NONE`, its `resolveImageLayout` member must not be `VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL` or **VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL**

So not sure why `VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL` is arbitrarily added in this VU as it wasn't also added for `VUID-VkRenderingAttachmentInfo-imageView-06135` because `VUID-VkRenderingInfo-colorAttachmentCount-06090` covers it

(context: VUID `06090` <-maps-> `06135` |  `06091` <-maps-> `06136` if you `expand up` this change on github a bit to see)