### PR TITLE
Add maxMeshWorkGroup*Count limits when no task shader is used

### DIFF
--- a/chapters/VK_NV_mesh_shader/drawing.adoc
+++ b/chapters/VK_NV_mesh_shader/drawing.adoc
@@ -209,22 +209,10 @@ local workgroups is assembled.
 .Valid Usage
 ****
 include::{chapters}/commonvalidity/draw_common.adoc[]
-  * [[VUID-vkCmdDrawMeshTasksEXT-groupCountX-07083]]
-    pname:groupCountX must: be less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupCount[0]
-  * [[VUID-vkCmdDrawMeshTasksEXT-groupCountY-07084]]
-    pname:groupCountY must: be less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupCount[1]
-  * [[VUID-vkCmdDrawMeshTasksEXT-groupCountZ-07085]]
-    pname:groupCountZ must: be less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupCount[2]
-  * [[VUID-vkCmdDrawMeshTasksEXT-groupCountX-07086]]
-    The product of pname:groupCountX, pname:groupCountY and
-    pname:groupCountZ must: be less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupTotalCount
+include::{chapters}/commonvalidity/draw_mesh_limits_common.adoc[]
   * [[VUID-vkCmdDrawMeshTasksEXT-MeshEXT-07087]]
     The current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
-    must: contain a shader stage using the code:MeshEXT {ExecutionModel}.
+    must: contain a shader stage using the code:MeshEXT {ExecutionModel}
 ****
 
 include::{generated}/validity/protos/vkCmdDrawMeshTasksEXT.adoc[]
@@ -277,7 +265,7 @@ include::{chapters}/commonvalidity/draw_indirect_drawcount.adoc[]
     than or equal to the size of pname:buffer
   * [[VUID-vkCmdDrawMeshTasksIndirectEXT-MeshEXT-07091]]
     The current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
-    must: contain a shader stage using the code:MeshEXT {ExecutionModel}.
+    must: contain a shader stage using the code:MeshEXT {ExecutionModel}
 ****
 
 include::{generated}/validity/protos/vkCmdDrawMeshTasksIndirectEXT.adoc[]
@@ -302,19 +290,7 @@ as the similarly named parameters of flink:vkCmdDrawMeshTasksEXT.
 
 .Valid Usage
 ****
-  * [[VUID-VkDrawMeshTasksIndirectCommandEXT-groupCountX-07092]]
-    pname:groupCountX must: be less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupCount[0]
-  * [[VUID-VkDrawMeshTasksIndirectCommandEXT-groupCountY-07093]]
-    pname:groupCountY must: be less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupCount[1]
-  * [[VUID-VkDrawMeshTasksIndirectCommandEXT-groupCountZ-07094]]
-    pname:groupCountZ must: be less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupCount[2]
-  * [[VUID-VkDrawMeshTasksIndirectCommandEXT-groupCountX-07095]]
-    The product of pname:groupCountX, pname:groupCountY and
-    pname:groupCountZ must: be less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupTotalCount
+include::{chapters}/commonvalidity/draw_mesh_limits_common.adoc[]
 ****
 
 include::{generated}/validity/structs/VkDrawMeshTasksIndirectCommandEXT.adoc[]
@@ -375,7 +351,7 @@ include::{chapters}/commonvalidity/draw_indirect_count_common.adoc[]
     less than or equal to the size of pname:buffer
   * [[VUID-vkCmdDrawMeshTasksIndirectCountEXT-MeshEXT-07100]]
     The current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
-    must: contain a shader stage using the code:MeshEXT {ExecutionModel}.
+    must: contain a shader stage using the code:MeshEXT {ExecutionModel}
 ****
 
 include::{generated}/validity/protos/vkCmdDrawMeshTasksIndirectCountEXT.adoc[]

--- a/chapters/commonvalidity/draw_mesh_limits_common.adoc
+++ b/chapters/commonvalidity/draw_mesh_limits_common.adoc
@@ -1,0 +1,43 @@
+// Copyright 2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+// Common Valid Usage
+// Common limits for draw mesh commands
+
+  * If the current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
+    contains a shader using the code:TaskEXT {ExecutionModel},
+    pname:groupCountX must: be less than or equal to
+    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupCount[0]
+  * If the current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
+    contains a shader using the code:TaskEXT {ExecutionModel},
+    pname:groupCountY must: be less than or equal to
+    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupCount[1]
+  * If the current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
+    contains a shader using the code:TaskEXT {ExecutionModel},
+    pname:groupCountZ must: be less than or equal to
+    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupCount[2]
+  * If the current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
+    contains a shader using the code:TaskEXT {ExecutionModel},
+    The product of pname:groupCountX, pname:groupCountY and
+    pname:groupCountZ must: be less than or equal to
+    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxTaskWorkGroupTotalCount
+  * If the current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
+    does not contain a shader using the code:TaskEXT {ExecutionModel},
+    pname:groupCountX must: be less than or equal to
+    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxMeshWorkGroupCount[0]
+  * If the current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
+    does not contain a shader using the code:TaskEXT {ExecutionModel},
+    pname:groupCountY must: be less than or equal to
+    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxMeshWorkGroupCount[1]
+  * If the current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
+    does not contain a shader using the code:TaskEXT {ExecutionModel},
+    pname:groupCountZ must: be less than or equal to
+    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxMeshWorkGroupCount[2]
+  * If the current pipeline bound to ename:VK_PIPELINE_BIND_POINT_GRAPHICS
+    does not contain a shader using the code:TaskEXT {ExecutionModel},
+    The product of pname:groupCountX, pname:groupCountY and
+    pname:groupCountZ must: be less than or equal to
+    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxMeshWorkGroupTotalCount
+
+// Common Valid Usage


### PR DESCRIPTION
from https://github.com/KhronosGroup/Vulkan-Docs/pull/1931#issuecomment-1241088493 (cc @pdaniell-nv for taking a look)

created a `draw_mesh_limits_common.adoc` to match what we do for `trace_rays_limits_common.adoc`