### PR TITLE
Clarify VK_EXT_mesh_shader builtin execution modes

### DIFF
--- a/chapters/interfaces.adoc
+++ b/chapters/interfaces.adoc
@@ -3368,8 +3368,8 @@ primitives.
     The code:PrimitivePointIndicesEXT decoration must: be used only within
     the code:MeshEXT {ExecutionModel}
   * [[VUID-{refpage}-PrimitivePointIndicesEXT-07042]]
-    The code:PrimitivePointIndicesEXT decoration must: be used only with the
-    the code:OutputPoints {ExecutionMode}
+    The code:PrimitivePointIndicesEXT decoration must: not be used with the
+    the code:OutputLinesEXT or code:OutputTrianglesEXT {ExecutionMode}
   * [[VUID-{refpage}-PrimitivePointIndicesEXT-07043]]
     The variable decorated with code:PrimitivePointIndicesEXT must: be
     declared using the code:Output {StorageClass}
@@ -3404,8 +3404,8 @@ primitives.
     The code:PrimitiveLineIndicesEXT decoration must: be used only within
     the code:MeshEXT {ExecutionModel}
   * [[VUID-{refpage}-PrimitiveLineIndicesEXT-07048]]
-    The code:PrimitiveLineIndicesEXT decoration must: be used only with the
-    the code:OutputLinesEXT {ExecutionMode}
+    The code:PrimitiveLineIndicesEXT decoration must: not be used with the
+    the code:OutputPoints or code:OutputTrianglesEXT {ExecutionMode}
   * [[VUID-{refpage}-PrimitiveLineIndicesEXT-07049]]
     The variable decorated with code:PrimitiveLineIndicesEXT must: be
     declared using the code:Output {StorageClass}
@@ -3440,8 +3440,8 @@ triangle primitives.
     The code:PrimitiveTriangleIndicesEXT decoration must: be used only
     within the code:MeshEXT {ExecutionModel}
   * [[VUID-{refpage}-PrimitiveTriangleIndicesEXT-07054]]
-    The code:PrimitiveTriangleIndicesEXT decoration must: be used only with
-    the the code:OutputTrianglesEXT {ExecutionMode}
+    The code:PrimitiveTriangleIndicesEXT decoration must: not be used with the
+    the code:OutputPoints or code:OutputLinesEXT {ExecutionMode}
   * [[VUID-{refpage}-PrimitiveTriangleIndicesEXT-07055]]
     The variable decorated with code:PrimitiveTriangleIndicesEXT must: be
     declared using the code:Output {StorageClass}

--- a/chapters/interfaces.adoc
+++ b/chapters/interfaces.adoc
@@ -3368,8 +3368,8 @@ primitives.
     The code:PrimitivePointIndicesEXT decoration must: be used only within
     the code:MeshEXT {ExecutionModel}
   * [[VUID-{refpage}-PrimitivePointIndicesEXT-07042]]
-    The code:PrimitivePointIndicesEXT decoration must: not be used with the
-    the code:OutputLinesEXT or code:OutputTrianglesEXT {ExecutionMode}
+    The code:PrimitivePointIndicesEXT decoration must: be used with the
+    code:OutputPoints {ExecutionMode}
   * [[VUID-{refpage}-PrimitivePointIndicesEXT-07043]]
     The variable decorated with code:PrimitivePointIndicesEXT must: be
     declared using the code:Output {StorageClass}
@@ -3404,8 +3404,8 @@ primitives.
     The code:PrimitiveLineIndicesEXT decoration must: be used only within
     the code:MeshEXT {ExecutionModel}
   * [[VUID-{refpage}-PrimitiveLineIndicesEXT-07048]]
-    The code:PrimitiveLineIndicesEXT decoration must: not be used with the
-    the code:OutputPoints or code:OutputTrianglesEXT {ExecutionMode}
+    The code:PrimitiveLineIndicesEXT decoration must: be used with the
+    code:OutputLinesEXT {ExecutionMode}
   * [[VUID-{refpage}-PrimitiveLineIndicesEXT-07049]]
     The variable decorated with code:PrimitiveLineIndicesEXT must: be
     declared using the code:Output {StorageClass}
@@ -3440,8 +3440,8 @@ triangle primitives.
     The code:PrimitiveTriangleIndicesEXT decoration must: be used only
     within the code:MeshEXT {ExecutionModel}
   * [[VUID-{refpage}-PrimitiveTriangleIndicesEXT-07054]]
-    The code:PrimitiveTriangleIndicesEXT decoration must: not be used with the
-    the code:OutputPoints or code:OutputLinesEXT {ExecutionMode}
+    The code:PrimitiveTriangleIndicesEXT decoration must: be used with the
+    code:OutputTrianglesEXT {ExecutionMode}
   * [[VUID-{refpage}-PrimitiveTriangleIndicesEXT-07055]]
     The variable decorated with code:PrimitiveTriangleIndicesEXT must: be
     declared using the code:Output {StorageClass}


### PR DESCRIPTION
About to add validation support and thought it meant "if another `OpExecutionMode` is used it is invalid" which doesn't make sense so updated it to be what I think it was intended to mean from the SPIR-V spec saying

> Each OpEntryPoint with the MeshEXT Execution Model must have an OpExecutionMode with exactly one of OutputPoints, OutputLinesEXT, or OutputTrianglesEXT Execution Modes.