### PR TITLE
fix typo: Initialization of **an** object has failed

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -7397,7 +7397,7 @@ typedef void <name>CAMetalLayer</name>;
             <comment>Error codes (negative values)</comment>
         <enum value="-1"    name="VK_ERROR_OUT_OF_HOST_MEMORY" comment="A host memory allocation has failed"/>
         <enum value="-2"    name="VK_ERROR_OUT_OF_DEVICE_MEMORY" comment="A device memory allocation has failed"/>
-        <enum value="-3"    name="VK_ERROR_INITIALIZATION_FAILED" comment="Initialization of a object has failed"/>
+        <enum value="-3"    name="VK_ERROR_INITIALIZATION_FAILED" comment="Initialization of an object has failed"/>
         <enum value="-4"    name="VK_ERROR_DEVICE_LOST" comment="The logical device has been lost. See &lt;&lt;devsandqueues-lost-device&gt;&gt;"/>
         <enum value="-5"    name="VK_ERROR_MEMORY_MAP_FAILED" comment="Mapping of a memory object has failed"/>
         <enum value="-6"    name="VK_ERROR_LAYER_NOT_PRESENT" comment="Layer specified does not exist"/>


### PR DESCRIPTION
I'm not a native speaker but I think this should be "an" object. At least "of an object" has much more Google results compared to "of a object".

I've run `make validate install test` and `(cd .. && make generated)` as the README in the xml directory told me. Is there anything else that I need to run to regenerate more resources?