### PR TITLE
remove ifdef from standalone spirv VUID

### DIFF
--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -427,7 +427,7 @@ endif::VK_VERSION_1_1[]
     must: be limited to *Reduce*, *InclusiveScan*, or *ExclusiveScan*
   * [[VUID-{refpage}-None-04686]]
     The _Pointer_ operand of all atomic instructions must: have a *Storage
-    Class* limited to *Uniform*, *Workgroup*, *Image*, *StorageBuffer*, or
+    Class* limited to *Uniform*, *Workgroup*, *Image*, *StorageBuffer*,
     *PhysicalStorageBuffer*, or *TaskPayloadWorkgroupEXT*
   * [[VUID-{refpage}-Offset-04687]]
     Output variables or block members decorated with code:Offset that have a

--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -425,18 +425,10 @@ endif::VK_VERSION_1_1[]
   * [[VUID-{refpage}-OpGroupNonUniformBallotBitCount-04685]]
     If code:OpGroupNonUniformBallotBitCount is used, the group operation
     must: be limited to *Reduce*, *InclusiveScan*, or *ExclusiveScan*
-ifndef::VK_EXT_mesh_shader[]
   * [[VUID-{refpage}-None-04686]]
     The _Pointer_ operand of all atomic instructions must: have a *Storage
     Class* limited to *Uniform*, *Workgroup*, *Image*, *StorageBuffer*, or
-    *PhysicalStorageBuffer*
-endif::VK_EXT_mesh_shader[]
-ifdef::VK_EXT_mesh_shader[]
-  * [[VUID-{refpage}-None-07101]]
-    The _Pointer_ operand of all atomic instructions must: have a *Storage
-    Class* limited to *Uniform*, *Workgroup*, *Image*, *StorageBuffer*,
     *PhysicalStorageBuffer*, or *TaskPayloadWorkgroupEXT*
-endif::VK_EXT_mesh_shader[]
   * [[VUID-{refpage}-Offset-04687]]
     Output variables or block members decorated with code:Offset that have a
     64-bit type, or a composite type containing a 64-bit type, must: specify
@@ -572,12 +564,10 @@ endif::VK_EXT_mesh_shader[]
   * [[VUID-{refpage}-Input-06778]]
     Variables with a storage class of code:Input in a fragment shader stage
     that are decorated with code:PerVertexKHR must: be declared as arrays
-ifdef::VK_NV_mesh_shader+VK_EXT_mesh_shader[]
   * [[VUID-{refpage}-MeshEXT-07102]]
     The module must: not contain both an entry point that uses the code:
-    TaskEXT or code:MeshEXT {ExecutionModel} and an entry point that uses
+    code:TaskEXT or code:MeshEXT {ExecutionModel} and an entry point that uses
     the code:TaskNV or code:MeshNV {ExecutionModel}
-endif::VK_NV_mesh_shader+VK_EXT_mesh_shader[]
   * [[VUID-{refpage}-PrimitivePointIndicesEXT-07103]]
     If a variable decorated with code:PrimitivePointIndicesEXT is used, the
     code:OutputPoints code:OpExecutionMode must: be set

--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -565,7 +565,7 @@ endif::VK_VERSION_1_1[]
     Variables with a storage class of code:Input in a fragment shader stage
     that are decorated with code:PerVertexKHR must: be declared as arrays
   * [[VUID-{refpage}-MeshEXT-07102]]
-    The module must: not contain both an entry point that uses the code:
+    The module must: not contain both an entry point that uses the
     code:TaskEXT or code:MeshEXT {ExecutionModel} and an entry point that uses
     the code:TaskNV or code:MeshNV {ExecutionModel}
   * [[VUID-{refpage}-MeshEXT-07106]]

--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -568,15 +568,6 @@ endif::VK_VERSION_1_1[]
     The module must: not contain both an entry point that uses the code:
     code:TaskEXT or code:MeshEXT {ExecutionModel} and an entry point that uses
     the code:TaskNV or code:MeshNV {ExecutionModel}
-  * [[VUID-{refpage}-PrimitivePointIndicesEXT-07103]]
-    If a variable decorated with code:PrimitivePointIndicesEXT is used, the
-    code:OutputPoints code:OpExecutionMode must: be set
-  * [[VUID-{refpage}-PrimitiveLineIndicesEXT-07104]]
-    If a variable decorated with code:PrimitiveLineIndicesEXT is used, the
-    code:OutputLinesEXT code:OpExecutionMode must: be set
-  * [[VUID-{refpage}-PrimitiveTriangleIndicesEXT-07105]]
-    If a variable decorated with code:PrimitiveTriangleIndicesEXT is used,
-    the code:OutputTrianglesEXT code:OpExecutionMode must: be set
   * [[VUID-{refpage}-MeshEXT-07106]]
     In mesh shaders using the code:MeshEXT {ExecutionModel}
     code:OpSetMeshOutputsEXT must: be called before any outputs are written
@@ -590,13 +581,13 @@ endif::VK_VERSION_1_1[]
   * [[VUID-{refpage}-MeshEXT-07109]]
     In mesh shaders using the code:MeshEXT {ExecutionModel} variables
     decorated with code:PrimitivePointIndicesEXT,
-    code:PrimitiveLineIndicesEXT or code:PrimitiveTriangleIndicesEXT
+    code:PrimitiveLineIndicesEXT, or code:PrimitiveTriangleIndicesEXT
     declared as an array must: not be accessed by indices that depend on
     code:ViewIndex
   * [[VUID-{refpage}-MeshEXT-07110]]
     In mesh shaders using the code:MeshEXT {ExecutionModel} any values
     stored in variables decorated with code:PrimitivePointIndicesEXT,
-    code:PrimitiveLineIndicesEXT or code:PrimitiveTriangleIndicesEXT must:
+    code:PrimitiveLineIndicesEXT, or code:PrimitiveTriangleIndicesEXT must:
     not depend on code:ViewIndex
   * [[VUID-{refpage}-MeshEXT-07111]]
     In mesh shaders using the code:MeshEXT {ExecutionModel} variables in


### PR DESCRIPTION
`VUID-StandaloneSpirv-None-04686` is already implemented in SPIR-V Tools and I can add the `TaskPayloadWorkgroupEXT` addition if wanted

-----

- `VUID-StandaloneSpirv-PrimitivePointIndicesEXT-07103`
- `VUID-StandaloneSpirv-PrimitiveLineIndicesEXT-07104`
- `VUID-StandaloneSpirv-PrimitiveTriangleIndicesEXT-07105`

are already found in the Built-in section for example

> VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07042
The PrimitivePointIndicesEXT decoration must be used only with the the OutputPoints Execution Mode
