### PR TITLE
Fix VK_EXT_shader_image_atomic_int64 ifdef location VUID

### DIFF
--- a/chapters/commonvalidity/draw_dispatch_common.adoc
+++ b/chapters/commonvalidity/draw_dispatch_common.adoc
@@ -234,7 +234,6 @@ endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
     of this command, then the code:Type of the code:Texel operand of that
     instruction must: have at least as many components as the buffer view's
     format
-ifdef::VK_EXT_shader_image_atomic_int64[]
   * [[VUID-{refpage}-SampledType-04470]]
     If a slink:VkImageView with a elink:VkFormat that has a 64-bit component
     width is accessed as a result of this command, the code:SampledType of
@@ -255,6 +254,7 @@ ifdef::VK_EXT_shader_image_atomic_int64[]
     less than 64-bit is accessed as a result of this command, the
     code:SampledType of the code:OpTypeImage operand of that instruction
     must: have a code:Width of 32
+ifdef::VK_EXT_shader_image_atomic_int64[]
   * [[VUID-{refpage}-sparseImageInt64Atomics-04474]]
     If the <<features-sparseImageInt64Atomics,
     pname:sparseImageInt64Atomics>> feature is not enabled, slink:VkImage


### PR DESCRIPTION
Was going to add validation for `04470`,`04471`,`04472`,`04473` and don't think they require `VK_EXT_shader_image_atomic_int64` in order to validate

> VUID-vkCmdDraw-SampledType-04470
If a [VkImageView](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkImageView) with a [VkFormat](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkFormat) that has a 64-bit component width is accessed as a result of this command, the SampledType of the OpTypeImage operand of that instruction must have a Width of 64