### PR TITLE
Use {chapters}/ in vkspec.adoc instead of chapters/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ $(PROPOSALDIR)/%.html: $(PROPOSALPATH)/%.adoc
 	$(QUIET)$(ASCIIDOC) --failure-level ERROR -b html5 -o $@ $<
 	$(QUIET) if egrep -q '\\[([]' $@ ; then \
 	    $(TRANSLATEMATH) $@ ; \
-    fi
+	fi
 
 # Reflow text in spec sources
 REFLOW = $(SCRIPTS)/reflow.py

--- a/vkspec.adoc
+++ b/vkspec.adoc
@@ -33,7 +33,7 @@ toc::[]
 
 // Preamble "chapter"
 
-include::chapters/preamble.adoc[]
+include::{chapters}/preamble.adoc[]
 
 // Actual chapters
 
@@ -41,150 +41,150 @@ include::chapters/preamble.adoc[]
 ifeval::["{test}"=="1"]
 
 // Include or insert trivial test markup here, to bypass building full spec
-// include::chapters/textest.adoc[]
+// include::{chapters}/textest.adoc[]
 
-include::chapters/introduction.adoc[]
+include::{chapters}/introduction.adoc[]
 
 endif::[]
 
 ifeval::["{test}"!="1"]
-include::chapters/introduction.adoc[]
+include::{chapters}/introduction.adoc[]
 
-include::chapters/fundamentals.adoc[]
+include::{chapters}/fundamentals.adoc[]
 
-include::chapters/initialization.adoc[]
+include::{chapters}/initialization.adoc[]
 
-include::chapters/devsandqueues.adoc[]
+include::{chapters}/devsandqueues.adoc[]
 
-include::chapters/cmdbuffers.adoc[]
+include::{chapters}/cmdbuffers.adoc[]
 
-include::chapters/synchronization.adoc[]
+include::{chapters}/synchronization.adoc[]
 
-include::chapters/renderpass.adoc[]
+include::{chapters}/renderpass.adoc[]
 
-include::chapters/shaders.adoc[]
+include::{chapters}/shaders.adoc[]
 
-include::chapters/pipelines.adoc[]
+include::{chapters}/pipelines.adoc[]
 
-include::chapters/memory.adoc[]
+include::{chapters}/memory.adoc[]
 
-include::chapters/resources.adoc[]
+include::{chapters}/resources.adoc[]
 
-include::chapters/samplers.adoc[]
+include::{chapters}/samplers.adoc[]
 
-include::chapters/descriptorsets.adoc[]
+include::{chapters}/descriptorsets.adoc[]
 
-include::chapters/interfaces.adoc[]
+include::{chapters}/interfaces.adoc[]
 
-include::chapters/textures.adoc[]
+include::{chapters}/textures.adoc[]
 
 ifdef::VK_EXT_fragment_density_map[]
-include::chapters/fragmentdensitymapops.adoc[]
+include::{chapters}/fragmentdensitymapops.adoc[]
 endif::VK_EXT_fragment_density_map[]
 
-include::chapters/queries.adoc[]
+include::{chapters}/queries.adoc[]
 
 // Transfer operations
-include::chapters/clears.adoc[]
+include::{chapters}/clears.adoc[]
 
-include::chapters/copies.adoc[]
+include::{chapters}/copies.adoc[]
 
 // Graphics Operations
-include::chapters/drawing.adoc[]
+include::{chapters}/drawing.adoc[]
 
-include::chapters/fxvertex.adoc[]
+include::{chapters}/fxvertex.adoc[]
 
-include::chapters/tessellation.adoc[]
+include::{chapters}/tessellation.adoc[]
 
-include::chapters/geometry.adoc[]
+include::{chapters}/geometry.adoc[]
 
 ifdef::VK_NV_mesh_shader,VK_EXT_mesh_shader[]
-include::chapters/VK_NV_mesh_shader/mesh.adoc[]
+include::{chapters}/VK_NV_mesh_shader/mesh.adoc[]
 endif::VK_NV_mesh_shader,VK_EXT_mesh_shader[]
 
 ifdef::VK_HUAWEI_cluster_culling_shader[]
-include::chapters/VK_HUAWEI_cluster_culling_shader/clusterculling.adoc[]
+include::{chapters}/VK_HUAWEI_cluster_culling_shader/clusterculling.adoc[]
 endif::VK_HUAWEI_cluster_culling_shader[]
 
-include::chapters/vertexpostproc.adoc[]
+include::{chapters}/vertexpostproc.adoc[]
 
