### PR TITLE
Add Vulkan 1.0 for supgroup memory scope

### DIFF
--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -165,6 +165,10 @@ ifdef::VK_VERSION_1_1[]
     *Scope* for <<shaders-group-operations,group operations>> must: be
     limited to *Subgroup*
 endif::VK_VERSION_1_1[]
+ifndef::VK_VERSION_1_1[]
+  * If the code:SubgroupVoteKHR or code:SubgroupBallotKHR capability
+    is not declared, *Scope* for memory must: not be *Subgroup*
+endif::VK_VERSION_1_1[]
   * [[VUID-{refpage}-None-04643]]
     *Storage Class* must: be limited to *UniformConstant*, *Input*,
     *Uniform*, *Output*, *Workgroup*, *Private*, *Function*, *PushConstant*,


### PR DESCRIPTION
There is a VUID

> VUID-StandaloneSpirv-None-04638
Scope for memory must be limited to Device, QueueFamily, Workgroup, ShaderCallKHR, Subgroup, or Invocation

and for `Subgroup` memory Scope in Vulkan 1.0 there is no VUID "banning" them, but I assumed if someone is using the `VK_EXT_shader_subgroup_vote`/`VK_EXT_shader_subgroup_ballot` in a 1.0 application is would still be valid

(related `spirv-val` PR https://github.com/KhronosGroup/SPIRV-Tools/pull/4869)