### PR TITLE
Rework Vertex Input Address Calculation

### DIFF
--- a/chapters/fxvertex.txt
+++ b/chapters/fxvertex.txt
@@ -870,10 +870,14 @@ code:instanceIndex is calculated as follows:
     code:attribDesc.binding.
   * Let code:vertexIndex be the index of the vertex within the draw (a value
     between pname:firstVertex and pname:firstVertex+pname:vertexCount for
-    fname:vkCmdDraw, or a value taken from the index buffer for
+    fname:vkCmdDraw, or a value taken from the index buffer plus pname:vertexOffset for
     fname:vkCmdDrawIndexed), and let code:instanceIndex be the instance
     number of the draw (a value between pname:firstInstance and
     pname:firstInstance+pname:instanceCount).
+  * Let code:offset be an array of offsets into the currently bound vertex buffers specified during fname:vkCmdBindVertexBuffers
+ifdef::VK_VERSION_1_3[    or fname:vkCmdBindVertexBuffers2]
+ifdef::VK_EXT_extended_dynamic_state[    or fname:vkCmdBindVertexBuffers2EXT]
+    with pname:pOffsets.
 ifdef::VK_EXT_vertex_attribute_divisor[]
   * Let code:divisor be the member of
     slink:VkPipelineVertexInputDivisorStateCreateInfoEXT::pname:pVertexBindingDivisors
@@ -886,19 +890,19 @@ endif::VK_EXT_vertex_attribute_divisor[]
 bufferBindingAddress = buffer[binding].baseAddress + offset[binding];
 
 if (bindingDesc.inputRate == VK_VERTEX_INPUT_RATE_VERTEX)
-    vertexOffset = vertexIndex * bindingDesc.stride;
+    effectiveVertexOffset = vertexIndex * bindingDesc.stride;
 else
 ifndef::VK_EXT_vertex_attribute_divisor[]
-    vertexOffset = instanceIndex * bindingDesc.stride;
+    effectiveVertexOffset = instanceIndex * bindingDesc.stride;
 endif::VK_EXT_vertex_attribute_divisor[]
 ifdef::VK_EXT_vertex_attribute_divisor[]
     if (divisor == 0)
-        vertexOffset = firstInstance * bindingDesc.stride;
+        effectiveVertexOffset = firstInstance * bindingDesc.stride;
     else
-        vertexOffset = (firstInstance + ((instanceIndex - firstInstance) / divisor)) * bindingDesc.stride;
+        effectiveVertexOffset = (firstInstance + ((instanceIndex - firstInstance) / divisor)) * bindingDesc.stride;
 endif::VK_EXT_vertex_attribute_divisor[]
 
-attribAddress = bufferBindingAddress + vertexOffset + attribDesc.offset;
+attribAddress = bufferBindingAddress + effectiveVertexOffset + attribDesc.offset;
 ---------------------------------------------------
 
 [[fxvertex-input-extraction]]

--- a/chapters/fxvertex.txt
+++ b/chapters/fxvertex.txt
@@ -875,8 +875,7 @@ code:instanceIndex is calculated as follows:
     number of the draw (a value between pname:firstInstance and
     pname:firstInstance+pname:instanceCount).
   * Let code:offset be an array of offsets into the currently bound vertex buffers specified during fname:vkCmdBindVertexBuffers
-ifdef::VK_VERSION_1_3[    or fname:vkCmdBindVertexBuffers2]
-ifdef::VK_EXT_extended_dynamic_state[    or fname:vkCmdBindVertexBuffers2EXT]
+ifdef::VK_VERSION_1_3,VK_EXT_extended_dynamic_state[or fname:vkCmdBindVertexBuffers2]
     with pname:pOffsets.
 ifdef::VK_EXT_vertex_attribute_divisor[]
   * Let code:divisor be the member of


### PR DESCRIPTION
The current section is missing a definition for `offset` and does not mention what happens with `vertexOffset` from the indexed variants, but introduces a different quantity with the same name.
The updated text still doesn't talk about indirect draws, which might be worth adding.

This is the first time I do conditional markup, please let me know if I didn't get it right.