### PR TITLE
Remove duplicate sentence in VK_EXT_subpass_merge_feedback.

### DIFF
--- a/chapters/VK_EXT_subpass_merge_feedback/renderpass.adoc
+++ b/chapters/VK_EXT_subpass_merge_feedback/renderpass.adoc
@@ -24,10 +24,6 @@ If a sname:VkRenderPassCreationControlEXT structure is included in the
 pname:pNext chain of slink:VkRenderPassCreateInfo2 and its value of
 pname:disallowMerging is ename:VK_TRUE, the implementation will disable
 subpass merging for the entire render pass.
-If a sname:VkRenderPassCreationControlEXT structure is included in the
-pname:pNext chain of slink:VkSubpassDescription2 and its value of
-pname:disallowMerging is ename:VK_TRUE, the implementation will disable
-merging the described subpass with previous subpasses in the render pass.
 
 include::{generated}/validity/structs/VkRenderPassCreationControlEXT.adoc[]
 --


### PR DESCRIPTION
VK_EXT_subpass_merge_feedback had repeated 
"If a sname:VkRenderPassCreationControlEXT structure is included in the pname:pNext chain of slink:VkRenderPassCreateInfo2 and its value of pname:disallowMerging is ename:VK_TRUE, the implementation will disable subpass merging for the entire render pass." 2 times one after the other.

Removed one of them