### PR TITLE
Fix incorrect link in VK_KHR_create_renderpass2

### DIFF
--- a/appendices/VK_KHR_create_renderpass2.adoc
+++ b/appendices/VK_KHR_create_renderpass2.adoc
@@ -38,8 +38,8 @@ follows:
     slink:VkRenderPassMultiviewCreateInfo::pname:pCorrelationMasks are
     directly specified in slink:VkRenderPassCreateInfo2KHR.
   * slink:VkInputAttachmentAspectReference::pname:aspectMask is now
-    specified in the relevant input attachment description in
-    slink:VkAttachmentDescription2KHR::pname:aspectMask
+    specified in the relevant input attachment reference in
+    slink:VkAttachmentReference2KHR::pname:aspectMask
 
 The details of these mappings are explained fully in the new structures.
 


### PR DESCRIPTION
aspectMask is not specified in VKAttachmentDescription2KHR but in VkAttachmentReference2KHR