### PR TITLE
Remove contraction in VK_EXT_non_seamless_cube_map proposal

### DIFF
--- a/proposals/VK_EXT_non_seamless_cube_map.asciidoc
+++ b/proposals/VK_EXT_non_seamless_cube_map.asciidoc
@@ -21,7 +21,7 @@ This proposal aims to provide functionality to support non seamless cube maps.
 
 The idea behind this solution is to represent cube map textures as 2D array textures with 6 layers, one for each cube map face.
 Cube map coordinates can then be transformed to a face index and a 2D coordinate within this face, so that then the fixed function sampling takes care of applying the sampler address modes.
-A problem is correct LOD selection while preserving anisotropic filtering. Emulation of implicit derivatives with LOD offset can't be easily emulated with explicit derivatives.
+A problem is correct LOD selection while preserving anisotropic filtering. Emulation of implicit derivatives with LOD offset cannot be easily emulated with explicit derivatives.
 Additionally, having pipeline variants depending on if seamless cube sampling is used prevents precompiling pipelines if any cubes are used as this information is only known at draw time.
 With advanced OpenGL features it is also not possible to know if a sampling operation is seamless even at draw time, so emulation needs extra descriptors, uniforms and branches.
 


### PR DESCRIPTION
Just noticed this in the CI.