### PR TITLE
Add pd2 requirement for VK_EXT_blend_operation_advanced

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -15429,7 +15429,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkImageFormatListCreateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_blend_operation_advanced" number="149" type="device" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_EXT_blend_operation_advanced" number="149" type="device" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan" requires="VK_KHR_get_physical_device_properties2">
             <require>
                 <enum value="2"                                             name="VK_EXT_BLEND_OPERATION_ADVANCED_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_blend_operation_advanced&quot;"   name="VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME"/>


### PR DESCRIPTION
Ran into in a Validation Layer tests, `VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT` requires `VK_KHR_get_physical_device_properties2` but was missing from XML