### PR TITLE
minor fixes for 1.3.215 spec

### DIFF
--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -550,11 +550,9 @@ endif::VK_VERSION_1_1[]
     storage class must: correspond to an entry in
     <<interfaces-resources-storage-class-correspondence, Shader Resource and
     Storage Class Correspondence>>
-ifdef::VK_NV_fragment_shader_barycentric,VK_KHR_fragment_shader_barycentric[]
   * [[VUID-{refpage}-Input-06778]]
     Variables with a storage class of code:Input in a fragment shader stage
-    that are decorated with code:perVertexKHR must: be declared as arrays
-endif::VK_NV_fragment_shader_barycentric,VK_KHR_fragment_shader_barycentric[]
+    that are decorated with code:PerVertexKHR must: be declared as arrays
 ****
 --
 

--- a/chapters/resources.txt
+++ b/chapters/resources.txt
@@ -6686,7 +6686,7 @@ endif::VK_EXT_image_drm_format_modifier[]
 ifdef::VK_EXT_image_drm_format_modifier[]
   * [[VUID-VkDeviceImageMemoryRequirements-pCreateInfo-06776]]
     The pname:pCreateInfo::pname:pNext chain must: not contain a
-    slink:VkImageDrmFormatModifierExplicitCreateInfoEXT structure.
+    slink:VkImageDrmFormatModifierExplicitCreateInfoEXT structure
 endif::VK_EXT_image_drm_format_modifier[]
   * [[VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06417]]
     If pname:pCreateInfo::pname:format specifies a _multi-planar_ format and


### PR DESCRIPTION
No need for the `ifdef` wrapper for standalone SPIR-V VUs since its in the unified SPIR-V spec, there isn't one for `VUID-StandaloneSpirv-PerVertexKHR-06777` which also references `PerVertexKHR`