### PR TITLE
Add a NOTE to VK_USE_64_BIT_PTR_DEFINES to define its availability

### DIFF
--- a/appendices/boilerplate.txt
+++ b/appendices/boilerplate.txt
@@ -256,6 +256,15 @@ the predefined preprocessor check does not identify the desired
 configuration.
 ====
 
+[NOTE]
+.Note
+====
+This macro was introduced starting with the Vulkan 1.2.174 headers.
+It is not available if you are using older headers, such as may be shipped
+with an older Vulkan SDK.
+The availability of this macro can be checked at compile time by requiring
+`dname:VK_HEADER_VERSION >= 174`.
+====
 --
 
 [[boilerplate-wsi-header]]

--- a/appendices/boilerplate.txt
+++ b/appendices/boilerplate.txt
@@ -259,11 +259,14 @@ configuration.
 [NOTE]
 .Note
 ====
-This macro was introduced starting with the Vulkan 1.2.174 headers.
+This macro was introduced starting with the Vulkan 1.2.174 headers, and its
+availability can be checked at compile time by requiring
+`dname:VK_HEADER_VERSION >= 174`.
+
 It is not available if you are using older headers, such as may be shipped
 with an older Vulkan SDK.
-The availability of this macro can be checked at compile time by requiring
-`dname:VK_HEADER_VERSION >= 174`.
+Developers requiring this functionality may wish to include a copy of the
+current Vulkan headers with their project in this case.
 ====
 --
 


### PR DESCRIPTION
The macro was added to the Vulkan headers starting with VK_HEADER_VERSION 174.

Closes #1917