### PR TITLE
GitHub CI: Regenerate and build-test Rust Vulkan bindings (Ash crate)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,6 +117,61 @@ jobs:
           name: hpp-outputs
           path: gen/include/
 
+  ash-generate:
+    name: Generate Rust bindings (Ash crate)
+    runs-on: ubuntu-latest
+    needs: spec-generate
+    continue-on-error: true
+    env:
+      # Cached folder outside of git repo
+      CARGO_TARGET_DIR: ${{ github.workspace }}/ash-target
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: ash-rs/ash
+          path: ash
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ash-target/
+          key: ${{ runner.os }}-cargo-ash-generator-${{ hashFiles('**/Cargo.toml', '.github/workflows/CI.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-ash-generator-
+      - name: Download generated spec
+        uses: actions/download-artifact@v3
+        with:
+          name: spec-outputs
+      - name: Unpack generated spec
+        run: tar -xvf spec-outputs.tar
+      - name: Prepare environment
+        working-directory: ash
+        run: |
+          # Piece together minimal Vulkan-Headers - Ash only needs headers and vk.xml
+          rm -rf generator/Vulkan-Headers/* # Should already be empty, just in case
+          ln -s ${{ github.workspace }}/gen/include generator/Vulkan-Headers/ # Complete headers come from spec-generate
+          ln -s ${{ github.workspace }}/xml generator/Vulkan-Headers/registry # vk.xml sits in the root of this spec repo
+
+      - name: Generate Ash crate
+        working-directory: ash
+        run: |
+          cargo run -p generator
+          cargo fmt --all
+
+      - name: Package generated Ash crate
+        # https://github.com/actions/upload-artifact#limitations, see above
+        run: tar -cvf ash-outputs.tar ash/
+      - name: Upload generated ash
+        uses: actions/upload-artifact@v3
+        with:
+          name: ash-outputs
+          path: ash-outputs.tar
+
   h-compile:
     name: Compile a simple test program that uses vulkan.h
     runs-on: ubuntu-latest
@@ -161,3 +216,31 @@ jobs:
       - run: |
           g++ -c -std=c++11 -Igen/include -IVulkan-Hpp -Wall -Wextra -Werror tests/hpptest.cpp
           clang++ -c -std=c++11 -Igen/include -IVulkan-Hpp -Wall -Wextra -Werror tests/hpptest.cpp
+
+  ash-compile:
+    name: Build-test Rust bindings (Ash crate)
+    runs-on: ubuntu-latest
+    needs: ash-generate
+    continue-on-error: true
+
+    steps:
+      - name: Download generated files
+        uses: actions/download-artifact@v3
+        with:
+          name: ash-outputs
+      - name: Unpack generated Ash crate
+        run: tar -xvf ash-outputs.tar
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ash/target/
+          key: ${{ runner.os }}-cargo-ash-compile-${{ hashFiles('**/Cargo.toml', '.github/workflows/CI.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-ash-compile-
+      - name: Build-test ash crate
+        working-directory: ash
+        run: cargo clippy --all --all-targets

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,8 @@ on:
   push:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # When a pull request is opened from a local branch or fork
+  pull_request:
 
 jobs:
   license-check:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,6 +154,6 @@ ash-compile:
     - ash-generate
   script:
     - cd ash
-    # Build-test all ash crates, including ash-window and the examples
+    # Build-test the ash crate
     - cargo clippy --all --all-targets
   allow_failure: true


### PR DESCRIPTION
_This complements a similar change done to the GitLab CI script._

Rust's Vulkan bindings, provided by [the Ash crate], rely on rather strict rules/conventions in vk.xml or otherwise fail to generate.  In order to provide more insight into the effect of spec changes to this project, and hopefully catch mishaps earlier (ie. naming rules for enum variants with respect to the typename of the enum) regenerate and build-test the Rust crate in the CI.

Since Rust bindings are not part of the official Khronos Vulkan SDK / release this check is currently allowed to fail.  Over time this task can be expanded to notify Ash maintainers when PRs merged to `main` break our build, so that we can resolve it quickly or request spec changes before they are released hence set-in-stone.  Additionally release managers can interpret build failures like [enum variant name mismatches] and address them on their own, or for the time being ping the Ash maintainers (me - @MarijnS95) to bring failures to our attention or request clarification/assistance.

[the Ash crate]: https://github.com/ash-rs/ash/
[enum variant name mismatches]: https://github.com/Traverse-Research/ash/blob/c4f1c053ea36e4de91094c63109eeda677ca3ecf/generator/src/lib.rs#L1207-L1210