-include::chapters/primsrast.adoc[]
+include::{chapters}/primsrast.adoc[]
 
-include::chapters/fragops.adoc[]
+include::{chapters}/fragops.adoc[]
 
-include::chapters/framebuffer.adoc[]
+include::{chapters}/framebuffer.adoc[]
 
 // Compute
-include::chapters/dispatch.adoc[]
+include::{chapters}/dispatch.adoc[]
 
 // Device Generated Commands
 ifdef::VK_NV_device_generated_commands[]
-include::chapters/VK_NV_device_generated_commands/generatedcommands.adoc[]
+include::{chapters}/VK_NV_device_generated_commands/generatedcommands.adoc[]
 endif::VK_NV_device_generated_commands[]
 
 // Sparse
-include::chapters/sparsemem.adoc[]
+include::{chapters}/sparsemem.adoc[]
 
 ifdef::VK_KHR_surface[]
-include::chapters/VK_KHR_surface/wsi.adoc[]
+include::{chapters}/VK_KHR_surface/wsi.adoc[]
 endif::VK_KHR_surface[]
 
 // Deferred host ops
 ifdef::VK_KHR_deferred_host_operations[]
-include::chapters/VK_KHR_deferred_host_operations/deferred_host_operations.adoc[]
+include::{chapters}/VK_KHR_deferred_host_operations/deferred_host_operations.adoc[]
 endif::VK_KHR_deferred_host_operations[]
 
 // Private data
 ifdef::VK_VERSION_1_3,VK_EXT_private_data[]
-include::chapters/VK_EXT_private_data.adoc[]
+include::{chapters}/VK_EXT_private_data.adoc[]
 endif::VK_VERSION_1_3,VK_EXT_private_data[]
 
 // Acceleration structures
 ifdef::VK_NV_ray_tracing,VK_KHR_acceleration_structure[]
-include::chapters/accelstructures.adoc[]
+include::{chapters}/accelstructures.adoc[]
 endif::VK_NV_ray_tracing,VK_KHR_acceleration_structure[]
 
 // Micromaps
 ifdef::VK_EXT_opacity_micromap[]
-include::chapters/VK_EXT_opacity_micromap/micromaps.adoc[]
+include::{chapters}/VK_EXT_opacity_micromap/micromaps.adoc[]
 endif::VK_EXT_opacity_micromap[]
 
 // Ray traversal
 ifdef::VK_NV_ray_tracing,VK_KHR_ray_tracing_pipeline,VK_KHR_ray_query[]
-include::chapters/raytraversal.adoc[]
+include::{chapters}/raytraversal.adoc[]
 endif::VK_NV_ray_tracing,VK_KHR_ray_tracing_pipeline,VK_KHR_ray_query[]
 
 // Ray tracing
 ifdef::VK_NV_ray_tracing,VK_KHR_ray_tracing_pipeline[]
-include::chapters/raytracing.adoc[]
+include::{chapters}/raytracing.adoc[]
 endif::VK_NV_ray_tracing,VK_KHR_ray_tracing_pipeline[]
 
 // Memory Decompression
 ifdef::VK_NV_memory_decompression[]
-include::chapters/VK_NV_memory_decompression.adoc[]
+include::{chapters}/VK_NV_memory_decompression.adoc[]
 endif::VK_NV_memory_decompression[]
 
 // Vulkan Video extensions
 ifdef::VK_KHR_video_queue[]
-include::chapters/video_extensions.adoc[]
+include::{chapters}/video_extensions.adoc[]
 endif::VK_KHR_video_queue[]
 
 ifdef::VK_NV_optical_flow[]
-include::chapters/VK_NV_optical_flow/optical_flow.adoc[]
+include::{chapters}/VK_NV_optical_flow/optical_flow.adoc[]
 endif::VK_NV_optical_flow[]
 
 // Sort of an appendix
-include::chapters/extensions.adoc[]
+include::{chapters}/extensions.adoc[]
 
-include::chapters/features.adoc[]
+include::{chapters}/features.adoc[]
 
-include::chapters/limits.adoc[]
+include::{chapters}/limits.adoc[]
 
-include::chapters/formats.adoc[]
+include::{chapters}/formats.adoc[]
 
-include::chapters/capabilities.adoc[]
+include::{chapters}/capabilities.adoc[]
 
-include::chapters/debugging.adoc[]
+include::{chapters}/debugging.adoc[]
 
 // Appendices
 :numbered!:


### PR DESCRIPTION
{chapters}/ is used everywhere else.  This makes it possible to override the macro consistently across the spec.