### PR TITLE
Fix XML tagging of VkShaderModuleCreateInfo and add explicit VU

### DIFF
--- a/chapters/shaders.txt
+++ b/chapters/shaders.txt
@@ -81,6 +81,13 @@ slink:VkPipelineShaderStageCreateInfo.
 This avoids the overhead of creating and managing an additional object.
 endif::VK_EXT_graphics_pipeline_libraries[]
 
+.Valid Usage
+****
+  * If pname:pCreateInfo is not `NULL`, pname:pCreateInfo->pNext must: be
+    `NULL` or a pointer to a
+    slink:VkShaderModuleValidationCacheCreateInfoEXT structure
+****
+
 include::{generated}/validity/protos/vkCreateShaderModule.txt[]
 --
 
@@ -246,7 +253,7 @@ include::{generated}/api/protos/vkGetShaderModuleCreateInfoIdentifierEXT.txt[]
 
   * pname:device is the logical device that can: create a
     slink:VkShaderModule from pname:pCreateInfo.
-  * pname:pCreateInfo is a pointer to slink:VkShaderModuleCreateInfo.
+  * pname:pCreateInfo is a pointer to a slink:VkShaderModuleCreateInfo structure.
   * pname:pIdentifier is a pointer to the returned
     slink:VkShaderModuleIdentifierEXT.
 

--- a/chapters/shaders.txt
+++ b/chapters/shaders.txt
@@ -83,9 +83,15 @@ endif::VK_EXT_graphics_pipeline_libraries[]
 
 .Valid Usage
 ****
+ifdef::VK_EXT_validation_cache[]
   * If pname:pCreateInfo is not `NULL`, pname:pCreateInfo->pNext must: be
     `NULL` or a pointer to a
     slink:VkShaderModuleValidationCacheCreateInfoEXT structure
+endif::VK_EXT_validation_cache[]
+ifndef::VK_EXT_validation_cache[]
+  * If pname:pCreateInfo is not `NULL`, pname:pCreateInfo->pNext must: be
+    `NULL`
+endif::VK_EXT_validation_cache[]
 ****
 
 include::{generated}/validity/protos/vkCreateShaderModule.txt[]

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -1254,7 +1254,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkShaderModuleCreateInfo" structextends="VkPipelineShaderStageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member noautovalidity="true" optional="true">const <type>void</type>*            <name>pNext</name><comment>noautovalidity because this structure can be either an explicit parameter, or passed in a pNext chain</comment></member>
             <member optional="true"><type>VkShaderModuleCreateFlags</type> <name>flags</name></member>
             <member><type>size_t</type>                 <name>codeSize</name><comment>Specified in bytes</comment></member>
             <member len="latexmath:[\textrm{codeSize} \over 4]" altlen="codeSize / 4">const <type>uint32_t</type>*            <name>pCode</name><comment>Binary code of size codeSize</comment></member>
@@ -3352,7 +3352,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>size_t</type>                 <name>initialDataSize</name></member>
             <member len="initialDataSize">const <type>void</type>*            <name>pInitialData</name></member>
         </type>
-        <type category="struct" name="VkShaderModuleValidationCacheCreateInfoEXT" structextends="VkShaderModuleCreateInfo">
+        <type category="struct" name="VkShaderModuleValidationCacheCreateInfoEXT" structextends="VkShaderModuleCreateInfo,VkPipelineShaderStageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkValidationCacheEXT</type>    <name>validationCache</name></member>


### PR DESCRIPTION
VkShaderModuleCreateInfo appears both as an explicit parameter, and in
the pNext chain of VkPipelineShaderStageCreateInfo, The validity
generator doesn't understand this case fully.

Proposed solution is to add an explicit VU to vkCreateShaderModule
expressing the pNext constraint; make sure implicit VU for pNext are
suppressed; and properly tag the structextends attribute for the single
structure extending VkShaderModuleCreateInfo.

Fixes #1883