### PR TITLE
Remove redundant drawIndirectFirstInstance VUID

### DIFF
--- a/chapters/drawing.txt
+++ b/chapters/drawing.txt
@@ -1176,11 +1176,6 @@ include::{chapters}/commonvalidity/draw_common.txt[]
 include::{chapters}/commonvalidity/draw_vertex_binding.txt[]
 include::{chapters}/commonvalidity/draw_dispatch_indirect_common.txt[]
 include::{chapters}/commonvalidity/draw_indirect_drawcount.txt[]
-  * [[VUID-vkCmdDrawIndirect-firstInstance-00478]]
-    If the <<features-drawIndirectFirstInstance,
-    pname:drawIndirectFirstInstance>> feature is not enabled, all the
-    pname:firstInstance members of the sname:VkDrawIndirectCommand
-    structures accessed by this command must: be code:0
   * [[VUID-vkCmdDrawIndirect-drawCount-00476]]
     If pname:drawCount is greater than `1`, pname:stride must: be a multiple
     of `4` and must: be greater than or equal to
@@ -1342,11 +1337,6 @@ include::{chapters}/commonvalidity/draw_indirect_drawcount.txt[]
     If pname:drawCount is greater than `1`, pname:stride must: be a multiple
     of `4` and must: be greater than or equal to
     code:sizeof(sname:VkDrawIndexedIndirectCommand)
-  * [[VUID-vkCmdDrawIndexedIndirect-firstInstance-00530]]
-    If the <<features-drawIndirectFirstInstance,
-    pname:drawIndirectFirstInstance>> feature is not enabled, all the
-    pname:firstInstance members of the sname:VkDrawIndexedIndirectCommand
-    structures accessed by this command must: be code:0
   * [[VUID-vkCmdDrawIndexedIndirect-drawCount-00539]]
     If pname:drawCount is equal to `1`, [eq]#(pname:offset {plus}
     code:sizeof(sname:VkDrawIndexedIndirectCommand))# must: be less than or


### PR DESCRIPTION
There is already 2 VUIDs for `drawIndirectFirstInstance` in the struct and no need for it in the function as well

> VUID-VkDrawIndirectCommand-firstInstance-00501
If the drawIndirectFirstInstance feature is not enabled, firstInstance must be 0

> VUID-VkDrawIndexedIndirectCommand-firstInstance-00554
If the drawIndirectFirstInstance feature is not enabled, firstInstance must be 0

Removing the function in favor of the structure VUID seem more consistent with rest of VUs