### PR TITLE
Add codespell tool to 'allchecks' target used by CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
     name: Verify repository license compliance
     runs-on: ubuntu-latest
     # container: khronosgroup/docker-images:asciidoctor-spec
-    container: khronosgroup/docker-images@sha256:5bd35a86def4646af8f75499eeb7cc04b30203036a40ee86a84b572585f616f7
+    container: khronosgroup/docker-images@sha256:1535246a0270e5a118b11ba121ac3c08849782d27afcac28e3859424db659f2f
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,8 @@ jobs:
   license-check:
     name: Verify repository license compliance
     runs-on: ubuntu-latest
-    container: khronosgroup/docker-images:asciidoctor-spec
+    # container: khronosgroup/docker-images:asciidoctor-spec
+    container: khronosgroup/docker-images@sha256:5bd35a86def4646af8f75499eeb7cc04b30203036a40ee86a84b572585f616f7
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ allman: manhtmlpages
 
 # CHECK_CONTRACTIONS looks for disallowed contractions
 # CHECK_BULLETS looks for bullet list items not preceded by exactly two spaces
+# CODESPELL looks for typos and suggests fixes
 # reflow.py looks for asciidoctor conditionals inside VU statements;
 #   and for duplicated VUID numbers, but only in spec sources.
 # check_spec_links.py looks for proper use of custom markup macros
@@ -68,10 +69,7 @@ allman: manhtmlpages
 # check_undefined looks for untagged use of 'undefined' in spec sources
 CHECK_CONTRACTIONS = git grep -i -F -f config/CI/contractions | egrep -v -E -f config/CI/contractions-allowed
 CHECK_BULLETS = git grep -E '^( |   +)[-*]+ ' chapters appendices style [a-z]*txt
-# Codespell has been added to the asciidoctor-spec Docker image but
-# caching problems prevent using it in CI, for now.
-#CODESPELL = codespell --config config/CI/codespellrc
-CODESPELL = true
+CODESPELL = codespell --config config/CI/codespellrc
 allchecks:
 	if test `$(CHECK_CONTRACTIONS) | wc -l` != 0 ; then \
 	    echo "Contractions found that are not allowed:" ; \


### PR DESCRIPTION
PR just to test if Docker container cache has refreshed on Github Actions, yet.

Branch name courtesy of a long-ago letter in *The Economist*: http://www.ojohaven.com/fun/spelling.html
