### PR TITLE
Add standalone VU for OpImageWrite component mismatch

### DIFF
--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -614,9 +614,9 @@ ifndef::VK_VERSION_1_3,VK_KHR_format_feature_flags2[]
     operand of 2 and an "`Image Format`" operand of code:Unknown must: be
     decorated with code:NonReadable.
 endif::VK_VERSION_1_3,VK_KHR_format_feature_flags2[]
-  * code:OpImageWrite to any variable created with a code:Type of
-    code:OpTypeImage must: have the code:Texel operand contain at least
-    as many components as the code:Image code:Format according to the
+  * code:OpImageWrite to any code:Image whose code:Image code:Format is not
+    code:Unknown must: have the code:Texel operand contain at least
+    as many components as the corresponding elink:VkFormat as given in the
     <<spirvenv-image-formats,SPIR-V Image Format compatibility table>>
   * [[VUID-{refpage}-Location-06272]]
     The sum of code:Location and the number of locations the variable it

--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -615,9 +615,8 @@ ifndef::VK_VERSION_1_3,VK_KHR_format_feature_flags2[]
     decorated with code:NonReadable.
 endif::VK_VERSION_1_3,VK_KHR_format_feature_flags2[]
   * code:OpImageWrite to any variable created with a code:Type of
-    code:OpTypeImage that has a code:Sampled operand of 2 must: have the
-    code:Texel operand contain at least as many components as the
-    code:Image code:Format according to the
+    code:OpTypeImage must: have the code:Texel operand contain at least
+    as many components as the code:Image code:Format according to the
     <<spirvenv-image-formats,SPIR-V Image Format compatibility table>>
   * [[VUID-{refpage}-Location-06272]]
     The sum of code:Location and the number of locations the variable it

--- a/appendices/spirvenv.txt
+++ b/appendices/spirvenv.txt
@@ -614,6 +614,11 @@ ifndef::VK_VERSION_1_3,VK_KHR_format_feature_flags2[]
     operand of 2 and an "`Image Format`" operand of code:Unknown must: be
     decorated with code:NonReadable.
 endif::VK_VERSION_1_3,VK_KHR_format_feature_flags2[]
+  * code:OpImageWrite to any variable created with a code:Type of
+    code:OpTypeImage that has a code:Sampled operand of 2 must: have the
+    code:Texel operand contain at least as many components as the
+    code:Image code:Format according to the
+    <<spirvenv-image-formats,SPIR-V Image Format compatibility table>>
   * [[VUID-{refpage}-Location-06272]]
     The sum of code:Location and the number of locations the variable it
     decorates consumes must: be less than or equal to the value for the

--- a/chapters/commonvalidity/draw_dispatch_common.txt
+++ b/chapters/commonvalidity/draw_dispatch_common.txt
@@ -215,15 +215,17 @@ ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
     object must: not use the code:ConstOffset and code:Offset operands
 endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-{refpage}-None-04115]]
-    If a slink:VkImageView is accessed using code:OpImageWrite as a result
-    of this command, then the code:Type of the code:Texel operand of that
-    instruction must: have at least as many components as the image view's
-    format
+    If as a result of this command a slink:VkImageView is accessed using
+    code:OpImageWrite with an code:OpTypeImage that has an "`Image Format`"
+    operand of code:Unknown, then the code:Type of the code:Texel operand
+    of that instruction must: have at least as many components as the
+    image view's format
   * [[VUID-{refpage}-OpImageWrite-04469]]
-    If a slink:VkBufferView is accessed using code:OpImageWrite as a result
-    of this command, then the code:Type of the code:Texel operand of that
-    instruction must: have at least as many components as the buffer view's
-    format
+    If as a result of this command a slink:VkBufferView is accessed using
+    code:OpImageWrite with an code:OpTypeImage that has an "`Image Format`"
+    operand of code:Unknown, then the code:Type of the code:Texel operand
+    of that instruction must: have at least as many components as the
+    buffer view's format
 ifdef::VK_EXT_shader_image_atomic_int64[]
   * [[VUID-{refpage}-SampledType-04470]]
     If a slink:VkImageView with a elink:VkFormat that has a 64-bit component

--- a/chapters/commonvalidity/draw_dispatch_common.txt
+++ b/chapters/commonvalidity/draw_dispatch_common.txt
@@ -215,17 +215,15 @@ ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
     object must: not use the code:ConstOffset and code:Offset operands
 endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
   * [[VUID-{refpage}-None-04115]]
-    If as a result of this command a slink:VkImageView is accessed using
-    code:OpImageWrite with an code:OpTypeImage that has an "`Image Format`"
-    operand of code:Unknown, then the code:Type of the code:Texel operand
-    of that instruction must: have at least as many components as the
-    image view's format
+    If a slink:VkImageView is accessed using code:OpImageWrite as a result
+    of this command, then the code:Type of the code:Texel operand of that
+    instruction must: have at least as many components as the image view's
+    format
   * [[VUID-{refpage}-OpImageWrite-04469]]
-    If as a result of this command a slink:VkBufferView is accessed using
-    code:OpImageWrite with an code:OpTypeImage that has an "`Image Format`"
-    operand of code:Unknown, then the code:Type of the code:Texel operand
-    of that instruction must: have at least as many components as the
-    buffer view's format
+    If a slink:VkBufferView is accessed using code:OpImageWrite as a result
+    of this command, then the code:Type of the code:Texel operand of that
+    instruction must: have at least as many components as the buffer view's
+    format
 ifdef::VK_EXT_shader_image_atomic_int64[]
   * [[VUID-{refpage}-SampledType-04470]]
     If a slink:VkImageView with a elink:VkFormat that has a 64-bit component


### PR DESCRIPTION
Currently trying to implement both VUID `04115` and `04469` in the Validation Layers, but when I have the following shader

```swift
 %type_image = OpTypeImage %uint 2D 0 0 0 2 Rgba8ui
    %texelU3 = OpConstantComposite %v3uint %uint_1 %uint_1 %uint_1
               OpImageWrite %image %int_1 %texelU3 ZeroExtend
```

`Rgba8ui` should become `VK_FORMAT_R8G8B8A8_UINT` and only writing 3 components triggers 

> VUID-vkCmdDraw-None-04115
If a VkImageView is accessed using OpImageWrite as a result of this command, then the Type of the Texel operand of that instruction must have at least as many components as the image view’s format

but I would purpose it might be more beneficial to have this checked at `vkCreateShaderModule` time instead of waiting until draw time (unless someone can point to CTS tests verifying all driver's compilers can handle a shader as given above)

This change makes the draw time VU only for `Unknown` `OpTypeImage` and then adds a separate Runtime SPIR-V Validation for the case where it is not `Unknown`

----

Another way to view this issue is the spec currently says

> If the image format of the OpTypeImage is not compatible with the VkImageView’s format, the write causes the contents of the image’s memory to become undefined.

So not sure if this means if I have `OpTypeImage %uint 2D 0 0 0 2 Rgba8ui` with a `OpImageWrite` of 3 components and then use an `VkImageView` format of `VK_FORMAT_R8G8B8_UINT` if we expect it to be **invalid** or **undefined**