### PR TITLE
Add SPIR-V VU for mesh shader output count

### DIFF
--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -595,6 +595,10 @@ endif::VK_VERSION_1_1[]
     In mesh shaders using the code:MeshEXT {ExecutionModel} variables in
     workgroup or private storage class declared as or containing a composite
     type must: not be accessed by indices that depend on code:ViewIndex
+  * In mesh shaders using the code:MeshEXT {ExecutionModel} the
+    code:OutputVertices code:OpExecutionMode must: be greater than 0
+  * In mesh shaders using the code:MeshEXT {ExecutionModel} the
+    code:OutputPrimitivesEXT code:OpExecutionMode must: be greater than 0
   * [[VUID-{refpage}-Input-07290]]
     Variables with a storage class of code:Input or code:Output and a type
     of code:OpTypeBool must: be decorated with the code:BuiltIn decoration
@@ -1009,11 +1013,17 @@ ifdef::VK_EXT_mesh_shader[]
     For mesh shaders using the code:MeshEXT {ExecutionModel} the
     code:OutputVertices code:OpExecutionMode must: be less than or equal to
     sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxMeshOutputVertices.
+  * For mesh shaders using the code:MeshEXT {ExecutionModel} the
+    "`Vertex Count`" operand of code:OpSetMeshOutputsEXT must: be less than
+    or equal to code:OutputVertices code:OpExecutionMode
   * [[VUID-{refpage}-MeshEXT-07116]]
     For mesh shaders using the code:MeshEXT {ExecutionModel} the
     code:OutputPrimitivesEXT code:OpExecutionMode must: be less than or
     equal to
     sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxMeshOutputPrimitives.
+  * For mesh shaders using the code:MeshEXT {ExecutionModel} the
+    "`Primitive Count`" operand of code:OpSetMeshOutputsEXT must: be less than
+    or equal to code:OutputPrimitivesEXT code:OpExecutionMode
   * [[VUID-{refpage}-TaskEXT-07117]]
     In task shaders using the code:TaskEXT {ExecutionModel}
     code:OpEmitMeshTasksEXT must: be called exactly once under dynamically

--- a/chapters/pipelines.adoc
+++ b/chapters/pipelines.adoc
@@ -483,38 +483,6 @@ ifdef::VK_EXT_shader_stencil_export[]
     either discard the fragment, or write or initialize the value of
     code:FragStencilRefEXT
 endif::VK_EXT_shader_stencil_export[]
-ifdef::VK_NV_mesh_shader[]
-  * [[VUID-VkPipelineShaderStageCreateInfo-stage-02093]]
-    If pname:stage is ename:VK_SHADER_STAGE_MESH_BIT_NV and the code:MeshNV
-    {ExecutionModel} is used, the identified entry point must: have an
-    code:OpExecutionMode instruction specifying a maximum output vertex
-    count, code:OutputVertices, that is greater than `0` and less than or
-    equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesNV::pname:maxMeshOutputVertices
-  * [[VUID-VkPipelineShaderStageCreateInfo-stage-02094]]
-    If pname:stage is ename:VK_SHADER_STAGE_MESH_BIT_NV and the code:MeshNV
-    {ExecutionModel} is used, the identified entry point must: have an
-    code:OpExecutionMode instruction specifying a maximum output primitive
-    count, code:OutputPrimitivesNV, that is greater than `0` and less than
-    or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesNV::pname:maxMeshOutputPrimitives
-endif::VK_NV_mesh_shader[]
-ifdef::VK_EXT_mesh_shader[]
-  * [[VUID-VkPipelineShaderStageCreateInfo-stage-07061]]
-    If pname:stage is ename:VK_SHADER_STAGE_MESH_BIT_EXT and the
-    code:MeshEXT {ExecutionModel} is used, the identified entry point must:
-    have an code:OpExecutionMode instruction specifying a maximum output
-    vertex count, code:OutputVertices, that is greater than `0` and less
-    than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxMeshOutputVertices
-  * [[VUID-VkPipelineShaderStageCreateInfo-stage-07062]]
-    If pname:stage is ename:VK_SHADER_STAGE_MESH_BIT_EXT and the
-    code:MeshEXT {ExecutionModel} is used, the identified entry point must:
-    have an code:OpExecutionMode instruction specifying a maximum output
-    primitive count, code:OutputPrimitivesEXT, that is greater than `0` and
-    less than or equal to
-    sname:VkPhysicalDeviceMeshShaderPropertiesEXT::pname:maxMeshOutputPrimitives
-endif::VK_EXT_mesh_shader[]
 ifdef::VK_VERSION_1_3,VK_EXT_subgroup_size_control[]
   * [[VUID-VkPipelineShaderStageCreateInfo-flags-02784]]
     If pname:flags has the


### PR DESCRIPTION
The VUs removed are already in the SPIR-V section, for example `VUID-VkPipelineShaderStageCreateInfo-stage-07061` is the same as 

> VUID-RuntimeSpirv-MeshEXT-07115
For mesh shaders using the MeshEXT Execution Model the OutputVertices OpExecutionMode must be less than or equal to VkPhysicalDeviceMeshShaderPropertiesEXT::maxMeshOutputVertices.

------

The 2 sets of VUs added make the following 2 shaders illegal

```swift
OpExecutionMode %mainMesh OutputVertices 1
OpExecutionMode %mainMesh OutputPrimitivesEXT 1
OpSetMeshOutputsEXT 2 2 
```

```swift
OpExecutionMode %mainMesh OutputVertices 0
OpExecutionMode %mainMesh OutputPrimitivesEXT 0
; Can't find spec language saying OpSetMeshOutputsEXT MUST be called if no other Output is also not written
```
