### PR TITLE
Explicit VU for Uniform being read only

### DIFF
--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -255,8 +255,10 @@ endif::VK_VERSION_1_1[]
     [eq]#v# components
   * [[VUID-{refpage}-OpTypeImage-04661]]
     Objects of types code:OpTypeImage, code:OpTypeSampler,
-    code:OpTypeSampledImage, and arrays of these types must: not be stored
-    to or modified
+    code:OpTypeSampledImage, code:OpTypeAccelerationStructureKHR,
+    and arrays of these types must: not be stored to or modified
+  * Any variable in the code:Uniform storage class must: not be stored to
+    or modified
   * [[VUID-{refpage}-Offset-04662]]
     Any image operation must: use at most one of the code:Offset,
     code:ConstOffset, and code:ConstOffsets image operands
@@ -273,9 +275,6 @@ endif::VK_VERSION_1_1[]
   * [[VUID-{refpage}-OpImage-04777]]
     code:OpImage*Dref* instructions must: not consume an image whose `Dim`
     is 3D
-  * [[VUID-{refpage}-OpTypeAccelerationStructureKHR-04665]]
-     Objects of types code:OpTypeAccelerationStructureKHR and arrays of this
-     type must: not be stored to or modified
   * [[VUID-{refpage}-OpReportIntersectionKHR-04666]]
     The value of the "`Hit Kind`" operand of code:OpReportIntersectionKHR
     must: be in the range [eq]#[0,127]#


### PR DESCRIPTION
According to the SPIR-V spec, `Uniform` are not defined as read-only (`UniformConstant` are) and `spirv-val` does validate this, but it is missing an explicit VUID and language in the Vulkan spec

Also combines the 2 VUs talking about which opaque types are read-only to a single VUID
(no need to change the VUID as neither `04661` or `04665` are currently being validated yet https://github.com/KhronosGroup/SPIRV-Tools/issues/4796)