### PR TITLE
Change StencilRefLessFrontEXT to DepthLess in early depth test part in Fragment Operations chapter

### DIFF
--- a/chapters/fragops.txt
+++ b/chapters/fragops.txt
@@ -142,7 +142,7 @@ endif::VK_AMD_shader_early_and_late_fragment_tests[]
      the pipeline uses a
      slink:VkPipelineDepthStencilStateCreateInfo::pname:depthCompareOp of
      ename:VK_COMPARE_OP_GREATER or ename:VK_COMPARE_OP_GREATER_OR_EQUAL; or
-  ** the fragment shader specifies the code:StencilRefLessFrontEXT execution
+  ** the fragment shader specifies the code:DepthLess execution
      mode and the pipeline uses a
      slink:VkPipelineDepthStencilStateCreateInfo::pname:depthCompareOp of
      ename:VK_COMPARE_OP_LESS or ename:VK_COMPARE_OP_LESS_OR_EQUAL


### PR DESCRIPTION
`StencilRefLessFrontEXT` execution mode was used in part about early depth tests where it should be `DepthLess` execution mode. 