### PR TITLE
Relax the rule of VUID-VkRenderPassCreateInfo-srcSubpass-02517 and VUID-VkRenderPassCreateInfo-dstSubpass-02518

### DIFF
--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1192,9 +1192,9 @@ endif::VK_VERSION_1_1,VK_KHR_multiview[]
     supported by the <<synchronization-pipeline-stages-types, pipeline>>
     identified by the pname:pipelineBindPoint member of the destination
     subpass
-  * For any element of pname:pDependencies, if the pname:srcSubpass is not
+  * For any element of pname:pDependencies, if its pname:srcSubpass is not
     ename:VK_SUBPASS_EXTERNAL, it must: be less than pname:subpassCount
-  * For any element of pname:pDependencies, if the pname:dstSubpass is not
+  * For any element of pname:pDependencies, if its pname:dstSubpass is not
     ename:VK_SUBPASS_EXTERNAL, it must: be less than pname:subpassCount
 ****
 

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1193,11 +1193,11 @@ endif::VK_VERSION_1_1,VK_KHR_multiview[]
     identified by the pname:pipelineBindPoint member of the destination
     subpass
   * [[VUID-VkRenderPassCreateInfo-srcSubpass-02517]]
-    The pname:srcSubpass member of each element of pname:pDependencies must:
-    be less than pname:subpassCount
+    For any element of pname:pDependencies, if the pname:srcSubpass is not
+    ename:VK_SUBPASS_EXTERNAL, it must: be less than pname:subpassCount
   * [[VUID-VkRenderPassCreateInfo-dstSubpass-02518]]
-    The pname:dstSubpass member of each element of pname:pDependencies must:
-    be less than pname:subpassCount
+    For any element of pname:pDependencies, if the pname:dstSubpass is not
+    ename:VK_SUBPASS_EXTERNAL, it must: be less than pname:subpassCount
 ****
 
 include::{generated}/validity/structs/VkRenderPassCreateInfo.txt[]

--- a/chapters/renderpass.txt
+++ b/chapters/renderpass.txt
@@ -1192,11 +1192,9 @@ endif::VK_VERSION_1_1,VK_KHR_multiview[]
     supported by the <<synchronization-pipeline-stages-types, pipeline>>
     identified by the pname:pipelineBindPoint member of the destination
     subpass
-  * [[VUID-VkRenderPassCreateInfo-srcSubpass-02517]]
-    For any element of pname:pDependencies, if the pname:srcSubpass is not
+  * For any element of pname:pDependencies, if the pname:srcSubpass is not
     ename:VK_SUBPASS_EXTERNAL, it must: be less than pname:subpassCount
-  * [[VUID-VkRenderPassCreateInfo-dstSubpass-02518]]
-    For any element of pname:pDependencies, if the pname:dstSubpass is not
+  * For any element of pname:pDependencies, if the pname:dstSubpass is not
     ename:VK_SUBPASS_EXTERNAL, it must: be less than pname:subpassCount
 ****
 


### PR DESCRIPTION
PR for issue #1828

According to the validation rule of VUID-VkRenderPassCreateInfo-srcSubpass-02517 and VUID-VkRenderPassCreateInfo-dstSubpass-02518:

    VUID-VkRenderPassCreateInfo-srcSubpass-02517
    The srcSubpass member of each element of pDependencies must be less than subpassCount

    VUID-VkRenderPassCreateInfo-dstSubpass-02518
    The dstSubpass member of each element of pDependencies must be less than subpassCount

the srcSubpass should always be less than subpassCount to make sure it points to a valid subpass, but VK_SUBPASS_EXTERNAL seems to be an exception. It is fine to create a dependency like this (in pseudo code):

vk::SubpassDependency {
            src_subpass: vk::SUBPASS_EXTERNAL,
            src_stage_mask: vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
            dst_access_mask: vk::AccessFlags::COLOR_ATTACHMENT_READ
                | vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
            dst_stage_mask: vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
            ..Default::default()

at lease the validation layer says nothing wrong about this.

So it is  suggested to relax the rule to this:

    VUID-VkRenderPassCreateInfo-srcSubpass-02517
    For any element of pDependencies, if the srcSubpass is not VK_SUBPASS_EXTERNAL, it must be less than subpassCount

    VUID-VkRenderPassCreateInfo-dstSubpass-02518
    For any element of pDependencies, if the dstSubpass is not VK_SUBPASS_EXTERNAL, it must be less than subpassCount

Closes #1828