### PR TITLE
Gate `VUID-StandaloneSpirv-OpVariable-04734` behind Vulkan 1.3 or ext

### DIFF
--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -206,10 +206,12 @@ endif::VK_VERSION_1_1[]
     Any code:OpVariable with an code:Initializer operand must: have
     *Output*, *Private*, *Function*, or *Workgroup* as its *Storage Class*
     operand
+ifdef::VK_VERSION_1_3,VK_KHR_zero_initialize_workgroup_memory[]
   * [[VUID-{refpage}-OpVariable-04734]]
     Any code:OpVariable with an code:Initializer operand and *Workgroup* as
     its *Storage Class* operand must: use code:OpConstantNull as the
     initializer
+endif::VK_VERSION_1_3,VK_KHR_zero_initialize_workgroup_memory[]
   * [[VUID-{refpage}-OpReadClockKHR-04652]]
     *Scope* for code:OpReadClockKHR must: be limited to *Subgroup* or
     *Device*


### PR DESCRIPTION
`VUID-StandaloneSpirv-OpVariable-04734` should require `VK_VERSION_1_3` or `VK_KHR_zero_initialize_workgroup_memory`.