### PR TITLE
Add a new driver id VK_DRIVER_ID_MESA_DOZEN

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -8171,6 +8171,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="20"      name="VK_DRIVER_ID_MESA_PANVK"                    comment="Mesa open source project"/>
         <enum value="21"      name="VK_DRIVER_ID_SAMSUNG_PROPRIETARY"           comment="Samsung Electronics Co., Ltd."/>
         <enum value="22"      name="VK_DRIVER_ID_MESA_VENUS"                    comment="Mesa open source project"/>
+        <enum value="23"      name="VK_DRIVER_ID_MESA_DOZEN"                    comment="Mesa open source project"/>
     </enums>
     <enums name="VkConditionalRenderingFlagBitsEXT" type="bitmask">
         <enum bitpos="0"    name="VK_CONDITIONAL_RENDERING_INVERTED_BIT_EXT"/>


### PR DESCRIPTION
This is the driver ID for Dozen, the Vulkan-on-Direct3D driver in Mesa.