### PR TITLE
Add missing SPV_KHR_ray_tracing storage class VUID

### DIFF
--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -492,7 +492,7 @@ endif::VK_VERSION_1_1[]
     A variable with code:HitAttributeKHR storage class must: only be written
     to in an intersection shader
   * A variable with code:HitAttributeKHR storage class must: only be read
-    to in an any-hit or closest hit shader
+    from in an any-hit or closest hit shader
   * [[VUID-{refpage}-CallableDataKHR-04704]]
     code:CallableDataKHR storage class must: only be used in ray generation,
     closest hit, miss, and callable shaders

--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -491,6 +491,8 @@ endif::VK_VERSION_1_1[]
   * [[VUID-{refpage}-HitAttributeKHR-04703]]
     A variable with code:HitAttributeKHR storage class must: only be written
     to in an intersection shader
+  * A variable with code:HitAttributeKHR storage class must: only be read
+    to in an any-hit or closest hit shader
   * [[VUID-{refpage}-CallableDataKHR-04704]]
     code:CallableDataKHR storage class must: only be used in ray generation,
     closest hit, miss, and callable shaders
@@ -501,6 +503,8 @@ endif::VK_VERSION_1_1[]
     There must: be at most one variable with the
     code:IncomingCallableDataKHR storage class in the input interface of an
     entry point
+  * code:ShaderRecordBufferKHR storage class must: only be used in ray
+    generation, intersection, any-hit, closest hit, callable, or miss shaders
   * [[VUID-{refpage}-Base-04707]]
     The code:Base operand of code:OpPtrAccessChain must: point to one of the
     following: *Workgroup*, if code:VariablePointers is enabled;

--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -491,8 +491,6 @@ endif::VK_VERSION_1_1[]
   * [[VUID-{refpage}-HitAttributeKHR-04703]]
     A variable with code:HitAttributeKHR storage class must: only be written
     to in an intersection shader
-  * A variable with code:HitAttributeKHR storage class must: only be read
-    from in an any-hit or closest hit shader
   * [[VUID-{refpage}-CallableDataKHR-04704]]
     code:CallableDataKHR storage class must: only be used in ray generation,
     closest hit, miss, and callable shaders


### PR DESCRIPTION
Currently, there is code in `spirv-val` to check the `Storage Classes` in `SPV_KHR_ray_tracing` and while I am adding support right now, I realized there is duplicate language in the Vulkan spec that is already well documented in the [SPV_KHR_ray_tracing](https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_ray_tracing.html#_modifications_to_the_spir_v_specification) spec

My argument for the removal is
- The Vulkan Spec was missing `ShaderRecordBufferKHR` so it is not complete in the Vulkan spec currently
- There are much more details missing from the SPIR-V spec missing here (eg. a VU for `HitAttributeKHR` can only be read from `AnyHitKHR` and `ClosestHitKHR`)
- single origin to change in future if another Storage Class interacts with the extension