### PR TITLE
Adjust wording in vkSetDebugUtilsObjectNameEXT for non-device handles

### DIFF
--- a/chapters/VK_EXT_debug_utils.txt
+++ b/chapters/VK_EXT_debug_utils.txt
@@ -42,7 +42,14 @@ fname:vkSetDebugUtilsObjectNameEXT as defined below.
 --
 include::{generated}/api/protos/vkSetDebugUtilsObjectNameEXT.txt[]
 
-  * pname:device is the device that created the object.
+  * pname:device is the name of a valid slink:VkDevice which is related to the object in
+    pname:pNameInfo.
+    If pname:pNameInfo references a slink:VkInstance or a slink:VkPhysicalDevice, 
+    pname:device must: be created from that object.
+    If pname:pNameInfo references any other instance-level object, that object and
+    pname:device must: be created from the same slink:VkInstance.
+    Otherwise, the object passed in pname:pNameInfo must: have been created from
+    the same slink:VkDevice ancestor as listed in pname:device.
   * pname:pNameInfo is a pointer to a slink:VkDebugUtilsObjectNameInfoEXT
     structure specifying parameters of the name to set on the object.
 
@@ -52,6 +59,16 @@ include::{generated}/api/protos/vkSetDebugUtilsObjectNameEXT.txt[]
     pname:pNameInfo->objectType must: not be ename:VK_OBJECT_TYPE_UNKNOWN
   * [[VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02588]]
     pname:pNameInfo->objectHandle must: not be dlink:VK_NULL_HANDLE
+  * If the object referred to by pname:pNameInfo->objectHandle was
+    created, allocated or retrieved from a slink:VkDevice,
+    pname:device must: be the device the object was created,
+    allocated or retrieved from.
+  * If pname:pNameInfo->objectType is ename:VK_OBJECT_TYPE_INSTANCE or
+    ename:VK_OBJECT_TYPE_PHYSICAL_DEVICE, pname:device must: have been
+    created from the object referred to by pname:pNameInfo->objectHandle.
+  * If pname:pNameInfo->objectType is not ename:VK_OBJECT_TYPE_INSTANCE,
+    both of pname:device, and pname:pNameInfo->objectHandle must: have the
+    same slink:VkInstance as their ancestor.
 ****
 
 include::{generated}/validity/protos/vkSetDebugUtilsObjectNameEXT.txt[]


### PR DESCRIPTION
Closes #1668.

As discussed there, it is currently unclear whether or not it is valid to name handles that are not created from a device. This PR is my attempt at specifying what should happen for those types of handles.

As I see it, there are two types of handles that aren't created from a device: For one, handles that a device can be created from (directly or indirectly), which are `VkPhysicalDevice` and `VkInstance`. The other type is handles that aren't related to the device at all (e. g. `VkSurfaceKHR`).

For the first type, I think all Mesa drivers have an internal struct that the handle points to that contains more data about that struct other than loader data (I'd guess other drivers do the same). I think it is reasonable to assume that if a driver wants to expose a custom implementation of `vkSetDebugUtilsObjectNameEXT`, it might want to access that data. Therefore, it makes sense to forbid apps from passing physical devices of other drivers because accessing the internal data of those devices would likely go horribly wrong there. This is the main purpose of the second VU restriction I added, but it also forbids passing a device and an object handle that were created from different instances.

For `VkSurfaceKHR` (and, I think, all relevant objects of the second type), this restriction does not need to apply since the loader gives a separate "real" surface to each ICD. Only the third VU restriction applies here, which simply forbids passing handles across instances.

I marked this as a draft because no VUID numbers are assigned to the new VU requirements. I tried to assign some myself using the reflow.py script, but was unable to because I was missing the vuidCounts.py file. I'll remove the draft status once this is resolved.