### PR TITLE
Do not guard VK_NV_acquire_winrt_display within win32

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -19110,7 +19110,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                     <type name="VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_acquire_winrt_display" number="346" type="device" requires="VK_EXT_direct_mode_display" author="NV" contact="Jeff Juliano @jjuliano" platform="win32" supported="vulkan">
+        <extension name="VK_NV_acquire_winrt_display" number="346" type="device" requires="VK_EXT_direct_mode_display" author="NV" contact="Jeff Juliano @jjuliano" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_ACQUIRE_WINRT_DISPLAY_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_acquire_winrt_display&quot;"       name="VK_NV_ACQUIRE_WINRT_DISPLAY_EXTENSION_NAME"/>


### PR DESCRIPTION
vkAcquireWinrtDisplayNV and vkGetWinrtDisplayNV are resident in vulkan/vulkan-core.h and always present remove  platform="win32" for consistence

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>