### PR TITLE
Clarify DebugUtils object support

### DIFF
--- a/chapters/VK_EXT_debug_utils.adoc
+++ b/chapters/VK_EXT_debug_utils.adoc
@@ -28,9 +28,19 @@ callback to capture debug messages from a variety of Vulkan components.
 
 It can be useful for an application to provide its own content relative to a
 specific Vulkan object.
+
 The following commands allow application developers to associate
 user-defined information with Vulkan objects.
-
+These commands are device-level commands but they may: reference instance-level
+objects (such as slink:VkInstance) and physical device-level objects (such as
+slink:VkPhysicalDevice) with a few restrictions:
+  * The data for the corresponding object may: still be available after the
+    slink:VkDevice used in the corresponding API call to set it is destroyed,
+    but access to this data is not guaranteed and should be avoided.
+  * Subsequent calls to change the data of the same object across multiple
+    sname:VkDevice objects, may: result in the data being changed to the most
+    recent version for all sname:VkDevice objects and not just the
+    sname:VkDevice used in the most recent API call.
 
 [[debugging-object-naming]]
 ==== Object Naming
@@ -42,7 +52,8 @@ fname:vkSetDebugUtilsObjectNameEXT as defined below.
 --
 include::{generated}/api/protos/vkSetDebugUtilsObjectNameEXT.adoc[]
 
-  * pname:device is the device that created the object.
+  * pname:device is the device that is associated with the named object passed
+    in via pname:objectHandle.
   * pname:pNameInfo is a pointer to a slink:VkDebugUtilsObjectNameInfoEXT
     structure specifying parameters of the name to set on the object.
 
@@ -52,6 +63,17 @@ include::{generated}/api/protos/vkSetDebugUtilsObjectNameEXT.adoc[]
     pname:pNameInfo->objectType must: not be ename:VK_OBJECT_TYPE_UNKNOWN
   * [[VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02588]]
     pname:pNameInfo->objectHandle must: not be dlink:VK_NULL_HANDLE
+  * If pname:pNameInfo->pname:objectHandle is the valid handle of an
+    instance-level object, the slink:VkDevice identified by pname:device must:
+    be a descendent of the same slink:VkInstance as the object identified by
+    pname:pNameInfo->pname:objectHandle
+  * If pname:pNameInfo->pname:objectHandle is the valid handle of a
+    physical-device-level object, the slink:VkDevice identified by pname:device
+    must: be a descendant of the same slink:VkPhysicalDevice as the object
+    identified by pname:pNameInfo->pname:objectHandle
+  * If pname:pNameInfo->pname:objectHandle is the valid handle of a device-level
+    object, that object must: be a descendent of the slink:VkDevice identified
+    by pname:device
 ****
 
 include::{generated}/validity/protos/vkSetDebugUtilsObjectNameEXT.adoc[]
@@ -124,6 +146,21 @@ include::{generated}/api/protos/vkSetDebugUtilsObjectTagEXT.adoc[]
   * pname:device is the device that created the object.
   * pname:pTagInfo is a pointer to a slink:VkDebugUtilsObjectTagInfoEXT
     structure specifying parameters of the tag to attach to the object.
+
+.Valid Usage
+****
+  * If pname:pNameInfo->pname:objectHandle is the valid handle of an
+    instance-level object, the slink:VkDevice identified by pname:device must:
+    be a descendent of the same slink:VkInstance as the object identified by
+    pname:pNameInfo->pname:objectHandle
+  * If pname:pNameInfo->pname:objectHandle is the valid handle of a
+    physical-device-level object, the slink:VkDevice identified by pname:device
+    must: be a descendant of the same slink:VkPhysicalDevice as the object
+    identified by pname:pNameInfo->pname:objectHandle
+  * If pname:pNameInfo->pname:objectHandle is the valid handle of a device-level
+    object, that object must: be a descendent of the slink:VkDevice identified
+    by pname:device
+****
 
 include::{generated}/validity/protos/vkSetDebugUtilsObjectTagEXT.adoc[]
 --


### PR DESCRIPTION
The DebugUtils commands that allow a developer to associate data with a given object handle were unclear in a number of places. In particular, if the object passed in was an instance-level or physical-device-level object, what were the restrictions. This language attempts to rectify that.

Associated Issues: #1668

NOTE: This replaces PR #1901 which was submitted to resolve this issue but appears to have gone stale.  But @pixelcluster deserves kudos for attempting to get this fixed since it lead to many good discussions with @krOoze as well.