### PR TITLE
Fix a typo in vkCmdSetCoverageToColorLocationNV

### DIFF
--- a/chapters/fragops.adoc
+++ b/chapters/fragops.adoc
@@ -1849,7 +1849,7 @@ drawing commands when the graphics pipeline is created with
 ename:VK_DYNAMIC_STATE_COVERAGE_TO_COLOR_LOCATION_NV set in
 slink:VkPipelineDynamicStateCreateInfo::pname:pDynamicStates.
 Otherwise, this state is specified by the
-slink:VkPipelineSampleLocationsStateCreateInfoEXT::pname:coverageToColorLocation
+slink:VkPipelineCoverageToColorStateCreateInfoNV::pname:coverageToColorLocation
 value used to create the currently active pipeline.
 
 .Valid Usage


### PR DESCRIPTION
coverageToColorLocation is in VkPipelineCoverageToColorStateCreateInfoNV, not VkPipelineSampleLocationsStateCreateInfoEXT.