### PR TITLE
Drop wayland-client.h include

### DIFF
--- a/include/vulkan/vulkan.h
+++ b/include/vulkan/vulkan.h
@@ -38,7 +38,6 @@
 
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-#include <wayland-client.h>
 #include "vulkan_wayland.h"
 #endif
 


### PR DESCRIPTION
With https://github.com/KhronosGroup/Vulkan-Tools/pull/670 resolved, wayland-client.h can be removed from Headers. This has been cooking in openSUSE for a while, and other vulkan infrastructure (vulkan-{tools,validationlayers}, glslang, spirv-tools, shaderc) still build fine.