### PR TITLE
Add support for Codified VUs

### DIFF
--- a/config/khronos.css
+++ b/config/khronos.css
@@ -730,3 +730,10 @@ li > p > a[id^="VUID-"].link { color: black; text-decoration: none; }
 li > p > a[id^="VUID-"].link:hover { color: black; }
 
 .vuid { color: #4d4d4d; font-family: monospace; }
+
+/* VU styling */
+.vu { font-family: monospace; white-space: nowrap; }
+.vu-keyword { font-weight: bold; }
+.vu-operator { font-weight: bold; }
+.vu-number { font-weight: bold; }
+.vu-builtin { }

--- a/scripts/doctransformer.py
+++ b/scripts/doctransformer.py
@@ -1,0 +1,437 @@
+# Copyright 2023 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for automatic transformation of spec sources.  Most of the logic
+has to do with detecting asciidoc markup or block types that should not be
+transformed (tables, code) and ignoring them.  It is very likely there are many
+asciidoc constructs not yet accounted for in the script, our usage of asciidoc
+markup is intentionally somewhat limited.
+"""
+
+import re
+import sys
+from reflib import logDiag, logWarn
+
+# Vulkan-specific - will consolidate into scripts/ like OpenXR soon
+sys.path.insert(0, 'xml')
+
+from apiconventions import APIConventions
+conventions = APIConventions()
+
+# Start of an asciidoctor conditional
+#   ifdef::
+#   ifndef::
+conditionalStart = re.compile(r'^(ifdef|ifndef)::')
+
+# Markup that always ends a paragraph
+#   empty line or whitespace
+#   [block options]
+#   [[anchor]]
+#   //                  comment
+#   <<<<                page break
+#   :attribute-setting
+#   macro-directive::terms
+#   +                   standalone list item continuation
+#   label::             labelled list - label must be standalone
+endPara = re.compile(r'^( *|\[.*\]|//.*|<<<<|:.*|[a-z]+::.*|\+|.*::)$')
+
+# Special case of markup ending a paragraph, used to track the current
+# command/structure. This allows for either OpenXR or Vulkan API path
+# conventions. Nominally it should use the file suffix defined by the API
+# conventions (conventions.file_suffix), except that XR uses '.txt' for
+# generated API include files, not '.adoc' like its other includes.
+includePat = re.compile(
+        r'include::(?P<directory_traverse>((../){1,4}|\{generated\}/)(generated/)?)(?P<generated_type>[\w]+)/(?P<category>\w+)/(?P<entity_name>[^./]+).adoc[\[][\]]')
+
+# Markup that is OK in a contiguous paragraph but otherwise passed through
+#   .anything (except .., which indicates a literal block)
+#   === Section Titles
+#   image::path_to_image[attributes]  (apparently a single colon is OK but less idiomatic)
+endParaContinue = re.compile(r'^(\.[^.].*|=+ .*|image:.*\[.*\])$')
+
+# Markup for block delimiters whose contents *should* be reformatted
+#   --   (exactly two)  (open block)
+#   **** (4 or more)    (sidebar block)
+#   ==== (4 or more)    (example block)
+#   ____ (4 or more)    (quote block)
+blockTransform = re.compile(r'^(--|[*=_]{4,})$')
+
+# Fake block delimiters for "common" VU statements
+blockCommonTransform = '// Common Valid Usage\n'
+
+# Markup for block delimiters whose contents should *not* be transformed
+#   |=== (3 or more)  (table)
+#   ```  (3 or more)  (listing block)
+#   //// (4 or more)  (comment block)
+#   ---- (4 or more)  (listing block)
+#   .... (4 or more)  (literal block)
+#   ++++ (4 or more)  (passthrough block)
+#   ~~~~ (4 or more)  (alternate open block delimiter, supported via extension)
+blockPassthrough = re.compile(r'^(\|={3,}|[`]{3}|[\-+./~]{4,})$')
+
+# Markup for introducing lists (hanging paragraphs)
+#   * bullet
+#     ** bullet
+#     -- bullet
+#   . bullet
+#   :: bullet (no longer supported by asciidoctor 2)
+#   {empty}:: bullet
+#   1. list item
+#   <1> source listing callout
+beginBullet = re.compile(r'^ *([-*.]+|\{empty\}::|::|[0-9]+[.]|<([0-9]+)>) ')
+
+class TransformState:
+    """State machine for transforming documents.
+
+    Represents the state of the transform operation"""
+    def __init__(self):
+        self.blockStack = [ None ]
+        """The last element is a line with the asciidoc block delimiter that is
+        currently in effect, such as '--', '----', '****', '====', or '++++'.
+        This affects whether or not the block contents should be transformed."""
+        self.transformStack = [ True ]
+        """The last element is True or False if the current blockStack contents
+        should be transformed."""
+        self.vuStack = [ False ]
+        """the last element is True or False if the current blockStack contents
+        are an explicit Valid Usage block."""
+
+        self.para = []
+        """list of lines in the paragraph being accumulated.
+        When this is non-empty, there is a current paragraph."""
+
+        self.lastTitle = False
+        """true if the previous line was a document title line
+        (e.g. :leveloffset: 0 - no attempt to track changes to this is made)."""
+
+        self.leadIndent = 0
+        """indent level (in spaces) of the first line of a paragraph."""
+
+        self.hangIndent = 0
+        """indent level of the remaining lines of a paragraph."""
+
+        self.lineNumber = 0
+        """line number being read from the input file."""
+
+        self.defaultApiName = '{refpage}'
+        self.apiName = self.defaultApiName
+        """String name of an API structure or command for VUID tag generation,
+        or {refpage} if one has not been included in this file yet."""
+
+    def incrLineNumber(self):
+        self.lineNumber = self.lineNumber + 1
+
+    def isOpenBlockDelimiter(self, line):
+        """Returns True if line is an open block delimiter."""
+        return line[0:2] == '--'
+
+    def resetPara(self):
+        """Reset the paragraph, including its indentation level"""
+        self.para = []
+        self.leadIndent = 0
+        self.hangIndent = 0
+
+    def endBlock(self, line, transform, vuBlock):
+        """If beginning a block, tag whether or not to transform the contents.
+
+        vuBlock is True if the previous line indicates this is a Valid Usage
+        block."""
+        if self.blockStack[-1] == line:
+            logDiag('endBlock line', self.lineNumber,
+                    ': popping block end depth:', len(self.blockStack),
+                    ':', line, end='')
+
+            # Reset apiName at the end of an open block.
+            # Open blocks cannot be nested (at present), so this is safe.
+            if self.isOpenBlockDelimiter(line):
+                logDiag('reset apiName to empty at line', self.lineNumber)
+                self.apiName = self.defaultApiName
+            else:
+                logDiag('NOT resetting apiName to default at line',
+                        self.lineNumber)
+
+            self.blockStack.pop()
+            self.transformStack.pop()
+            self.vuStack.pop()
+        else:
+            # Start a block
+            self.blockStack.append(line)
+            self.transformStack.append(transform)
+            self.vuStack.append(vuBlock)
+
+            logDiag('endBlock transform =', transform, ' line', self.lineNumber,
+                    ': pushing block start depth', len(self.blockStack),
+                    ':', line, end='')
+
+    def addLine(self, line, indent):
+        """Add a line to the current paragraph"""
+        if self.para == []:
+            # Begin a new paragraph
+            self.para = [line]
+            self.leadIndent = indent
+            self.hangIndent = indent
+        else:
+            # Add a line to a paragraph. Increase the hanging indentation
+            # level - once.
+            if self.hangIndent == self.leadIndent:
+                self.hangIndent = indent
+            self.para.append(line)
+
+
+class TransformCallbackState:
+    """State given to the transformer callback object, derived from
+    TransformState."""
+    def __init__(self, state):
+        self.isVU = state.vuStack[-1] if len(state.vuStack) > 0 else False
+        """Whether this paragraph is a VU."""
+
+        self.apiName = state.apiName
+        """String name of an API structure or command this paragraph belongs
+        to."""
+
+        self.leadIndent = state.leadIndent
+        """indent level (in spaces) of the first line of a paragraph."""
+
+        self.hangIndent = state.hangIndent
+        """indent level of the remaining lines of a paragraph."""
+
+        self.lineNumber = state.lineNumber
+        """line number being read from the input file."""
+
+
+class DocTransformer:
+    """A transformer that recursively goes over all spec files under a path.
+
+    The transformer goes over all spec files under a path and does some basic
+    parsing.  In particular, it tracks which section the current text belongs
+    to, whether it references a VU, etc and processes them in 'paragraph'
+    granularity.
+    The transformer takes a callback object with the following methods:
+
+    - transformParagraph: Called when a paragraph is parsed.  The paragraph
+      along with some information (such as whether it is a VU) is passed.  The
+      function may transform the paragraph as necessary.
+    - onEmbeddedVUConditional: Called when an embedded VU conditional is
+      encountered.
+    """
+    def __init__(self,
+                 filename,
+                 outfile,
+                 callback):
+        self.filename = filename
+        """base name of file being read from."""
+
+        self.outfile = outfile
+        """file handle to write to."""
+
+        self.state = TransformState()
+        """State of transformation"""
+
+        self.callback = callback
+        """The transformation callback object"""
+
+    def printLines(self, lines):
+        """Print an array of lines with newlines already present"""
+        if len(lines) > 0:
+            logDiag(':: printLines:', len(lines), 'lines: ', lines[0], end='')
+
+        if self.outfile is not None:
+            for line in lines:
+                print(line, file=self.outfile, end='')
+
+    def emitPara(self):
+        """Emit a paragraph, possibly transforming it depending on the block
+        context.
+
+        Resets the paragraph accumulator."""
+        if self.state.para != []:
+            transformedPara = self.state.para
+
+            if self.state.transformStack[-1]:
+                callbackState = TransformCallbackState(self.state)
+
+                transformedPara = self.callback.transformParagraph(
+                        self.state.para,
+                        callbackState)
+
+            self.printLines(transformedPara)
+
+        self.state.resetPara()
+
+    def endPara(self, line):
+        """'line' ends a paragraph and should itself be emitted.
+        line may be None to indicate EOF or other exception."""
+        logDiag('endPara line', self.state.lineNumber, ': emitting paragraph')
+
+        # Emit current paragraph, this line, and reset tracker
+        self.emitPara()
+
+        if line:
+            self.printLines([line])
+
+    def endParaContinue(self, line):
+        """'line' ends a paragraph (unless there is already a paragraph being
+        accumulated, e.g. len(para) > 0 - currently not implemented)"""
+        self.endPara(line)
+
+    def endBlock(self, line, transform = False, vuBlock = False):
+        """'line' begins or ends a block.
+
+        If beginning a block, tag whether or not to transform the contents.
+
+        vuBlock is True if the previous line indicates this is a Valid Usage
+        block."""
+        self.endPara(line)
+        self.state.endBlock(line, transform, vuBlock)
+
+    def endParaBlockTransform(self, line, vuBlock):
+        """'line' begins or ends a block. The paragraphs in the block *should* be
+        reformatted (e.g. a NOTE)."""
+        self.endBlock(line, transform = True, vuBlock = vuBlock)
+
+    def endParaBlockPassthrough(self, line):
+        """'line' begins or ends a block. The paragraphs in the block should
+        *not* be reformatted (e.g. a code listing)."""
+        self.endBlock(line, transform = False)
+
+    def addLine(self, line):
+        """'line' starts or continues a paragraph.
+
+        Paragraphs may have "hanging indent", e.g.
+
+        ```
+          * Bullet point...
+            ... continued
+        ```
+
+        In this case, when the higher indentation level ends, so does the
+        paragraph."""
+        logDiag('addLine line', self.state.lineNumber, ':', line, end='')
+
+        # See https://stackoverflow.com/questions/13648813/what-is-the-pythonic-way-to-count-the-leading-spaces-in-a-string
+        indent = len(line) - len(line.lstrip())
+
+        # A hanging paragraph ends due to a less-indented line.
+        if self.state.para != [] and indent < self.state.hangIndent:
+            logDiag('addLine: line reduces indentation, emit paragraph')
+            self.emitPara()
+
+        # A bullet point (or something that looks like one) always ends the
+        # current paragraph.
+        if beginBullet.match(line):
+            logDiag('addLine: line matches beginBullet, emit paragraph')
+            self.emitPara()
+
+        self.state.addLine(line, indent)
+
+    def apiMatch(self, oldname, newname):
+        """Returns whether oldname and newname match, up to an API suffix.
+           This should use the API map instead of this heuristic, since aliases
+           like VkPhysicalDeviceVariablePointerFeaturesKHR ->
+           VkPhysicalDeviceVariablePointersFeatures are not recognized."""
+        upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        return oldname.rstrip(upper) == newname.rstrip(upper)
+
+    def transformFile(self, lines):
+        """Transform lines, and possibly output to to the given file."""
+
+        for line in lines:
+            self.state.incrLineNumber()
+
+            # Is this a title line (leading '= ' followed by text)?
+            thisTitle = False
+
+            # The logic here is broken. If we are in a non-transformable block and
+            # this line *does not* end the block, it should always be
+            # accumulated.
+
+            # Test for a blockCommonTransform delimiter comment first, to avoid
+            # treating it solely as a end-Paragraph marker comment.
+            if line == blockCommonTransform:
+                # Starting or ending a pseudo-block for "common" VU statements.
+                self.endParaBlockTransform(line, vuBlock = True)
+
+            elif blockTransform.match(line):
+                # Starting or ending a block whose contents may be transformed.
+                # Blocks cannot be nested.
+
+                # Is this is an explicit Valid Usage block?
+                vuBlock = (self.state.lineNumber > 1 and
+                           lines[self.state.lineNumber-2] == '.Valid Usage\n')
+
+                self.endParaBlockTransform(line, vuBlock)
+
+            elif endPara.match(line):
+                # Ending a paragraph. Emit the current paragraph, if any, and
+                # prepare to begin a new paragraph.
+
+                self.endPara(line)
+
+                # If this is an include:: line starting the definition of a
+                # structure or command, track that for use in VUID generation.
+
+                matches = includePat.search(line)
+                if matches is not None:
+                    generated_type = matches.group('generated_type')
+                    include_type = matches.group('category')
+                    if generated_type == 'api' and include_type in ('protos', 'structs', 'funcpointers'):
+                        apiName = matches.group('entity_name')
+                        if self.state.apiName != self.state.defaultApiName:
+                            # This happens when there are multiple API include
+                            # lines in a single block. The style guideline is to
+                            # always place the API which others are promoted to
+                            # first. In virtually all cases, the promoted API
+                            # will differ solely in the vendor suffix (or
+                            # absence of it), which is benign.
+                            if not self.apiMatch(self.state.apiName, apiName):
+                                logDiag(f'Promoted API name mismatch at line {self.state.lineNumber}: {apiName} does not match self.state.apiName (this is OK if it is just a spelling alias)')
+                        else:
+                            self.state.apiName = apiName
+
+            elif endParaContinue.match(line):
+                # For now, always just end the paragraph.
+                # Could check see if len(para) > 0 to accumulate.
+
+                self.endParaContinue(line)
+
+                # If it is a title line, track that
+                if line[0:2] == '= ':
+                    thisTitle = True
+
+            elif blockPassthrough.match(line):
+                # Starting or ending a block whose contents must not be
+                # transformed.  These are tables, etc. Blocks cannot be nested.
+
+                self.endParaBlockPassthrough(line)
+            elif self.state.lastTitle:
+                # The previous line was a document title line. This line
+                # is the author / credits line and must not be transformed.
+
+                self.endPara(line)
+            else:
+                # Just accumulate a line to the current paragraph. Watch out for
+                # hanging indents / bullet-points and track that indent level.
+
+                self.addLine(line)
+
+                # This test looks for disallowed conditionals inside Valid Usage
+                # blocks, by checking if (a) this line does not start a new VU
+                # (bullet point) and (b) the previous line starts an asciidoctor
+                # conditional (ifdef:: or ifndef::).
+                if (self.state.vuStack[-1]
+                    and not beginBullet.match(line)
+                    and conditionalStart.match(lines[self.state.lineNumber-2])):
+                       self.callback.onEmbeddedVUConditional(self.state)
+
+            self.state.lastTitle = thisTitle
+
+        # Cleanup at end of file
+        self.endPara(None)
+
+        # Check for sensible block nesting
+        if len(self.state.blockStack) > 1:
+            logWarn('file', self.filename,
+                    'mismatched asciidoc block delimiters at EOF:',
+                    self.state.blockStack[-1])
+

--- a/scripts/doctransformer.py
+++ b/scripts/doctransformer.py
@@ -24,17 +24,23 @@ conventions = APIConventions()
 #   ifndef::
 conditionalStart = re.compile(r'^(ifdef|ifndef)::')
 
+# Attribute setting markup in the following form:
+#
+#   :attribute-setting
+#
+# This always ends the paragraph
+attributeSetting = re.compile(r'^:.*$')
+
 # Markup that always ends a paragraph
 #   empty line or whitespace
 #   [block options]
 #   [[anchor]]
 #   //                  comment
 #   <<<<                page break
-#   :attribute-setting
 #   macro-directive::terms
 #   +                   standalone list item continuation
 #   label::             labelled list - label must be standalone
-endPara = re.compile(r'^( *|\[.*\]|//.*|<<<<|:.*|[a-z]+::.*|\+|.*::)$')
+endPara = re.compile(r'^( *|\[.*\]|//.*|<<<<|[a-z]+::.*|\+|.*::)$')
 
 # Special case of markup ending a paragraph, used to track the current
 # command/structure. This allows for either OpenXR or Vulkan API path
@@ -182,7 +188,7 @@ class TransformState:
 class TransformCallbackState:
     """State given to the transformer callback object, derived from
     TransformState."""
-    def __init__(self, state):
+    def __init__(self, state, paragraphLineCount):
         self.isVU = state.vuStack[-1] if len(state.vuStack) > 0 else False
         """Whether this paragraph is a VU."""
 
@@ -196,7 +202,9 @@ class TransformCallbackState:
         self.hangIndent = state.hangIndent
         """indent level of the remaining lines of a paragraph."""
 
-        self.lineNumber = state.lineNumber
+        # Make sure line number points to the beginning of the
+        # paragraph, not the end of it.
+        self.lineNumber = state.lineNumber - paragraphLineCount
         """line number being read from the input file."""
 
 
@@ -212,6 +220,10 @@ class DocTransformer:
     - transformParagraph: Called when a paragraph is parsed.  The paragraph
       along with some information (such as whether it is a VU) is passed.  The
       function may transform the paragraph as necessary.
+    - transformInclude: Called when an include directive is encountered.  The
+      include line and the state is passed.  The function may transform the
+      line as necessary.
+    - onMacro: Called when a macro is encountered.
     - onEmbeddedVUConditional: Called when an embedded VU conditional is
       encountered.
     """
@@ -249,7 +261,8 @@ class DocTransformer:
             transformedPara = self.state.para
 
             if self.state.transformStack[-1]:
-                callbackState = TransformCallbackState(self.state)
+                callbackState = TransformCallbackState(self.state,
+                                                       len(self.state.para))
 
                 transformedPara = self.callback.transformParagraph(
                         self.state.para,
@@ -362,32 +375,46 @@ class DocTransformer:
 
                 self.endParaBlockTransform(line, vuBlock)
 
+            elif attributeSetting.match(line):
+                # Notify that a macro was encountered
+
+                callbackState = TransformCallbackState(self.state, 1)
+                self.callback.onMacro(line, callbackState)
+
+                # End the paragraph.
+                self.endPara(line)
+
             elif endPara.match(line):
+                # If this is an include:: line starting the definition of a
+                # structure or command, track that for use in VUID generation.
+
+                if line.startswith('include::'):
+                    matches = includePat.search(line)
+                    if matches is not None:
+                        generated_type = matches.group('generated_type')
+                        include_type = matches.group('category')
+                        if generated_type == 'api' and include_type in ('protos', 'structs', 'funcpointers'):
+                            apiName = matches.group('entity_name')
+                            if self.state.apiName != self.state.defaultApiName:
+                                # This happens when there are multiple API include
+                                # lines in a single block. The style guideline is to
+                                # always place the API which others are promoted to
+                                # first. In virtually all cases, the promoted API
+                                # will differ solely in the vendor suffix (or
+                                # absence of it), which is benign.
+                                if not self.apiMatch(self.state.apiName, apiName):
+                                    logDiag(f'Promoted API name mismatch at line {self.state.lineNumber}: {apiName} does not match self.state.apiName (this is OK if it is just a spelling alias)')
+                            else:
+                                self.state.apiName = apiName
+
+                    callbackState = TransformCallbackState(self.state, 1)
+                    line = self.callback.transformInclude(line, callbackState)
+
                 # Ending a paragraph. Emit the current paragraph, if any, and
                 # prepare to begin a new paragraph.
 
                 self.endPara(line)
 
-                # If this is an include:: line starting the definition of a
-                # structure or command, track that for use in VUID generation.
-
-                matches = includePat.search(line)
-                if matches is not None:
-                    generated_type = matches.group('generated_type')
-                    include_type = matches.group('category')
-                    if generated_type == 'api' and include_type in ('protos', 'structs', 'funcpointers'):
-                        apiName = matches.group('entity_name')
-                        if self.state.apiName != self.state.defaultApiName:
-                            # This happens when there are multiple API include
-                            # lines in a single block. The style guideline is to
-                            # always place the API which others are promoted to
-                            # first. In virtually all cases, the promoted API
-                            # will differ solely in the vendor suffix (or
-                            # absence of it), which is benign.
-                            if not self.apiMatch(self.state.apiName, apiName):
-                                logDiag(f'Promoted API name mismatch at line {self.state.lineNumber}: {apiName} does not match self.state.apiName (this is OK if it is just a spelling alias)')
-                        else:
-                            self.state.apiName = apiName
 
             elif endParaContinue.match(line):
                 # For now, always just end the paragraph.
@@ -422,7 +449,8 @@ class DocTransformer:
                 if (self.state.vuStack[-1]
                     and not beginBullet.match(line)
                     and conditionalStart.match(lines[self.state.lineNumber-2])):
-                       self.callback.onEmbeddedVUConditional(self.state)
+                        callbackState = TransformCallbackState(self.state, 1)
+                        self.callback.onEmbeddedVUConditional(callbackState)
 
             self.state.lastTitle = thisTitle
 

--- a/scripts/reflib.py
+++ b/scripts/reflib.py
@@ -7,6 +7,7 @@
 # Utility functions for automatic ref page generation and other script stuff
 
 import io
+from pathlib import Path
 import re
 import sys
 import subprocess
@@ -251,6 +252,16 @@ def loadFile(filename):
         return None, None
 
     return lines, newline_string
+
+def resolveAndMkdir(path):
+    path = Path(path).resolve()
+    # TOCTOU-safe directory creation
+    try:
+        path.mkdir()
+    except FileExistsError:
+        pass
+
+    return path
 
 def clampToBlock(line, minline, maxline):
     """Clamp a line number to be in the range [minline,maxline].

--- a/scripts/reflow-tests/.gitignore
+++ b/scripts/reflow-tests/.gitignore
@@ -1,0 +1,5 @@
+# Copyright 2023 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+results/

--- a/scripts/reflow-tests/expect-ifdef-in-vu.adoc
+++ b/scripts/reflow-tests/expect-ifdef-in-vu.adoc
@@ -1,0 +1,35 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+.Valid Usage
+****
+  * [[VUID-vkCmdClearColorImage-image-00003]]
+    If pname:image is non-sparse then it must: be bound completely and
+    contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource
+    ranges of pname:image specified in pname:pRanges at the time this
+    command is executed on a sname:VkDevice
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or
+    ename:VK_IMAGE_LAYOUT_GENERAL
+ifdef::VK_KHR_shared_presentable_image[]
+    , or ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-pColor-04961]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+****

--- a/scripts/reflow-tests/expect-new-vuid-codified.adoc
+++ b/scripts/reflow-tests/expect-new-vuid-codified.adoc
@@ -1,0 +1,92 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+.Valid Usage
+****
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-01993]]
+    The <<resources-image-format-features,format features>> of pname:image
+    must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
+endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-10000]]
+    require(image.create_info().usage.has_bit(VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-01545]]
+    pname:image must: not use any of the
+    <<formats-requiring-sampler-ycbcr-conversion, formats that require a
+    sampler {YCbCr} conversion>>
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-10001]]
+    If pname:image is non-sparse then it must: be bound completely and
+    contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource
+    ranges of pname:image specified in pname:pRanges at the time this
+    command is executed on a sname:VkDevice
+ifndef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or
+    ename:VK_IMAGE_LAYOUT_GENERAL
+endif::VK_KHR_shared_presentable_image[]
+ifdef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-10002]]
+    require(imageLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or
+        imageLayout == VK_IMAGE_LAYOUT_GENERAL or
+        imageLayout == VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the
+    elements of the pname:pRanges array must: each only include
+    ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * [[VUID-vkCmdClearColorImage-image-10003]]
+    mipLevels = image.create_info().mipLevels
+    for range in pRanges:
+     require(range.baseMipLevel < mipLevels)
+  * [[VUID-vkCmdClearColorImage-image-10004]]
+    mipLevels = image.create_info().mipLevels
+    for range in pRanges:
+     if range.levelCount != VK_REMAINING_MIP_LEVELS:
+      require(range.baseMipLevel + range.levelCount <= mipLevels)
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01693]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than or
+    equal to the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-image-10005]]
+    pname:image must: not have a compressed or depth/stencil format
+  * [[VUID-vkCmdClearColorImage-pColor-10006]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+ifdef::VK_VERSION_1_1[]
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01805]]
+    If pname:commandBuffer is an unprotected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    pname:image must: not be a protected image
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01806]]
+    If pname:commandBuffer is a protected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    must: not be an unprotected image
+endif::VK_VERSION_1_1[]
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow-tests/expect-new-vuid.adoc
+++ b/scripts/reflow-tests/expect-new-vuid.adoc
@@ -1,0 +1,95 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+.Valid Usage
+****
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-01993]]
+    The <<resources-image-format-features,format features>> of pname:image
+    must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
+endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-10000]]
+    pname:image must: have been created with
+    ename:VK_IMAGE_USAGE_TRANSFER_DST_BIT usage flag
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-01545]]
+    pname:image must: not use any of the
+    <<formats-requiring-sampler-ycbcr-conversion, formats that require a
+    sampler {YCbCr} conversion>>
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-10001]]
+    If pname:image is non-sparse then it must: be bound completely and
+    contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource
+    ranges of pname:image specified in pname:pRanges at the time this
+    command is executed on a sname:VkDevice
+ifndef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or
+    ename:VK_IMAGE_LAYOUT_GENERAL
+endif::VK_KHR_shared_presentable_image[]
+ifdef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-10002]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_GENERAL, or
+    ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the
+    elements of the pname:pRanges array must: each only include
+    ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * [[VUID-vkCmdClearColorImage-baseMipLevel-01470]]
+    The slink:VkImageSubresourceRange::pname:baseMipLevel members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * [[VUID-vkCmdClearColorImage-pRanges-10003]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than or
+    equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01693]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than or
+    equal to the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-image-10004]]
+    pname:image must: not have a compressed or depth/stencil format
+  * [[VUID-vkCmdClearColorImage-pColor-10005]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+ifdef::VK_VERSION_1_1[]
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01805]]
+    If pname:commandBuffer is an unprotected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    pname:image must: not be a protected image
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01806]]
+    If pname:commandBuffer is a protected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    must: not be an unprotected image
+endif::VK_VERSION_1_1[]
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow-tests/expect-table.adoc
+++ b/scripts/reflow-tests/expect-table.adoc
@@ -1,0 +1,33 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[formats]]
+= Formats
+
+<<<
+
+[[formats-numericformat]]
+.Interpretation of Numeric Format
+[width="95%",cols="2,3,10",options="header"]
+|====
+| Numeric format | SPIR-V _Sampled Type_ | Description
+| etext:UNORM    | OpTypeFloat           | The components are unsigned normalized values in the range [eq]#[0,1]#
+| etext:SNORM    | OpTypeFloat           | The components are signed normalized values in the range [eq]#[-1,1]#
+| etext:USCALED  | OpTypeFloat           | The components are unsigned integer values that get converted to floating-point in the range [0,2^n^-1]
+| etext:SSCALED  | OpTypeFloat           | The components are signed integer values that get converted to floating-point in the range [-2^n-1^,2^n-1^-1]
+| etext:UINT     | OpTypeInt             | The components are unsigned integer values in the range [0,2^n^-1]
+| etext:SINT     | OpTypeInt             | The components are signed integer values in the range [-2^n-1^,2^n-1^-1]
+| etext:UFLOAT   | OpTypeFloat           | The components are unsigned floating-point numbers (used by packed, shared exponent, and some compressed formats)
+| etext:SFLOAT   | OpTypeFloat           | The components are signed floating-point numbers
+| etext:SRGB     | OpTypeFloat           | The R, G, and B components are unsigned normalized values that represent values using sRGB nonlinear encoding, while the A component (if one exists) is a regular unsigned normalized value
+3+| [eq]#n# is the number of bits in the component.
+|====
+
+The suffix etext:_PACKnn indicates that the format is packed into an
+underlying type with etext:nn bits.
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+The suffix etext:_mPACKnn is a short-hand that indicates that the format has
+etext:m groups of components (which may or may not be stored in separate
+_planes_) that are each packed into an underlying type with etext:nn bits.
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]

--- a/scripts/reflow-tests/expect-text.adoc
+++ b/scripts/reflow-tests/expect-text.adoc
@@ -1,0 +1,15 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[formats]]
+= Formats
+
+Supported buffer and image formats may: vary across implementations.
+A minimum set of format features are guaranteed, but others must: be
+explicitly queried before use to ensure they are supported by the
+implementation.
+
+The features for the set of formats (elink:VkFormat) supported by the
+implementation are queried individually using the
+flink:vkGetPhysicalDeviceFormatProperties command.

--- a/scripts/reflow-tests/expect-vu-codified.adoc
+++ b/scripts/reflow-tests/expect-vu-codified.adoc
@@ -1,0 +1,120 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+Color and depth/stencil images can: be cleared outside a render pass
+instance using flink:vkCmdClearColorImage or
+flink:vkCmdClearDepthStencilImage, respectively.
+These commands are only allowed outside of a render pass instance.
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+  * pname:commandBuffer is the command buffer into which the command will be
+    recorded.
+  * pname:image is the image to be cleared.
+  * pname:imageLayout specifies the current layout of the image subresource
+    ranges to be cleared, and must: be
+ifdef::VK_KHR_shared_presentable_image[]
+    ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR,
+endif::VK_KHR_shared_presentable_image[]
+    ename:VK_IMAGE_LAYOUT_GENERAL or
+    ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL.
+  * pname:pColor is a pointer to a slink:VkClearColorValue structure
+    containing the values that the image subresource ranges will be cleared
+    to (see <<clears-values>> below).
+  * pname:rangeCount is the number of image subresource range structures in
+    pname:pRanges.
+  * pname:pRanges is a pointer to an array of slink:VkImageSubresourceRange
+    structures describing a range of mipmap levels, array layers, and
+    aspects to be cleared, as described in <<resources-image-views,Image
+    Views>>.
+
+Each specified range in pname:pRanges is cleared to the value specified by
+pname:pColor.
+
+.Valid Usage
+****
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-01993]]
+    The <<resources-image-format-features,format features>> of pname:image
+    must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
+endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-00002]]
+    require(image.create_info().usage.has_bit(VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-01545]]
+    pname:image must: not use any of the
+    <<formats-requiring-sampler-ycbcr-conversion, formats that require a
+    sampler {YCbCr} conversion>>
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-00003]]
+    If pname:image is non-sparse then it must: be bound completely and
+    contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource
+    ranges of pname:image specified in pname:pRanges at the time this
+    command is executed on a sname:VkDevice
+ifndef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    require(imageLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or
+        imageLayout == VK_IMAGE_LAYOUT_GENERAL)
+endif::VK_KHR_shared_presentable_image[]
+ifdef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-01394]]
+    require(imageLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or
+        imageLayout == VK_IMAGE_LAYOUT_GENERAL or
+        imageLayout == VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the
+    elements of the pname:pRanges array must: each only include
+    ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * [[VUID-vkCmdClearColorImage-baseMipLevel-01470]]
+    mipLevels = image.create_info().mipLevels
+    for range in pRanges:
+     require(range.baseMipLevel < mipLevels)
+  * [[VUID-vkCmdClearColorImage-pRanges-01692]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than or
+    equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01693]]
+    arrayLayers = image.create_info().arrayLayers
+    for range in pRanges:
+     if range.layerCount != VK_REMAINING_ARRAY_LAYERS:
+      require(range.baseArrayLayer + range.layerCount <= arrayLayers)
+  * [[VUID-vkCmdClearColorImage-image-00007]]
+    pname:image must: not have a compressed or depth/stencil format
+  * [[VUID-vkCmdClearColorImage-pColor-04961]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+ifdef::VK_VERSION_1_1[]
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01805]]
+    If pname:commandBuffer is an unprotected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    pname:image must: not be a protected image
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01806]]
+    If pname:commandBuffer is a protected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    must: not be an unprotected image
+endif::VK_VERSION_1_1[]
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow-tests/expect-vu.adoc
+++ b/scripts/reflow-tests/expect-vu.adoc
@@ -1,0 +1,123 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+Color and depth/stencil images can: be cleared outside a render pass
+instance using flink:vkCmdClearColorImage or
+flink:vkCmdClearDepthStencilImage, respectively.
+These commands are only allowed outside of a render pass instance.
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+  * pname:commandBuffer is the command buffer into which the command will be
+    recorded.
+  * pname:image is the image to be cleared.
+  * pname:imageLayout specifies the current layout of the image subresource
+    ranges to be cleared, and must: be
+ifdef::VK_KHR_shared_presentable_image[]
+    ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR,
+endif::VK_KHR_shared_presentable_image[]
+    ename:VK_IMAGE_LAYOUT_GENERAL or
+    ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL.
+  * pname:pColor is a pointer to a slink:VkClearColorValue structure
+    containing the values that the image subresource ranges will be cleared
+    to (see <<clears-values>> below).
+  * pname:rangeCount is the number of image subresource range structures in
+    pname:pRanges.
+  * pname:pRanges is a pointer to an array of slink:VkImageSubresourceRange
+    structures describing a range of mipmap levels, array layers, and
+    aspects to be cleared, as described in <<resources-image-views,Image
+    Views>>.
+
+Each specified range in pname:pRanges is cleared to the value specified by
+pname:pColor.
+
+.Valid Usage
+****
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-01993]]
+    The <<resources-image-format-features,format features>> of pname:image
+    must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
+endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-00002]]
+    pname:image must: have been created with
+    ename:VK_IMAGE_USAGE_TRANSFER_DST_BIT usage flag
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-01545]]
+    pname:image must: not use any of the
+    <<formats-requiring-sampler-ycbcr-conversion, formats that require a
+    sampler {YCbCr} conversion>>
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-00003]]
+    If pname:image is non-sparse then it must: be bound completely and
+    contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource
+    ranges of pname:image specified in pname:pRanges at the time this
+    command is executed on a sname:VkDevice
+ifndef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or
+    ename:VK_IMAGE_LAYOUT_GENERAL
+endif::VK_KHR_shared_presentable_image[]
+ifdef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-01394]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+    ename:VK_IMAGE_LAYOUT_GENERAL, or
+    ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the
+    elements of the pname:pRanges array must: each only include
+    ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * [[VUID-vkCmdClearColorImage-baseMipLevel-01470]]
+    The slink:VkImageSubresourceRange::pname:baseMipLevel members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01692]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than or
+    equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01693]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than or
+    equal to the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-image-00007]]
+    pname:image must: not have a compressed or depth/stencil format
+  * [[VUID-vkCmdClearColorImage-pColor-04961]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+ifdef::VK_VERSION_1_1[]
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01805]]
+    If pname:commandBuffer is an unprotected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    pname:image must: not be a protected image
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01806]]
+    If pname:commandBuffer is a protected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    must: not be an unprotected image
+endif::VK_VERSION_1_1[]
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow-tests/expect-vuid-repeat.adoc
+++ b/scripts/reflow-tests/expect-vuid-repeat.adoc
@@ -1,0 +1,58 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+Color and depth/stencil images can: be cleared outside a render pass
+instance using flink:vkCmdClearColorImage or
+flink:vkCmdClearDepthStencilImage, respectively.
+These commands are only allowed outside of a render pass instance.
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+.Valid Usage
+****
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the
+    elements of the pname:pRanges array must: each only include
+    ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * [[VUID-vkCmdClearColorImage-baseMipLevel-01470]]
+    The slink:VkImageSubresourceRange::pname:baseMipLevel members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * [[VUID-vkCmdClearColorImage-pRanges-02498]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than or
+    equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-00007]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * [[VUID-vkCmdClearColorImage-pRanges-02498]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than or
+    equal to the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-image-00007]]
+    pname:image must: not have a compressed or depth/stencil format
+  * [[VUID-vkCmdClearColorImage-pColor-02498]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow-tests/src-ifdef-in-vu.adoc
+++ b/scripts/reflow-tests/src-ifdef-in-vu.adoc
@@ -1,0 +1,35 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+.Valid Usage
+****
+  * [[VUID-vkCmdClearColorImage-image-00003]]
+    If pname:image is non-sparse then it must: be bound completely and
+    contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource
+    ranges of pname:image specified in pname:pRanges at the time this
+    command is executed on a sname:VkDevice
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or
+    ename:VK_IMAGE_LAYOUT_GENERAL
+ifdef::VK_KHR_shared_presentable_image[]
+    , or ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-pColor-04961]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+****

--- a/scripts/reflow-tests/src-new-vuid-codified.adoc
+++ b/scripts/reflow-tests/src-new-vuid-codified.adoc
@@ -1,0 +1,71 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+.Valid Usage
+****
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-01993]]
+    The <<resources-image-format-features,format features>> of pname:image must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
+endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * require(image.create_info().usage.has_bit(VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-01545]]
+    pname:image must: not use any of the <<formats-requiring-sampler-ycbcr-conversion, formats that require a sampler {YCbCr} conversion>>
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * If pname:image is non-sparse then it must: be bound completely and contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource ranges of pname:image specified in pname:pRanges at the time this command is executed on a sname:VkDevice
+ifndef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or ename:VK_IMAGE_LAYOUT_GENERAL
+endif::VK_KHR_shared_presentable_image[]
+ifdef::VK_KHR_shared_presentable_image[]
+  * require(imageLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or imageLayout == VK_IMAGE_LAYOUT_GENERAL or
+            imageLayout == VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the
+    elements of the pname:pRanges array must: each only include
+    ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * mipLevels = image.create_info().mipLevels
+    for range in pRanges:
+       require(range.baseMipLevel <
+               mipLevels)
+  * mipLevels = image.create_info().mipLevels
+    for range in pRanges:
+     if range.levelCount != VK_REMAINING_MIP_LEVELS:
+       require(range.baseMipLevel + range.levelCount <= mipLevels)
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the elements of the pname:pRanges array must: each be less than the pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01693]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than or equal to the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * pname:image must: not have a compressed or depth/stencil format
+  * pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+ifdef::VK_VERSION_1_1[]
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01805]]
+    If pname:commandBuffer is an unprotected command buffer and <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    pname:image must: not be a protected image
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01806]]
+    If pname:commandBuffer is a protected command buffer and <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    must: not be an unprotected image
+endif::VK_VERSION_1_1[]
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow-tests/src-new-vuid.adoc
+++ b/scripts/reflow-tests/src-new-vuid.adoc
@@ -1,0 +1,72 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+.Valid Usage
+****
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-01993]]
+    The <<resources-image-format-features,format features>> of pname:image must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
+endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * pname:image must: have been created with ename:VK_IMAGE_USAGE_TRANSFER_DST_BIT usage flag
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-01545]]
+    pname:image must: not use any of the <<formats-requiring-sampler-ycbcr-conversion, formats that require a sampler {YCbCr} conversion>>
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * If pname:image is non-sparse then it must: be bound completely and contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource ranges of pname:image specified in pname:pRanges at the time this command is executed on a sname:VkDevice
+ifndef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or ename:VK_IMAGE_LAYOUT_GENERAL
+endif::VK_KHR_shared_presentable_image[]
+ifdef::VK_KHR_shared_presentable_image[]
+  * pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, ename:VK_IMAGE_LAYOUT_GENERAL, or ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the
+    elements of the pname:pRanges array must: each only include
+    ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * [[VUID-vkCmdClearColorImage-baseMipLevel-01470]]
+    The slink:VkImageSubresourceRange::pname:baseMipLevel members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than or
+    equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the elements of the pname:pRanges array must: each be less than the pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01693]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than or equal to the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * pname:image must: not have a compressed or depth/stencil format
+  * pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+ifdef::VK_VERSION_1_1[]
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01805]]
+    If pname:commandBuffer is an unprotected command buffer and <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    pname:image must: not be a protected image
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01806]]
+    If pname:commandBuffer is a protected command buffer and <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    must: not be an unprotected image
+endif::VK_VERSION_1_1[]
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow-tests/src-table.adoc
+++ b/scripts/reflow-tests/src-table.adoc
@@ -1,0 +1,30 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[formats]]
+= Formats
+
+<<<
+
+[[formats-numericformat]]
+.Interpretation of Numeric Format
+[width="95%",cols="2,3,10",options="header"]
+|====
+| Numeric format | SPIR-V _Sampled Type_ | Description
+| etext:UNORM    | OpTypeFloat           | The components are unsigned normalized values in the range [eq]#[0,1]#
+| etext:SNORM    | OpTypeFloat           | The components are signed normalized values in the range [eq]#[-1,1]#
+| etext:USCALED  | OpTypeFloat           | The components are unsigned integer values that get converted to floating-point in the range [0,2^n^-1]
+| etext:SSCALED  | OpTypeFloat           | The components are signed integer values that get converted to floating-point in the range [-2^n-1^,2^n-1^-1]
+| etext:UINT     | OpTypeInt             | The components are unsigned integer values in the range [0,2^n^-1]
+| etext:SINT     | OpTypeInt             | The components are signed integer values in the range [-2^n-1^,2^n-1^-1]
+| etext:UFLOAT   | OpTypeFloat           | The components are unsigned floating-point numbers (used by packed, shared exponent, and some compressed formats)
+| etext:SFLOAT   | OpTypeFloat           | The components are signed floating-point numbers
+| etext:SRGB     | OpTypeFloat           | The R, G, and B components are unsigned normalized values that represent values using sRGB nonlinear encoding, while the A component (if one exists) is a regular unsigned normalized value
+3+| [eq]#n# is the number of bits in the component.
+|====
+
+The suffix etext:_PACKnn indicates that the format is packed into an underlying type with etext:nn bits.
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+The suffix etext:_mPACKnn is a short-hand that indicates that the format has etext:m groups of components (which may or may not be stored in separate _planes_) that are each packed into an underlying type with etext:nn bits.
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]

--- a/scripts/reflow-tests/src-text.adoc
+++ b/scripts/reflow-tests/src-text.adoc
@@ -1,0 +1,11 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[formats]]
+= Formats
+
+Supported buffer and image formats may: vary across implementations.
+A minimum set of format features are guaranteed, but others must: be explicitly queried before use to ensure they are supported by the implementation.
+
+The features for the set of formats (elink:VkFormat) supported by the implementation are queried individually using the flink:vkGetPhysicalDeviceFormatProperties command.

--- a/scripts/reflow-tests/src-vu-codified.adoc
+++ b/scripts/reflow-tests/src-vu-codified.adoc
@@ -1,0 +1,102 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+Color and depth/stencil images can: be cleared outside a render pass
+instance using flink:vkCmdClearColorImage or
+flink:vkCmdClearDepthStencilImage, respectively.
+These commands are only allowed outside of a render pass instance.
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+  * pname:commandBuffer is the command buffer into which the command will be
+    recorded.
+  * pname:image is the image to be cleared.
+  * pname:imageLayout specifies the current layout of the image subresource ranges to be cleared, and must: be
+ifdef::VK_KHR_shared_presentable_image[]
+    ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR,
+endif::VK_KHR_shared_presentable_image[]
+    ename:VK_IMAGE_LAYOUT_GENERAL or ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL.
+  * pname:pColor is a pointer to a slink:VkClearColorValue structure containing the values that the image subresource ranges will be cleared to (see <<clears-values>> below).
+  * pname:rangeCount is the number of image subresource range structures in pname:pRanges.
+  * pname:pRanges is a pointer to an array of slink:VkImageSubresourceRange
+    structures describing a range of mipmap levels, array layers, and
+    aspects to be cleared, as described in <<resources-image-views,Image Views>>.
+
+Each specified range in pname:pRanges is cleared to the value specified by
+pname:pColor.
+
+.Valid Usage
+****
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-01993]]
+    The <<resources-image-format-features,format features>> of pname:image must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
+endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-00002]]
+    require(image.create_info().usage.has_bit(VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-01545]]
+    pname:image must: not use any of the <<formats-requiring-sampler-ycbcr-conversion, formats that require a sampler {YCbCr} conversion>>
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-00003]]
+    If pname:image is non-sparse then it must: be bound completely and contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource ranges of pname:image specified in pname:pRanges at the time this command is executed on a sname:VkDevice
+ifndef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    require(imageLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or imageLayout == VK_IMAGE_LAYOUT_GENERAL)
+endif::VK_KHR_shared_presentable_image[]
+ifdef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-01394]]
+    require(imageLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or imageLayout == VK_IMAGE_LAYOUT_GENERAL or imageLayout == VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the
+    elements of the pname:pRanges array must: each only include
+    ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * [[VUID-vkCmdClearColorImage-baseMipLevel-01470]]
+    mipLevels = image.create_info().mipLevels
+    for range in pRanges:
+       require(range.baseMipLevel <
+               mipLevels)
+  * [[VUID-vkCmdClearColorImage-pRanges-01692]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than or
+    equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the elements of the pname:pRanges array must: each be less than the pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01693]]
+    arrayLayers = image.create_info().arrayLayers
+    for range in pRanges:
+      if range.layerCount != VK_REMAINING_ARRAY_LAYERS:
+        require(range.baseArrayLayer + range.layerCount <= arrayLayers)
+  * [[VUID-vkCmdClearColorImage-image-00007]]
+    pname:image must: not have a compressed or depth/stencil format
+  * [[VUID-vkCmdClearColorImage-pColor-04961]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+ifdef::VK_VERSION_1_1[]
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01805]]
+    If pname:commandBuffer is an unprotected command buffer and <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    pname:image must: not be a protected image
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01806]]
+    If pname:commandBuffer is a protected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    must: not be an unprotected image
+endif::VK_VERSION_1_1[]
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow-tests/src-vu.adoc
+++ b/scripts/reflow-tests/src-vu.adoc
@@ -1,0 +1,101 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+Color and depth/stencil images can: be cleared outside a render pass
+instance using flink:vkCmdClearColorImage or
+flink:vkCmdClearDepthStencilImage, respectively.
+These commands are only allowed outside of a render pass instance.
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+  * pname:commandBuffer is the command buffer into which the command will be
+    recorded.
+  * pname:image is the image to be cleared.
+  * pname:imageLayout specifies the current layout of the image subresource ranges to be cleared, and must: be
+ifdef::VK_KHR_shared_presentable_image[]
+    ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR,
+endif::VK_KHR_shared_presentable_image[]
+    ename:VK_IMAGE_LAYOUT_GENERAL or ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL.
+  * pname:pColor is a pointer to a slink:VkClearColorValue structure containing the values that the image subresource ranges will be cleared to (see <<clears-values>> below).
+  * pname:rangeCount is the number of image subresource range structures in pname:pRanges.
+  * pname:pRanges is a pointer to an array of slink:VkImageSubresourceRange
+    structures describing a range of mipmap levels, array layers, and
+    aspects to be cleared, as described in <<resources-image-views,Image Views>>.
+
+Each specified range in pname:pRanges is cleared to the value specified by
+pname:pColor.
+
+.Valid Usage
+****
+ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-01993]]
+    The <<resources-image-format-features,format features>> of pname:image must: contain ename:VK_FORMAT_FEATURE_TRANSFER_DST_BIT
+endif::VK_VERSION_1_1,VK_KHR_maintenance1[]
+  * [[VUID-vkCmdClearColorImage-image-00002]]
+    pname:image must: have been created with ename:VK_IMAGE_USAGE_TRANSFER_DST_BIT usage flag
+ifdef::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-01545]]
+    pname:image must: not use any of the <<formats-requiring-sampler-ycbcr-conversion, formats that require a sampler {YCbCr} conversion>>
+endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+  * [[VUID-vkCmdClearColorImage-image-00003]]
+    If pname:image is non-sparse then it must: be bound completely and contiguously to a single sname:VkDeviceMemory object
+  * [[VUID-vkCmdClearColorImage-imageLayout-00004]]
+    pname:imageLayout must: specify the layout of the image subresource ranges of pname:image specified in pname:pRanges at the time this command is executed on a sname:VkDevice
+ifndef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-00005]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL or ename:VK_IMAGE_LAYOUT_GENERAL
+endif::VK_KHR_shared_presentable_image[]
+ifdef::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-imageLayout-01394]]
+    pname:imageLayout must: be ename:VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, ename:VK_IMAGE_LAYOUT_GENERAL, or ename:VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
+endif::VK_KHR_shared_presentable_image[]
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the
+    elements of the pname:pRanges array must: each only include
+    ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * [[VUID-vkCmdClearColorImage-baseMipLevel-01470]]
+    The slink:VkImageSubresourceRange::pname:baseMipLevel members of the
+    elements of the pname:pRanges array must: each be less than the
+    pname:mipLevels specified in slink:VkImageCreateInfo when pname:image
+    was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01692]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than or
+    equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the elements of the pname:pRanges array must: each be less than the pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image was created
+  * [[VUID-vkCmdClearColorImage-pRanges-01693]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than or equal to the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-image-00007]]
+    pname:image must: not have a compressed or depth/stencil format
+  * [[VUID-vkCmdClearColorImage-pColor-04961]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+ifdef::VK_VERSION_1_1[]
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01805]]
+    If pname:commandBuffer is an unprotected command buffer and <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    pname:image must: not be a protected image
+  * [[VUID-vkCmdClearColorImage-commandBuffer-01806]]
+    If pname:commandBuffer is a protected command buffer and
+    <<limits-protectedNoFault, pname:protectedNoFault>> is not supported,
+    must: not be an unprotected image
+endif::VK_VERSION_1_1[]
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow-tests/src-vuid-repeat.adoc
+++ b/scripts/reflow-tests/src-vuid-repeat.adoc
@@ -1,0 +1,47 @@
+// Copyright 2015-2022 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[[clears]]
+= Clear Commands
+
+
+[[clears-outside]]
+== Clearing Images Outside A Render Pass Instance
+
+Color and depth/stencil images can: be cleared outside a render pass
+instance using flink:vkCmdClearColorImage or
+flink:vkCmdClearDepthStencilImage, respectively.
+These commands are only allowed outside of a render pass instance.
+
+[open,refpage='vkCmdClearColorImage',desc='Clear regions of a color image',type='protos']
+--
+To clear one or more subranges of a color image, call:
+
+include::{generated}/api/protos/vkCmdClearColorImage.adoc[]
+
+.Valid Usage
+****
+  * [[VUID-vkCmdClearColorImage-aspectMask-02498]]
+    The slink:VkImageSubresourceRange::pname:aspectMask members of the elements of the pname:pRanges array must: each only include ename:VK_IMAGE_ASPECT_COLOR_BIT
+  * [[VUID-vkCmdClearColorImage-baseMipLevel-01470]]
+    The slink:VkImageSubresourceRange::pname:baseMipLevel members of the elements of the pname:pRanges array must: each be less than the pname:mipLevels specified in slink:VkImageCreateInfo when pname:image was created
+  * [[VUID-vkCmdClearColorImage-pRanges-02498]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the
+    pname:levelCount member is not ename:VK_REMAINING_MIP_LEVELS, then
+    [eq]#pname:baseMipLevel {plus} pname:levelCount# must: be less than or equal to the pname:mipLevels specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-baseArrayLayer-00007]]
+    The slink:VkImageSubresourceRange::pname:baseArrayLayer members of the elements of the pname:pRanges array must: each be less than the pname:arrayLayers specified in slink:VkImageCreateInfo when pname:image was created
+  * [[VUID-vkCmdClearColorImage-pRanges-02498]]
+    For each slink:VkImageSubresourceRange element of pname:pRanges, if the pname:layerCount member is not ename:VK_REMAINING_ARRAY_LAYERS, then
+    [eq]#pname:baseArrayLayer {plus} pname:layerCount# must: be less than or equal to the pname:arrayLayers specified in slink:VkImageCreateInfo when
+    pname:image was created
+  * [[VUID-vkCmdClearColorImage-image-00007]]
+    pname:image must: not have a compressed or depth/stencil format
+  * [[VUID-vkCmdClearColorImage-pColor-02498]]
+    pname:pColor must: be a valid pointer to a slink:VkClearColorValue union
+****
+
+include::{generated}/validity/protos/vkCmdClearColorImage.adoc[]
+--

--- a/scripts/reflow.py
+++ b/scripts/reflow.py
@@ -5,13 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Used for automatic reflow of spec sources to satisfy the agreed layout to
-minimize git churn. Most of the logic has to do with detecting asciidoc
-markup or block types that should not be reflowed (tables, code) and
-ignoring them. It is very likely there are many asciidoc constructs not yet
-accounted for in the script, our usage of asciidoc markup is intentionally
-somewhat limited.
-
-Also used to insert identifying tags on explicit Valid Usage statements.
+minimize git churn.  Also used to insert identifying tags on explicit Valid
+Usage statements.
 
 Usage: `reflow.py [-noflow] [-tagvu] [-nextvu #] [-overwrite] [-out dir] [-suffix str] files`
 
@@ -38,6 +33,7 @@ import re
 import sys
 from reflib import loadFile, logDiag, logWarn, logErr, setLogFile, getBranch
 from pathlib import Path
+import doctransformer
 
 # Vulkan-specific - will consolidate into scripts/ like OpenXR soon
 sys.path.insert(0, 'xml')
@@ -45,71 +41,12 @@ sys.path.insert(0, 'xml')
 from apiconventions import APIConventions
 conventions = APIConventions()
 
-# Markup that always ends a paragraph
-#   empty line or whitespace
-#   [block options]
-#   [[anchor]]
-#   //                  comment
-#   <<<<                page break
-#   :attribute-setting
-#   macro-directive::terms
-#   +                   standalone list item continuation
-#   label::             labelled list - label must be standalone
-endPara = re.compile(r'^( *|\[.*\]|//.*|<<<<|:.*|[a-z]+::.*|\+|.*::)$')
-
-# Special case of markup ending a paragraph, used to track the current
-# command/structure. This allows for either OpenXR or Vulkan API path
-# conventions. Nominally it should use the file suffix defined by the API
-# conventions (conventions.file_suffix), except that XR uses '.txt' for
-# generated API include files, not '.adoc' like its other includes.
-includePat = re.compile(
-        r'include::(?P<directory_traverse>((../){1,4}|\{generated\}/)(generated/)?)(?P<generated_type>[\w]+)/(?P<category>\w+)/(?P<entity_name>[^./]+).adoc[\[][\]]')
+# Patterns used to recognize interesting lines in an asciidoc source file.
+# These patterns are only compiled once.
 
 # Find the first pname: or code: pattern in a Valid Usage statement
 pnamePat = re.compile(r'pname:(?P<param>\{?\w+\}?)')
 codePat = re.compile(r'code:(?P<param>\w+)')
-
-# Markup that is OK in a contiguous paragraph but otherwise passed through
-#   .anything (except .., which indicates a literal block)
-#   === Section Titles
-#   image::path_to_image[attributes]  (apparently a single colon is OK but less idiomatic)
-endParaContinue = re.compile(r'^(\.[^.].*|=+ .*|image:.*\[.*\])$')
-
-# Markup for block delimiters whose contents *should* be reformatted
-#   --   (exactly two)  (open block)
-#   **** (4 or more)    (sidebar block)
-#   ==== (4 or more)    (example block)
-#   ____ (4 or more)    (quote block)
-blockReflow = re.compile(r'^(--|[*=_]{4,})$')
-
-# Fake block delimiters for "common" VU statements
-blockCommonReflow = '// Common Valid Usage\n'
-
-# Markup for block delimiters whose contents should *not* be reformatted
-#   |=== (3 or more)  (table)
-#   ```  (3 or more)  (listing block)
-#   //// (4 or more)  (comment block)
-#   ---- (4 or more)  (listing block)
-#   .... (4 or more)  (literal block)
-#   ++++ (4 or more)  (passthrough block)
-#   ~~~~ (4 or more)  (alternate open block delimiter, supported via extension)
-blockPassthrough = re.compile(r'^(\|={3,}|[`]{3}|[\-+./~]{4,})$')
-
-# Markup for introducing lists (hanging paragraphs)
-#   * bullet
-#     ** bullet
-#     -- bullet
-#   . bullet
-#   :: bullet (no longer supported by asciidoctor 2)
-#   {empty}:: bullet
-#   1. list item
-#   <1> source listing callout
-beginBullet = re.compile(r'^ *([-*.]+|\{empty\}::|::|[0-9]+[.]|<([0-9]+)>) ')
-
-# Start of an asciidoctor conditional
-#   ifdef::
-#   ifndef::
-conditionalStart = re.compile(r'^(ifdef|ifndef)::')
 
 # Text that (may) not end sentences
 
@@ -118,63 +55,48 @@ endInitial = re.compile(r'^[A-Z]\.$')
 # An abbreviation, which does not (usually) end a line.
 endAbbrev = re.compile(r'(e\.g|i\.e|c\.f|vs)\.$', re.IGNORECASE)
 
-class ReflowState:
-    """State machine for reflowing.
+# Explicit Valid Usage list item with one or more leading asterisks
+# The re.DOTALL is needed to prevent vuPat.search() from stripping
+# the trailing newline.
+vuPat = re.compile(r'^(?P<head>  [*]+)( *)(?P<tail>.*)', re.DOTALL)
 
-    Represents the state of the reflow operation"""
+# VUID with the numeric portion captured in the match object
+vuidPat = re.compile(r'VUID-[^-]+-[^-]+-(?P<vuid>[0-9]+)')
+
+# Pattern matching leading nested bullet points
+global nestedVuPat
+nestedVuPat = re.compile(r'^  \*\*')
+
+class ReflowCallbacks:
+    """State and arguments for reflowing.
+
+    Used with DocTransformer to reflow a file."""
     def __init__(self,
                  filename,
+                 vuidDict,
                  margin = 76,
-                 file = sys.stdout,
                  breakPeriod = True,
                  reflow = True,
                  nextvu = None,
-                 maxvu = None):
-
-        self.blockStack = [ None ]
-        """The last element is a line with the asciidoc block delimiter that is currently in effect,
-        such as '--', '----', '****', '====', or '++++'.
-        This affects whether or not the block contents should be formatted."""
-
-        self.reflowStack = [ True ]
-        """The last element is True or False if the current blockStack contents
-        should be reflowed."""
-        self.vuStack = [ False ]
-        """the last element is True or False if the current blockStack contents
-        are an explicit Valid Usage block."""
-
-        self.margin = margin
-        """margin to reflow text to."""
-
-        self.para = []
-        """list of lines in the paragraph being accumulated.
-        When this is non-empty, there is a current paragraph."""
-
-        self.lastTitle = False
-        """true if the previous line was a document title line
-        (e.g. :leveloffset: 0 - no attempt to track changes to this is made)."""
-
-        self.leadIndent = 0
-        """indent level (in spaces) of the first line of a paragraph."""
-
-        self.hangIndent = 0
-        """indent level of the remaining lines of a paragraph."""
-
-        self.file = file
-        """file handle to write to."""
+                 maxvu = None,
+                 check = True):
 
         self.filename = filename
         """base name of file being read from."""
 
-        self.lineNumber = 0
-        """line number being read from the input file."""
+        self.check = check
+        """Whether consistency checks must be performed."""
+
+        self.margin = margin
+        """margin to reflow text to."""
 
         self.breakPeriod = breakPeriod
-        """True if justification should break to a new line after the end of a sentence."""
+        """True if justification should break to a new line after the end of a
+        sentence."""
 
         self.breakInitial = True
-        """True if justification should break to a new line after
-        something that appears to be an initial in someone's name. **TBD**"""
+        """True if justification should break to a new line after something
+        that appears to be an initial in someone's name. **TBD**"""
 
         self.reflow = reflow
         """True if text should be reflowed, False to pass through unchanged."""
@@ -184,7 +106,8 @@ class ReflowState:
 
         self.vuFormat = '{0}-{1}-{2}-{3:0>5d}'
         """Format string for generating Valid Usage tags.
-        First argument is vuPrefix, second is command/struct name, third is parameter name, fourth is the tag number."""
+        First argument is vuPrefix, second is command/struct name, third is
+        parameter name, fourth is the tag number."""
 
         self.nextvu = nextvu
         """Integer to start tagging un-numbered Valid Usage statements with,
@@ -194,23 +117,13 @@ class ReflowState:
         """Maximum tag to use for Valid Usage statements, or None if no
         tagging should be done."""
 
-        self.defaultApiName = '{refpage}'
-        self.apiName = self.defaultApiName
-        """String name of an API structure or command for VUID tag
-        generation, or {refpage} if one has not been included in this file
-        yet."""
+        self.vuidDict = vuidDict
+        """Dictionary of VUID numbers found, containing a list of (file, VUID)
+        on which that number was found.  This is used to warn on duplicate
+        VUIDs."""
 
-    def incrLineNumber(self):
-        self.lineNumber = self.lineNumber + 1
-
-    def printLines(self, lines):
-        """Print an array of lines with newlines already present"""
-        if len(lines) > 0:
-            logDiag(':: printLines:', len(lines), 'lines: ', lines[0], end='')
-
-        if self.file is not None:
-            for line in lines:
-                print(line, file=self.file, end='')
+        self.warnCount = 0
+        """Count of markup check warnings encountered."""
 
     def endSentence(self, word):
         """Return True if word ends with a sentence-period, False otherwise.
@@ -230,12 +143,105 @@ class ReflowState:
         """Return True if word is a Valid Usage ID Tag anchor."""
         return (word[0:7] == '[[VUID-')
 
-    def isOpenBlockDelimiter(self, line):
-        """Returns True if line is an open block delimiter."""
-        return line[0:2] == '--'
+    def addVUID(self, para, state):
+        hangIndent = state.hangIndent
 
-    def reflowPara(self):
-        """Reflow the current paragraph, respecting the paragraph lead and
+        """Generate and add VUID if necessary."""
+        if not state.isVU or self.nextvu is None:
+            return para, hangIndent
+
+        # If:
+        #   - this paragraph is in a Valid Usage block,
+        #   - VUID tags are being assigned,
+        # Try to assign VUIDs
+
+        if nestedVuPat.search(para[0]):
+            # Check for nested bullet points. These should not be
+            # assigned VUIDs, nor present at all, because they break
+            # the VU extractor.
+            logWarn(self.filename + ': Invalid nested bullet point in VU block:', para[0])
+            return para, hangIndent
+
+        # Skip if there is already a VUID assigned
+        if self.vuPrefix in para[0]:
+            return para, hangIndent
+
+        # If:
+        #   - a tag is not already present, and
+        #   - the paragraph is a properly marked-up list item
+        # Then add a VUID tag starting with the next free ID.
+
+        # Split the first line after the bullet point
+        matches = vuPat.search(para[0])
+        if matches is None:
+            # There are only a few cases of this, and they are all
+            # legitimate. Leave detecting this case to another tool
+            # or hand inspection.
+            # logWarn(self.filename + ': Unexpected non-bullet item in VU block (harmless if following an ifdef):',
+            #         para[0])
+            return para, hangIndent
+
+        outPara = para
+
+        logDiag('addVUID: Matched vuPat on line:', para[0], end='')
+        head = matches.group('head')
+        tail = matches.group('tail')
+
+        # Use the first pname: or code: tag in the paragraph as
+        # the parameter name in the VUID tag. This will not always
+        # be correct, but should be highly reliable.
+        for vuLine in para:
+            matches = pnamePat.search(vuLine)
+            if matches is not None:
+                break
+            matches = codePat.search(vuLine)
+            if matches is not None:
+                break
+
+        if matches is not None:
+            paramName = matches.group('param')
+        else:
+            paramName = 'None'
+            logWarn(self.filename,
+                    'No param name found for VUID tag on line:',
+                    para[0])
+
+        # Transform:
+        #
+        #   * VU first line
+        #
+        # To:
+        #
+        #   * [[VUID]]
+        #     VU first line
+        #
+        tagLine = (head + ' [[' +
+                   self.vuFormat.format(self.vuPrefix,
+                                        state.apiName,
+                                        paramName,
+                                        self.nextvu) + ']]')
+        newLines = [tagLine]
+        if tail.strip() != ' ':
+            logDiag('transformParagraph first line matches bullet point -'
+                    'single line, assuming hangIndent @ input line',
+                    state.lineNumber)
+            hangIndent = len(head) + 1
+            newLines.append(''.ljust(hangIndent) + tail)
+
+        logDiag('Assigning', self.vuPrefix, state.apiName, self.nextvu,
+                ' on line:\n' + para[0], '->\n' + newLines[0] + 'END', '\n' + newLines[1] if len(newLines) > 1 else '')
+
+        # Do not actually assign the VUID unless it is in the reserved range
+        if self.nextvu <= self.maxvu:
+            if self.nextvu == self.maxvu:
+                logWarn('Skipping VUID assignment, no more VUIDs available')
+            outPara = newLines + para[1:]
+            self.nextvu = self.nextvu + 1
+
+        return outPara, hangIndent
+
+    def transformParagraph(self, para, state):
+        """Reflow a given paragraph, respecting the paragraph lead and
         hanging indentation levels.
 
         The algorithm also respects trailing '+' signs that indicate embedded newlines,
@@ -243,12 +249,16 @@ class ReflowState:
 
         Just return the paragraph unchanged if the -noflow argument was
         given."""
-        if not self.reflow:
-            return self.para
 
-        logDiag('reflowPara lead indent = ', self.leadIndent,
-                'hangIndent =', self.hangIndent,
-                'para:', self.para[0], end='')
+        if not self.reflow:
+            return para
+
+        # If this is a VU that is missing a VUID, add it to the paragraph now.
+        para, hangIndent = self.addVUID(para, state)
+
+        logDiag('transformParagraph lead indent = ', state.leadIndent,
+                'hangIndent =', state.hangIndent,
+                'para:', para[0], end='')
 
         # Total words processed (we care about the *first* word vs. others)
         wordCount = 0
@@ -260,11 +270,11 @@ class ReflowState:
         outLine = None
         outPara = []
 
-        for line in self.para:
+        for line in para:
             line = line.rstrip()
             words = line.split()
 
-            # logDiag('reflowPara: input line =', line)
+            # logDiag('transformParagraph: input line =', line)
             numWords = len(words) - 1
 
             for i in range(0, numWords + 1):
@@ -276,10 +286,12 @@ class ReflowState:
                 if i == numWords and word == '+':
                     # Trailing ' +' must stay on the same line
                     endEscape = word
-                    # logDiag('reflowPara last word of line =', word, 'prevWord =', prevWord, 'endEscape =', endEscape)
+                    # logDiag('transformParagraph last word of line =', word,
+                    #         'prevWord =', prevWord, 'endEscape =', endEscape)
                 else:
+                    # logDiag('transformParagraph wordCount =', wordCount,
+                    #         'word =', word, 'prevWord =', prevWord)
                     pass
-                    # logDiag('reflowPara wordCount =', wordCount, 'word =', word, 'prevWord =', prevWord)
 
                 if wordCount == 1:
                     # The first word of the paragraph is treated specially.
@@ -287,23 +299,22 @@ class ReflowState:
                     # done prior to looping over lines and words, so all the
                     # setup logic is done here.
 
-                    outPara = []
-                    outLine = ''.ljust(self.leadIndent) + word
-                    outLineLen = self.leadIndent + wordLen
+                    outLine = ''.ljust(state.leadIndent) + word
+                    outLineLen = state.leadIndent + wordLen
 
                     # If the paragraph begins with a bullet point, generate
                     # a hanging indent level if there is not one already.
-                    if beginBullet.match(self.para[0]):
+                    if doctransformer.beginBullet.match(para[0]):
                         bulletPoint = True
-                        if len(self.para) > 1:
-                            logDiag('reflowPara first line matches bullet point',
+                        if len(para) > 1:
+                            logDiag('transformParagraph first line matches bullet point',
                                     'but indent already hanging @ input line',
-                                    self.lineNumber)
+                                    state.lineNumber)
                         else:
-                            logDiag('reflowPara first line matches bullet point -'
+                            logDiag('transformParagraph first line matches bullet point -'
                                     'single line, assuming hangIndent @ input line',
-                                    self.lineNumber)
-                            self.hangIndent = outLineLen + 1
+                                    state.lineNumber)
+                            hangIndent = outLineLen + 1
                     else:
                         bulletPoint = False
                 else:
@@ -335,13 +346,24 @@ class ReflowState:
                         # immediately after a bullet point, but we do not
                         # currently check for this.
                         (addWord, closeLine, startLine) = (True, True, False)
+
+                        # Add the VUID to the vuidDict dictionary.  It will be
+                        # used to generate warnings if this VUID number was met
+                        # multiple times.
+                        matches = vuidPat.search(word)
+                        if matches is not None:
+                            vuid = matches.group('vuid')
+                            if vuid not in self.vuidDict:
+                                self.vuidDict[vuid] = []
+                            self.vuidDict[vuid].append([self.filename, word])
+
                     elif newLen > self.margin:
                         if firstBullet:
                             # If the word follows a bullet point, add it to
                             # the current line no matter its length.
 
                             (addWord, closeLine, startLine) = (True, True, False)
-                        elif beginBullet.match(word + ' '):
+                        elif doctransformer.beginBullet.match(word + ' '):
                             # If the word *is* a bullet point, add it to
                             # the current line no matter its length.
                             # This avoids an innocent inline '-' or '*'
@@ -383,217 +405,36 @@ class ReflowState:
 
                     # Start a new line and add a word to it
                     if startLine:
-                        outLine = ''.ljust(self.hangIndent) + word
-                        outLineLen = self.hangIndent + wordLen
+                        outLine = ''.ljust(hangIndent) + word
+                        outLineLen = hangIndent + wordLen
 
                 # Track the previous word, for use in breaking at end of
                 # a sentence
                 prevWord = word
 
-        # Add this line to the output paragraph.
+        # Add last line to the output paragraph.
         if outLine:
             outPara.append(outLine + '\n')
 
         return outPara
 
-    def emitPara(self):
-        """Emit a paragraph, possibly reflowing it depending on the block context.
-
-        Resets the paragraph accumulator."""
-        if self.para != []:
-            if self.vuStack[-1] and self.nextvu is not None:
-                # If:
-                #   - this paragraph is in a Valid Usage block,
-                #   - VUID tags are being assigned,
-                # Try to assign VUIDs
-
-                if nestedVuPat.search(self.para[0]):
-                    # Check for nested bullet points. These should not be
-                    # assigned VUIDs, nor present at all, because they break
-                    # the VU extractor.
-                    logWarn(self.filename + ': Invalid nested bullet point in VU block:', self.para[0])
-                elif self.vuPrefix not in self.para[0]:
-                    # If:
-                    #   - a tag is not already present, and
-                    #   - the paragraph is a properly marked-up list item
-                    # Then add a VUID tag starting with the next free ID.
-
-                    # Split the first line after the bullet point
-                    matches = vuPat.search(self.para[0])
-                    if matches is not None:
-                        logDiag('findRefs: Matched vuPat on line:', self.para[0], end='')
-                        head = matches.group('head')
-                        tail = matches.group('tail')
-
-                        # Use the first pname: or code: tag in the paragraph as
-                        # the parameter name in the VUID tag. This will not always
-                        # be correct, but should be highly reliable.
-                        for vuLine in self.para:
-                            matches = pnamePat.search(vuLine)
-                            if matches is not None:
-                                break
-                            matches = codePat.search(vuLine)
-                            if matches is not None:
-                                break
-
-                        if matches is not None:
-                            paramName = matches.group('param')
-                        else:
-                            paramName = 'None'
-                            logWarn(self.filename,
-                                    'No param name found for VUID tag on line:',
-                                    self.para[0])
-
-                        newline = (head + ' [[' +
-                                   self.vuFormat.format(self.vuPrefix,
-                                                        self.apiName,
-                                                        paramName,
-                                                        self.nextvu) + ']] ' + tail)
-
-                        logDiag('Assigning', self.vuPrefix, self.apiName, self.nextvu,
-                                ' on line:', self.para[0], '->', newline, 'END')
-
-                        # Do not actually assign the VUID unless it is in the reserved range
-                        if self.nextvu <= self.maxvu:
-                            if self.nextvu == self.maxvu:
-                                logWarn('Skipping VUID assignment, no more VUIDs available')
-                            self.para[0] = newline
-                            self.nextvu = self.nextvu + 1
-                # else:
-                #     There are only a few cases of this, and they are all
-                #     legitimate. Leave detecting this case to another tool
-                #     or hand inspection.
-                #     logWarn(self.filename + ': Unexpected non-bullet item in VU block (harmless if following an ifdef):',
-                #             self.para[0])
-
-            if self.reflowStack[-1]:
-                self.printLines(self.reflowPara())
-            else:
-                self.printLines(self.para)
-
-        # Reset the paragraph, including its indentation level
-        self.para = []
-        self.leadIndent = 0
-        self.hangIndent = 0
-
-    def endPara(self, line):
-        """'line' ends a paragraph and should itself be emitted.
-        line may be None to indicate EOF or other exception."""
-        logDiag('endPara line', self.lineNumber, ': emitting paragraph')
-
-        # Emit current paragraph, this line, and reset tracker
-        self.emitPara()
-
-        if line:
-            self.printLines( [ line ] )
-
-    def endParaContinue(self, line):
-        """'line' ends a paragraph (unless there is already a paragraph being
-        accumulated, e.g. len(para) > 0 - currently not implemented)"""
-        self.endPara(line)
-
-    def endBlock(self, line, reflow = False, vuBlock = False):
-        """'line' begins or ends a block.
-
-        If beginning a block, tag whether or not to reflow the contents.
-
-        vuBlock is True if the previous line indicates this is a Valid Usage block."""
-        self.endPara(line)
-
-        if self.blockStack[-1] == line:
-            logDiag('endBlock line', self.lineNumber,
-                    ': popping block end depth:', len(self.blockStack),
-                    ':', line, end='')
-
-            # Reset apiName at the end of an open block.
-            # Open blocks cannot be nested (at present), so this is safe.
-            if self.isOpenBlockDelimiter(line):
-                logDiag('reset apiName to empty at line', self.lineNumber)
-                self.apiName = self.defaultApiName
-            else:
-                logDiag('NOT resetting apiName to default at line', self.lineNumber)
-
-            self.blockStack.pop()
-            self.reflowStack.pop()
-            self.vuStack.pop()
-        else:
-            # Start a block
-            self.blockStack.append(line)
-            self.reflowStack.append(reflow)
-            self.vuStack.append(vuBlock)
-
-            logDiag('endBlock reflow =', reflow, ' line', self.lineNumber,
-                    ': pushing block start depth', len(self.blockStack),
-                    ':', line, end='')
-
-    def endParaBlockReflow(self, line, vuBlock):
-        """'line' begins or ends a block. The paragraphs in the block *should* be
-        reformatted (e.g. a NOTE)."""
-        self.endBlock(line, reflow = True, vuBlock = vuBlock)
-
-    def endParaBlockPassthrough(self, line):
-        """'line' begins or ends a block. The paragraphs in the block should
-        *not* be reformatted (e.g. a code listing)."""
-        self.endBlock(line, reflow = False)
-
-    def addLine(self, line):
-        """'line' starts or continues a paragraph.
-
-        Paragraphs may have "hanging indent", e.g.
-
-        ```
-          * Bullet point...
-            ... continued
-        ```
-
-        In this case, when the higher indentation level ends, so does the
-        paragraph."""
-        logDiag('addLine line', self.lineNumber, ':', line, end='')
-
-        # See https://stackoverflow.com/questions/13648813/what-is-the-pythonic-way-to-count-the-leading-spaces-in-a-string
-        indent = len(line) - len(line.lstrip())
-
-        # A hanging paragraph ends due to a less-indented line.
-        if self.para != [] and indent < self.hangIndent:
-            logDiag('addLine: line reduces indentation, emit paragraph')
-            self.emitPara()
-
-        # A bullet point (or something that looks like one) always ends the
-        # current paragraph.
-        if beginBullet.match(line):
-            logDiag('addLine: line matches beginBullet, emit paragraph')
-            self.emitPara()
-
-        if self.para == []:
-            # Begin a new paragraph
-            self.para = [ line ]
-            self.leadIndent = indent
-            self.hangIndent = indent
-        else:
-            # Add a line to a paragraph. Increase the hanging indentation
-            # level - once.
-            if self.hangIndent == self.leadIndent:
-                self.hangIndent = indent
-            self.para.append(line)
-
-def apiMatch(oldname, newname):
-    """Returns whether oldname and newname match, up to an API suffix.
-       This should use the API map instead of this heuristic, since aliases
-       like VkPhysicalDeviceVariablePointerFeatures ->
-       VkPhysicalDeviceVariablePointersFeatures are not recognized."""
-    upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-    return oldname.rstrip(upper) == newname.rstrip(upper)
+    def onEmbeddedVUConditional(self, state):
+        if self.check:
+            logWarn('Detected embedded Valid Usage conditional: {}:{}'.format(
+                    self.filename, state.lineNumber - 1))
+            # Keep track of warning check count
+            self.warnCount = self.warnCount + 1
 
 def reflowFile(filename, args):
     logDiag('reflow: filename', filename)
 
-    lines, newline_string = loadFile(filename)
-    if lines is None:
-        return
-
     # Output file handle and reflow object for this file. There are no race
     # conditions on overwriting the input, but it is not recommended unless
     # you have backing store such as git.
+
+    lines, newline_string = loadFile(filename)
+    if lines is None:
+        return
 
     if args.overwrite:
         outFilename = filename
@@ -616,134 +457,29 @@ def reflowFile(filename, args):
             logWarn('Cannot open output file', outFilename, ':', sys.exc_info()[0])
             return
 
-    state = ReflowState(filename,
-                        margin = args.margin,
-                        file = fp,
-                        reflow = not args.noflow,
-                        nextvu = args.nextvu,
-                        maxvu = args.maxvu)
+    callback = ReflowCallbacks(filename,
+                               args.vuidDict,
+                               margin = args.margin,
+                               reflow = not args.noflow,
+                               nextvu = args.nextvu,
+                               maxvu = args.maxvu,
+                               check = args.check)
 
-    for line in lines:
-        state.incrLineNumber()
+    transformer = doctransformer.DocTransformer(filename,
+                                                outfile = fp,
+                                                callback = callback)
 
-        # Is this a title line (leading '= ' followed by text)?
-        thisTitle = False
-
-        matches = vuidPat.search(line)
-        if matches is not None:
-            # If we found a VUID pattern, add the (filename,line) it was
-            # found at to a list for that VUID, to find duplicates.
-            vuid = matches.group('vuid')
-            if vuid not in args.vuidDict:
-                args.vuidDict[vuid] = []
-            args.vuidDict[vuid].append([filename, line])
-
-        # The logic here is broken. If we are in a non-reflowable block and
-        # this line *does not* end the block, it should always be
-        # accumulated.
-
-        # Test for a blockCommonReflow delimiter comment first, to avoid
-        # treating it solely as a end-Paragraph marker comment.
-        if line == blockCommonReflow:
-            # Starting or ending a pseudo-block for "common" VU statements.
-            state.endParaBlockReflow(line, vuBlock = True)
-
-        elif blockReflow.match(line):
-            # Starting or ending a block whose contents may be reflowed.
-            # Blocks cannot be nested.
-
-            # Is this is an explicit Valid Usage block?
-            vuBlock = (state.lineNumber > 1 and
-                       lines[state.lineNumber-2] == '.Valid Usage\n')
-
-            state.endParaBlockReflow(line, vuBlock)
-
-        elif endPara.match(line):
-            # Ending a paragraph. Emit the current paragraph, if any, and
-            # prepare to begin a new paragraph.
-
-            state.endPara(line)
-
-            # If this is an include:: line starting the definition of a
-            # structure or command, track that for use in VUID generation.
-
-            matches = includePat.search(line)
-            if matches is not None:
-                generated_type = matches.group('generated_type')
-                include_type = matches.group('category')
-                if generated_type == 'api' and include_type in ('protos', 'structs', 'funcpointers'):
-                    apiName = matches.group('entity_name')
-                    if state.apiName != state.defaultApiName:
-                        # This happens when there are multiple API include
-                        # lines in a single block. The style guideline is to
-                        # always place the API which others are promoted to
-                        # first. In virtually all cases, the promoted API
-                        # will differ solely in the vendor suffix (or
-                        # absence of it), which is benign.
-                        if not apiMatch(state.apiName, apiName):
-                            logDiag(f'Promoted API name mismatch at line {state.lineNumber}: {apiName} does not match state.apiName (this is OK if it is just a spelling alias)')
-                    else:
-                        state.apiName = apiName
-
-        elif endParaContinue.match(line):
-            # For now, always just end the paragraph.
-            # Could check see if len(para) > 0 to accumulate.
-
-            state.endParaContinue(line)
-
-            # If it is a title line, track that
-            if line[0:2] == '= ':
-                thisTitle = True
-
-        elif blockPassthrough.match(line):
-            # Starting or ending a block whose contents must not be reflowed.
-            # These are tables, etc. Blocks cannot be nested.
-
-            state.endParaBlockPassthrough(line)
-        elif state.lastTitle:
-            # The previous line was a document title line. This line
-            # is the author / credits line and must not be reflowed.
-
-            state.endPara(line)
-        else:
-            # Just accumulate a line to the current paragraph. Watch out for
-            # hanging indents / bullet-points and track that indent level.
-
-            state.addLine(line)
-
-            # This test looks for disallowed conditionals inside Valid Usage
-            # blocks, by checking if (a) this line does not start a new VU
-            # (bullet point) and (b) the previous line starts an asciidoctor
-            # conditional (ifdef:: or ifndef::).
-
-            if (args.check
-                and state.vuStack[-1]
-                and not beginBullet.match(line)
-                and conditionalStart.match(lines[state.lineNumber-2])):
-
-                logWarn('Detected embedded Valid Usage conditional: {}:{}'.format(
-                        filename, state.lineNumber - 1))
-                # Keep track of warning check count
-                args.warnCount = args.warnCount + 1
-
-        state.lastTitle = thisTitle
-
-    # Cleanup at end of file
-    state.endPara(None)
-
-    # Check for sensible block nesting
-    if len(state.blockStack) > 1:
-        logWarn('file', filename,
-                'mismatched asciidoc block delimiters at EOF:',
-                state.blockStack[-1])
+    transformer.transformFile(lines)
 
     if fp is not None:
         fp.close()
 
     # Update the 'nextvu' value
-    if args.nextvu != state.nextvu:
-        logWarn('Updated nextvu to', state.nextvu, 'after file', filename)
-        args.nextvu = state.nextvu
+    if args.nextvu != callback.nextvu:
+        logWarn('Updated nextvu to', callback.nextvu, 'after file', filename)
+        args.nextvu = callback.nextvu
+
+    args.warnCount += callback.warnCount
 
 def reflowAllAdocFiles(folder_to_reflow, args):
     for root, subdirs, files in os.walk(folder_to_reflow):
@@ -759,21 +495,6 @@ def reflowAllAdocFiles(folder_to_reflow, args):
                 reflowAllAdocFiles(sub_folder, args)
             else:
                 print('   Skipping = %s' % sub_folder)
-
-# Patterns used to recognize interesting lines in an asciidoc source file.
-# These patterns are only compiled once.
-
-# Explicit Valid Usage list item with one or more leading asterisks
-# The re.DOTALL is needed to prevent vuPat.search() from stripping
-# the trailing newline.
-vuPat = re.compile(r'^(?P<head>  [*]+)( *)(?P<tail>.*)', re.DOTALL)
-
-# VUID with the numeric portion captured in the match object
-vuidPat = re.compile(r'VUID-[^-]+-[^-]+-(?P<vuid>[0-9]+)')
-
-# Pattern matching leading nested bullet points
-global nestedVuPat
-nestedVuPat = re.compile(r'^  \*\*')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -853,7 +574,7 @@ if __name__ == '__main__':
     # This is added to the argparse structure
     args.warnCount = 0
 
-    # Dictionary of VUID numbers found, containing a list of (file, line) on
+    # Dictionary of VUID numbers found, containing a list of (file, VUID) on
     # which that number was found
     # This is added to the argparse structure
     args.vuidDict = {}
@@ -884,8 +605,8 @@ if __name__ == '__main__':
             found = args.vuidDict[vuid]
             if len(found) > 1:
                 logWarn('Duplicate VUID number {} found in files:'.format(vuid))
-                for (file, line) in found:
-                    logWarn('    {}: {}'.format(file, line))
+                for (file, vuidTag) in found:
+                    logWarn('    {}: {}'.format(file, vuidTag))
                 dupVUIDs = dupVUIDs + 1
 
         if dupVUIDs > 0:

--- a/scripts/test_VuFormatter.py
+++ b/scripts/test_VuFormatter.py
@@ -1,0 +1,232 @@
+#!/usr/bin/python3 -i
+#
+# Copyright 2023 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import os
+import pytest
+
+from check_spec_links import VulkanEntityDatabase
+from vuAST import VuFormatter, VuFormat
+
+
+@pytest.fixture
+def db():
+    entity_db = VulkanEntityDatabase()
+    return entity_db
+
+def verify(formatter, input, output):
+    assert(formatter.format(ast.parse(input)) == output)
+
+def test_source_unary_op(db):
+    """Source formatting: Test unary ops."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    verify(formatter, '-1', '-1')
+    verify(formatter, '- 1', '-1')
+    verify(formatter, '-a', '-a')
+    verify(formatter, '+1.0', '+1.0')
+    verify(formatter, '~b', '~b')
+    verify(formatter, 'not  a', 'not a')
+
+    verify(formatter, '-(a+1)', '-(a + 1)')
+    verify(formatter, '+(1+a)', '+(1 + a)')
+    verify(formatter, '~(a|b)', '~(a | b)')
+    verify(formatter, 'not (a and b)', '\n'.join(['not (a and', '    b)']))
+
+def test_source_bool_op(db):
+    """Source formatting: Test boolean ops."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    verify(formatter, 'a and b', '\n'.join(['(a and', '    b)']))
+    verify(formatter, 'a and b and c and d', '\n'.join(['(a and', '    b and', '    c and', '    d)']))
+    verify(formatter, 'a or b', '\n'.join(['(a or', '    b)']))
+    verify(formatter, 'a or b or c or d', '\n'.join(['(a or', '    b or', '    c or', '    d)']))
+
+    verify(formatter, 'not a and b', '\n'.join(['(not a and', '    b)']))
+    verify(formatter, 'a and not b', '\n'.join(['(a and', '    not b)']))
+    verify(formatter, 'not a or b', '\n'.join(['(not a or', '    b)']))
+    verify(formatter, 'a or not b', '\n'.join(['(a or', '    not b)']))
+
+    verify(formatter, 'a == b and c != d', '\n'.join(['(a == b and', '    c != d)']))
+    verify(formatter, 'a < b or c >= d', '\n'.join(['(a < b or', '    c >= d)']))
+    verify(formatter, 'a <= b or c > d', '\n'.join(['(a <= b or', '    c > d)']))
+
+def test_source_compare_op(db):
+    """Source formatting: Test compare ops."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    verify(formatter, 'a == b', 'a == b')
+    verify(formatter, 'a != b + 1', 'a != b + 1')
+    verify(formatter, 'a % 4 == b', 'a % 4 == b')
+    verify(formatter, 'a-2 <= b*4', 'a - 2 <= b * 4')
+
+    verify(formatter, '(a != b) == (not c)', '(a != b) == (not c)')
+    verify(formatter, 'a == (b == c)', 'a == (b == c)')
+    verify(formatter, '(a == b) != (c == d)', '(a == b) != (c == d)')
+
+def test_source_binary_op(db):
+    """Source formatting: Test binary ops."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    verify(formatter, 'a + b', 'a + b')
+    verify(formatter, 'a - b', 'a - b')
+    verify(formatter, 'a * b', 'a * b')
+    verify(formatter, 'a / b', 'a / b')
+    verify(formatter, 'a % b', 'a % b')
+    verify(formatter, 'a ** b', 'a ** b')
+
+    verify(formatter, 'a + b + c + d', 'a + b + c + d')
+    verify(formatter, 'a + b - c + d', 'a + b - c + d')
+    verify(formatter, 'a - b + c', 'a - b + c')
+    verify(formatter, 'a - b - c', 'a - b - c')
+    verify(formatter, 'a + b * c', 'a + b * c')
+    verify(formatter, 'a - b / c % d + e', 'a - b / c % d + e')
+    verify(formatter, 'a * b * c / d / e % f', 'a * b * c / d / e % f')
+    verify(formatter, 'a / b % c * d', 'a / b % c * d')
+
+    verify(formatter, 'a % 2**b == -1', 'a % (2 ** b) == -1')
+
+def test_source_assign(db):
+    """Source formatting: Test assignment."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    verify(formatter, 'a=b', 'a = b')
+    verify(formatter, 'a=b+1', 'a = b + 1')
+    verify(formatter, 'a = b == 2', 'a = b == 2')
+    verify(formatter, 'a = f(x)', 'a = f(x)')
+    verify(formatter, 'a = b[2]', 'a = b[2]')
+    verify(formatter, 'a = b.f(x)', 'a = b.f(x)')
+
+def test_source_call(db):
+    """Source formatting: Test function calls."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    verify(formatter, 'f(x)', 'f(x)')
+    verify(formatter, 'f(g(x))', 'f(g(x))')
+    verify(formatter, 'f(x, -y, z + 1)', 'f(x, -y, z + 1)')
+    verify(formatter, '~f(x, y if a else z)', '~f(x, y if a else z)')
+
+def test_source_subscript(db):
+    """Source formatting: Test array subscripts."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    verify(formatter, 'a[b]', 'a[b]')
+    verify(formatter, 'a[b + 1]', 'a[b + 1]')
+    verify(formatter, 'a.f().b[loop_index(i)]', 'a.f().b[loop_index(i)]')
+
+def test_source_attribute(db):
+    """Source formatting: Test attribute selection."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    verify(formatter, 'a.b', 'a.b')
+    verify(formatter, 'a.f(x)', 'a.f(x)')
+    verify(formatter, 'a[2].b', 'a[2].b')
+    verify(formatter, 'a[2].f(b[3], c)', 'a[2].f(b[3], c)')
+
+def test_source_builtins(db):
+    """Source formatting: Test calling builtins."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    # function-style builtins
+    verify(formatter, 'loop_index(info)', 'loop_index(info)')
+    verify(formatter, 'require(a == b)', 'require(a == b)')
+    verify(formatter, 'require(a <= b and c > d)', '\n'.join(['require(a <= b and', '    c > d)']))
+
+    # attribute-style builtins
+    verify(formatter, 'info.has_pnext(other)', 'info.has_pnext(other)')
+    verify(formatter, 'info.pnext(other)', 'info.pnext(other)')
+    verify(formatter, 'flags.has_bit(VK_CULL_MODE_FRONT_BIT)', 'flags.has_bit(VK_CULL_MODE_FRONT_BIT)')
+    verify(formatter, 'srcImage.image_type(VK_IMAGE_TYPE_1D)', 'srcImage.image_type(VK_IMAGE_TYPE_1D)')
+
+def test_source_if(db):
+    """Source formatting: Test conditionals."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    input = '\n'.join(['if a:',
+                       '    b'])
+    output = '\n'.join(['if a:',
+                        ' b'])
+    verify(formatter, input, output)
+
+    input = '\n'.join(['if a == b:',
+                       '    c',
+                       '    d'])
+    output = '\n'.join(['if a == b:',
+                        ' c',
+                        ' d'])
+    verify(formatter, input, output)
+
+    input = '\n'.join(['if a == b and c == d and e == f:',
+                       '    require(x)'])
+    output = '\n'.join(['if (a == b and',
+                        '    c == d and',
+                        '    e == f):',
+                        ' require(x)'])
+    verify(formatter, input, output)
+
+    input = '\n'.join(['if a != NULL:',
+                       '  if a.f(b) > 1:',
+                       '    require(a.f(b) % 4 == 0)'])
+    output = '\n'.join(['if a != NULL:',
+                        ' if a.f(b) > 1:',
+                        '  require(a.f(b) % 4 == 0)'])
+    verify(formatter, input, output)
+
+def test_source_for(db):
+    """Source formatting: Test for loops."""
+    formatter = VuFormatter(db, VuFormat.SOURCE, 'file.adoc', 123)
+
+    input = '\n'.join(['for a in b:',
+                       '    c'])
+    output = '\n'.join(['for a in b:',
+                        ' c'])
+    verify(formatter, input, output)
+
+    input = '\n'.join(['for a in b:',
+                       '    c',
+                       '    d'])
+    output = '\n'.join(['for a in b:',
+                        ' c',
+                        ' d'])
+    verify(formatter, input, output)
+
+    input = '\n'.join(['for info in pInfos:',
+                       ' require(other[loop_index(info)].layout == info.layout)'])
+    output = '\n'.join(['for info in pInfos:',
+                        ' require(other[loop_index(info)].layout == info.layout)'])
+    verify(formatter, input, output)
+
+    input = '\n'.join(['for info in pInfos:',
+                       ' if info.pDepthStencil != NULL:',
+                       '  require(info.pDepthStencil.handle != VK_NULL_HANDLE)'])
+    output = '\n'.join(['for info in pInfos:',
+                        ' if info.pDepthStencil != NULL:',
+                        '  require(info.pDepthStencil.handle != VK_NULL_HANDLE)'])
+    verify(formatter, input, output)
+
+    input = '\n'.join(['if info.has_pnext(VkSwapchainPresentFenceInfoEXT):',
+                       ' for fence in info.pnext(VkSwapchainPresentFenceInfoEXT).pFences:',
+                       '  if fence != VK_NULL_HANDLE:',
+                       '   require(fence.valid())'])
+    output = '\n'.join(['if info.has_pnext(VkSwapchainPresentFenceInfoEXT):',
+                        ' for fence in info.pnext(VkSwapchainPresentFenceInfoEXT).pFences:',
+                        '  if fence != VK_NULL_HANDLE:',
+                        '   require(fence.valid())'])
+    verify(formatter, input, output)
+
+def test_output(db):
+    """Output formatting."""
+    formatter = VuFormatter(db, VuFormat.OUTPUT, 'file.adoc', 123)
+
+    input = '\n'.join(['if info.has_pnext(VkSwapchainPresentFenceInfoEXT):',
+                       ' for fence in info.pnext(VkSwapchainPresentFenceInfoEXT).pFences:',
+                       '  if fence != VK_NULL_HANDLE:',
+                       '   require(fence.valid())'])
+    output = '\n'.join(['[vu]#[vu-keyword]##if## info.[vu-builtin]##<<vu-builtin-has_pnext,has_pnext>>##(slink:VkSwapchainPresentFenceInfoEXT): +',
+                        '&nbsp;[vu-keyword]##for## fence [vu-operator]##in## info.[vu-builtin]##<<vu-builtin-pnext,pnext>>##(slink:VkSwapchainPresentFenceInfoEXT).pFences: +',
+                        '&nbsp;&nbsp;[vu-keyword]##if## fence [vu-operator]##!=## dlink:VK_NULL_HANDLE: +',
+                        '&nbsp;&nbsp;&nbsp;[vu-builtin]##<<vu-builtin-require,require>>##(fence.[vu-builtin]##<<vu-builtin-valid,valid>>##())#'])
+    verify(formatter, input, output)

--- a/scripts/test_reflow.py
+++ b/scripts/test_reflow.py
@@ -1,0 +1,230 @@
+#!/usr/bin/python3
+#
+# Copyright 2023 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author(s):    Shahbaz Youssefi <syoussefi@google.com>
+#
+# Purpose:      This file contains tests for reflow.py
+
+import pytest
+
+from collections import namedtuple
+import os
+
+from reflib import loadFile
+from reflow import reflowFile
+
+testsDir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'reflow-tests')
+resultsDir = os.path.join(testsDir, 'results')
+
+class ReflowArgs:
+    def __init__(self):
+        self.overwrite = False
+        self.nowrite = False
+        self.outDir = resultsDir
+        self.check = True
+        self.checkVUID = True
+        self.noflow = False
+        self.margin = 76
+        self.suffix = ''
+        self.nextvu = 10000
+        self.maxvu = 99999
+        self.warnCount = 0
+        self.vuidDict = {}
+
+@pytest.fixture
+def args():
+    return ReflowArgs()
+
+def getPath(*names):
+    return os.path.join(testsDir, *names)
+
+def match_with_expected(resultFile, expectation):
+    result, result_newline = loadFile(resultFile)
+    expect, expect_newline = loadFile(expectation)
+
+    assert(result_newline == expect_newline)
+    assert(result == expect)
+
+def run_reflow_test(args, filetag):
+    source = 'src-' + filetag + '.adoc'
+    expect = 'expect-' + filetag + '.adoc'
+
+    filename = getPath(source)
+
+    reflowFile(filename, args)
+
+    match_with_expected(getPath(resultsDir, source), getPath(expect))
+
+def match_warn_count(args, expected):
+    assert(args.warnCount == expected)
+
+def match_vuid_dict(args, expected):
+    assert(sorted(args.vuidDict.keys()) == sorted(expected.keys()))
+
+    for vuid, locations in args.vuidDict.items():
+        for location, expectedLocation in zip(locations, expected[vuid]):
+            filename, tag = location
+            expectedFilename, expectedTag = expectedLocation
+
+        assert(expectedFilename in filename)
+        assert(tag == expectedTag)
+
+def test_text(args):
+    """Basic test of text reflow."""
+    run_reflow_test(args, 'text')
+    match_warn_count(args, 0)
+    match_vuid_dict(args, {})
+
+def test_table(args):
+    """Basic test that ensures tables are not reformatted."""
+    run_reflow_test(args, 'table')
+    match_warn_count(args, 0)
+    match_vuid_dict(args, {})
+
+def test_vu(args):
+    """Basic test that VU reflows work."""
+    run_reflow_test(args, 'vu')
+    match_warn_count(args, 0)
+    match_vuid_dict(args, {'01993':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-01993]]']],
+                           '00002':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-00002]]']],
+                           '01545':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-01545]]']],
+                           '00003':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-00003]]']],
+                           '00004':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00004]]']],
+                           '00005':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00005]]']],
+                           '01394':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-01394]]']],
+                           '02498':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-aspectMask-02498]]']],
+                           '01470':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-baseMipLevel-01470]]']],
+                           '01692':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-pRanges-01692]]']],
+                           '01472':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]']],
+                           '01693':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-pRanges-01693]]']],
+                           '00007':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-00007]]']],
+                           '04961':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-pColor-04961]]']],
+                           '01805':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-commandBuffer-01805]]']],
+                           '01806':
+                           [['scripts/reflow-tests/src-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-commandBuffer-01806]]']]})
+
+def test_ifdef_in_vu(args):
+    """Test that ifdef in VUs are warned against."""
+    run_reflow_test(args, 'ifdef-in-vu')
+    match_warn_count(args, 1)
+    match_vuid_dict(args, {'00003':
+                           [['scripts/reflow-tests/src-ifdef-in-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-00003]]']],
+                           '00004':
+                           [['scripts/reflow-tests/src-ifdef-in-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00004]]']],
+                           '00005':
+                           [['scripts/reflow-tests/src-ifdef-in-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00005]]']],
+                           '04961':
+                           [['scripts/reflow-tests/src-ifdef-in-vu.adoc',
+                             '[[VUID-vkCmdClearColorImage-pColor-04961]]']]})
+
+def test_vuid_repeat(args):
+    """Test that same VUID in multiple VUs is detected."""
+    run_reflow_test(args, 'vuid-repeat')
+    match_warn_count(args, 0)
+    match_vuid_dict(args, {'02498':
+                           [['scripts/reflow-tests/src-vuid-repeat.adoc',
+                             '[[VUID-vkCmdClearColorImage-aspectMask-02498]]'],
+                            ['scripts/reflow-tests/src-vuid-repeat.adoc',
+                             '[[VUID-vkCmdClearColorImage-pRanges-02498]]'],
+                            ['scripts/reflow-tests/src-vuid-repeat.adoc',
+                             '[[VUID-vkCmdClearColorImage-pRanges-02498]]'],
+                            ['scripts/reflow-tests/src-vuid-repeat.adoc',
+                             '[[VUID-vkCmdClearColorImage-pColor-02498]]']],
+                           '01470':
+                           [['scripts/reflow-tests/src-vuid-repeat.adoc',
+                             '[[VUID-vkCmdClearColorImage-baseMipLevel-01470]]']],
+                           '00007':
+                           [['scripts/reflow-tests/src-vuid-repeat.adoc',
+                             '[[VUID-vkCmdClearColorImage-baseArrayLayer-00007]]'],
+                            ['scripts/reflow-tests/src-vuid-repeat.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-00007]]']]})
+
+def test_new_vuid(args):
+    """Test that VUID generation works."""
+    run_reflow_test(args, 'new-vuid')
+    match_warn_count(args, 0)
+    match_vuid_dict(args, {'01993':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-01993]]']],
+                           '10000':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-10000]]']],
+                           '01545':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-01545]]']],
+                           '10001':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-10001]]']],
+                           '00004':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00004]]']],
+                           '00005':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00005]]']],
+                           '10002':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-10002]]']],
+                           '02498':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-aspectMask-02498]]']],
+                           '01470':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-baseMipLevel-01470]]']],
+                           '10003':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-pRanges-10003]]']],
+                           '01472':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]']],
+                           '01693':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-pRanges-01693]]']],
+                           '10004':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-10004]]']],
+                           '10005':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-pColor-10005]]']],
+                           '01805':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-commandBuffer-01805]]']],
+                           '01806':
+                           [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-commandBuffer-01806]]']]})

--- a/scripts/test_reflow.py
+++ b/scripts/test_reflow.py
@@ -137,6 +137,61 @@ def test_vu(args):
                            [['scripts/reflow-tests/src-vu.adoc',
                              '[[VUID-vkCmdClearColorImage-commandBuffer-01806]]']]})
 
+def test_vu_codified(args):
+    """Basic test that VU reflows work for codified VUs."""
+    run_reflow_test(args, 'vu-codified')
+    match_warn_count(args, 0)
+    match_vuid_dict(args, {'01993':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-01993]]']],
+                           '00002':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-00002]]']],
+                           '01545':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-01545]]']],
+                           '00003':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-00003]]']],
+                           '00004':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00004]]']],
+                           '00005':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00005]]']],
+                           '01394':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-01394]]']],
+                           '02498':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-aspectMask-02498]]']],
+                           '01470':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-baseMipLevel-01470]]']],
+                           '01692':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-pRanges-01692]]']],
+                           '01472':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]']],
+                           '01693':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-pRanges-01693]]']],
+                           '00007':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-00007]]']],
+                           '04961':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-pColor-04961]]']],
+                           '01805':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-commandBuffer-01805]]']],
+                           '01806':
+                           [['scripts/reflow-tests/src-vu-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-commandBuffer-01806]]']]})
+
+
+
 def test_ifdef_in_vu(args):
     """Test that ifdef in VUs are warned against."""
     run_reflow_test(args, 'ifdef-in-vu')
@@ -227,4 +282,57 @@ def test_new_vuid(args):
                              '[[VUID-vkCmdClearColorImage-commandBuffer-01805]]']],
                            '01806':
                            [['scripts/reflow-tests/src-new-vuid.adoc',
+                             '[[VUID-vkCmdClearColorImage-commandBuffer-01806]]']]})
+
+def test_new_vuid_codified(args):
+    """Test that VUID generation works for codified VUs."""
+    run_reflow_test(args, 'new-vuid-codified')
+    match_warn_count(args, 0)
+    match_vuid_dict(args, {'01993':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-01993]]']],
+                           '10000':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-10000]]']],
+                           '01545':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-01545]]']],
+                           '10001':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-10001]]']],
+                           '00004':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00004]]']],
+                           '00005':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-00005]]']],
+                           '10002':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-imageLayout-10002]]']],
+                           '02498':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-aspectMask-02498]]']],
+                           '10003':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-10003]]']],
+                           '10004':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-10004]]']],
+                           '01472':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-baseArrayLayer-01472]]']],
+                           '01693':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-pRanges-01693]]']],
+                           '10005':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-image-10005]]']],
+                           '10006':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-pColor-10006]]']],
+                           '01805':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
+                             '[[VUID-vkCmdClearColorImage-commandBuffer-01805]]']],
+                           '01806':
+                           [['scripts/reflow-tests/src-new-vuid-codified.adoc',
                              '[[VUID-vkCmdClearColorImage-commandBuffer-01806]]']]})

--- a/scripts/test_vuAST.py
+++ b/scripts/test_vuAST.py
@@ -1,0 +1,890 @@
+#!/usr/bin/python3 -i
+#
+# Copyright 2023 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import xml.etree.ElementTree as etree
+
+from check_spec_links import VulkanEntityDatabase
+from vuAST import VuAST
+
+
+@pytest.fixture
+def db():
+    entity_db = VulkanEntityDatabase()
+    return entity_db
+
+def assertParseAndVerify(db, api, vu, filename, fileline = 100, macros = {}):
+    ast = VuAST()
+    assert(ast.parse(vu, filename, fileline))
+    assert(ast.applyMacros(macros))
+    assert(ast.verify(db, api))
+
+def assertParseFailVerify(db, api, vu, filename, fileline = 200, macros = {}):
+    ast = VuAST()
+    assert(ast.parse(vu, filename, fileline))
+    assert(ast.applyMacros(macros))
+    assert(not ast.verify(db, api))
+
+def assertParseAndGetTag(vu, filename, fileline, expectedTag):
+    ast = VuAST()
+    assert(ast.parse(vu, filename, fileline))
+    assert(ast.getParameterTag() == expectedTag)
+
+##################
+### REAL VU Tests.  Make sure each new builtin gets a test based on a real VU
+### in this section
+
+def test_basic_function(db):
+    """Basic test of parsing a VU for a function."""
+    vu = """   for info in pCreateInfos:
+                 if info.flags.has_bit(VK_PIPELINE_CREATE_DERIVATIVE_BIT) and info.basePipelineIndex != -1:
+                   require(pCreateInfos[info.basePipelineIndex].flags.has_bit(VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT))
+        """
+
+    assertParseAndVerify(db, 'vkCreateComputePipelines', vu, 'pipelines.adoc', 123, {})
+
+def test_basic_macro(db):
+    """Basic test of parsing a VU for a function, including a macro."""
+    vu = """if macro(imageparam).create_info().imageType == VK_IMAGE_TYPE_1D:
+              for region in pRegions:
+               require(region.imageOffset.y == 0)
+               require(region.imageExtent.height == 1)"""
+
+    assertParseAndVerify(db, 'vkCmdCopyImageToBuffer', vu, 'copy_bufferimage_to_imagebuffer_common.adoc', 45, {'imageparam': 'srcImage'})
+
+def test_basic_variable(db):
+    """Basic test of parsing a VU for a struct, including a temp variable."""
+    vu = """ if flags.has_bit(VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM):
+               for subpass in pSubpasses:
+                 shading_rate_attachment = subpass.pnext(VkFragmentShadingRateAttachmentInfoKHR).pFragmentShadingRateAttachment
+                 if shading_rate_attachment != NULL:
+                   require(shading_rate_attachment.attachment == VK_ATTACHMENT_UNUSED)"""
+
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc', 99, {})
+
+def test_basic_extension(db):
+    """Basic test of whether an extension is enabled."""
+    vu = """if (renderPass != VK_NULL_HANDLE and
+                ext_enabled(VK_EXT_multisampled_render_to_single_sampled)):
+             subpassInfo = renderPass.create_info().pSubpasses[subpass]
+             msrtssInfo = subpassInfo.pnext(VkMultisampledRenderToSingleSampledInfoEXT)
+             if msrtssInfo.multisampledRenderToSingleSampledEnable == VK_TRUE:
+              require(pMultisampleState.rasterizationSamples == msrtssInfo.rasterizationSamples)"""
+
+    assertParseAndVerify(db, 'VkGraphicsPipelineCreateInfo', vu, 'pipelines.adoc', 1860, {})
+
+def test_builtin_loop_index(db):
+    """Basic test of the loop_index() builtin."""
+    vu = """maxMutableBindingIndex = -1
+for binding in pBindings:
+  if binding.descriptorType == VK_DESCRIPTOR_TYPE_MUTABLE_EXT:
+    maxMutableBindingIndex = loop_index(binding)
+if maxMutableBindingIndex != -1:
+  require(has_pnext(VkMutableDescriptorTypeCreateInfoEXT))
+  mutableType = pnext(VkMutableDescriptorTypeCreateInfoEXT)
+  require(mutableType.mutableDescriptorTypeListCount > maxMutableBindingIndex)"""
+
+    assertParseAndVerify(db, 'VkDescriptorSetLayoutCreateInfo', vu, 'pipelines.adoc', 1860, {})
+
+def test_builtin_any(db):
+    """Basic test of the any() builtin."""
+    vu = """libraryInfo = pnext(VkPipelineLibraryCreateInfoKHR)
+graphicsLibraryInfo = pnext(VkGraphicsPipelineLibraryCreateInfoEXT)
+withCaptureFlag = False
+if libraryInfo.libraryCount > 0 and graphicsLibraryInfo.flags.any():
+  for library in libraryInfo.pLibraries:
+    if library.create_info().flags.has_bit(VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR):
+      withCaptureFlag = True
+      break
+  if withCaptureFlag:
+    require(flags.has_bit(VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR))"""
+
+    assertParseAndVerify(db, 'VkGraphicsPipelineCreateInfo', vu, 'pipelines.adoc', 1860, {})
+
+##################
+### Unit tests for parsing and type checking.
+
+def test_negative_parse(db):
+    """Parse error tests.  Since python's own ast module is used for parsing,
+    this is not quite so extensive."""
+    ast = VuAST()
+
+    # Missing parenthesis in condition:
+    vu = """if (renderPass != VK_NULL_HANDLE and
+                ext_enabled(VK_EXT_multisampled_render_to_single_sampled):
+             require(VK_FALSE)"""
+    assert(not ast.parse(vu, 'no_file', 100))
+
+    # Invalid character `
+    vu = """require(ext_enabled(`VK_EXT_foo`))"""
+    assert(not ast.parse(vu, 'no_file', 100))
+
+    # Tag specified in source
+    vu = """require(ename:VK_FALSE)"""
+    assert(not ast.parse(vu, 'no_file', 100))
+
+def test_negative_macros(db):
+    """Parse error tests post macro expansion."""
+    ast = VuAST()
+
+    vu = """if (macro(m)):
+             require(VK_FALSE)"""
+    assert(ast.parse(vu, 'no_file', 100))
+    assert(not ast.applyMacros({'m': 'a b'}))
+    assert(not ast.applyMacros({'m': 'ename:VK_TRUE'}))
+    assert(not ast.applyMacros({'m': 'VK_TRUE)'}))
+
+def test_negative_no_require(db):
+    """Test that verification fails if require() is not found in VU."""
+
+    vu = """ if flags.has_bit(VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM):
+               subpasses = pSubpasses"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_assignment(db):
+    """Test assignment statements."""
+
+    # Basic check
+    vu = """variable = flags
+require(variable.any())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Test complex expression on RHS
+    vu = """variable = pSubpasses[0].pDepthStencilAttachment
+require(variable != NULL)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Test builtin call on RHS
+    vu = """variable = flags.any()
+require(variable)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_assignment(db):
+    """Test validation for assignments."""
+
+    # Multiple targets disallowed
+    vu = """ if flags.has_bit(VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM):
+               subpasses = x = pSubpasses
+               require(subpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Tuple disallowed as target
+    vu = """ if flags.has_bit(VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM):
+               subpasses, x = pSubpasses
+               require(subpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # List disallowed as target
+    vu = """ if flags.has_bit(VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM):
+               [subpasses, x] = pSubpasses
+               require(subpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Assignment to API token is not allowed
+    vu = """ if flags.has_bit(VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM):
+               VkImageType = pSubpasses
+               require(pSubpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Assignment to VU token is not allowed
+    vu = """ if flags.has_bit(VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM):
+               flags = pSubpasses
+               require(flags != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Assignment to builtin function is not allowed
+    vu = """loop_index = pSubpasses
+require(0 == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """has_bit = pSubpasses
+require(0 == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_if(db):
+    """Test if statements."""
+
+    # Basic check
+    vu = """if flags.any():
+             require(0 == 0)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Variable inside condition
+    vu = """variable = flags.any()
+if variable:
+ require(0 == 0)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Multiline body
+    vu = """if flags.any():
+             variable = 0 == 0
+             require(variable)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_if(db):
+    """Test validation for if."""
+
+    # If condition must be a boolean
+    vu = """ if flags:
+               require(pSubpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # If condition cannot be a pointer
+    vu = """ if pSubpasses:
+               require(flags.any())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_while(db):
+    """Test while statements."""
+
+    # Basic check
+    vu = """while flags.any():
+             require(0 == 0)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # For loop emulation
+    vu = """index = 0
+while index < correlatedViewMaskCount:
+ require(pCorrelatedViewMasks[index] == 0)
+ index = index + 1"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Multiline body
+    vu = """while flags.any():
+             variable = 0 == 0
+             require(variable)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_while(db):
+    """Test validation for while."""
+
+    # While condition must be a boolean
+    vu = """ while flags:
+               require(pSubpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # While condition cannot be a pointer
+    vu = """ while pSubpasses:
+               require(flags.any())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_for(db):
+    """Test for loops."""
+
+    # Statically sized arrays can be looped over
+    vu = """for c in deviceName:
+             require(c >= 'a' and c <= 'z')"""
+    assertParseAndVerify(db, 'VkPhysicalDeviceProperties', vu, 'devsandqueues.adoc', 531, {})
+
+    # Basic test for loops
+    vu = """for layer in ppEnabledLayerNames:
+             require(layer == ppEnabledExtensionNames[loop_index(layer)])"""
+    assertParseAndVerify(db, 'VkDeviceCreateInfo', vu, 'devsandqueues.adoc', 531, {})
+
+    # Multiline for loop
+    vu = """for layer in ppEnabledLayerNames:
+             variable = loop_index(layer)
+             require(layer == ppEnabledExtensionNames[variable])"""
+    assertParseAndVerify(db, 'VkDeviceCreateInfo', vu, 'devsandqueues.adoc', 531, {})
+
+def test_negative_for(db):
+    """Test validation for for."""
+
+    # For target must be a single variable
+    vu = """ for a, b in pSubpasses:
+               require(pSubpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # For iterator cannot be a tuple
+    vu = """ for subpass in pSubpasses, flags:
+               require(flags.any())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # For iterator cannot be a list
+    vu = """ for subpass in [pSubpasses, flags]:
+               require(flags.any())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # For iterator must be an array
+    vu = """ for attachment in pSubpasses[0].pDepthStencilAttachment:
+               require(attachment.attachment == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # For target cannot be a builtin
+    vu = """ for has_bit in pSubpasses[0].pColorAttachments:
+               require(0 == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # For iterator cannot be a builtin
+    vu = """ for attachment in loop_index:
+               require(0 == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_bool_op(db):
+    """Test and/or."""
+
+    # Basic check
+    vu = """require(0 == 0 and flags.any())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # More than 2 expressions
+    vu = """require(0 == 0 or flags.any() or pSubpasses != NULL or pCorrelatedViewMasks[0] != 0)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Complex and nested
+    vu = """require(0 == 0 or
+                    (flags.any() and
+                     pSubpasses != NULL) or
+                    pCorrelatedViewMasks[0] != 0)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Complex and nested in if
+    vu = """if (0 == 0 or
+                (flags.any() and
+                 pSubpasses != NULL) or
+                pCorrelatedViewMasks[0] != 0):
+             require(flags.any())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_bool_op(db):
+    """Test validation for and/or."""
+
+    # Pointers do not implicitly cast to bool
+    vu = """ if pSubpasses and flags.any():
+               require(pSubpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Numbers do not implicitly cast to bool
+    vu = """ if flags.any() or pSubpasses[0].colorAttachmentCount:
+               require(pSubpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Enums do not implicitly cast to bool
+    vu = """ if flags.any() and pSubpasses != NULL and sType:
+               require(pSubpasses != NULL)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Bool operations in assignments are no different
+    vu = """correct = flags.any() or sType
+require(correct)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_unary_not(db):
+    """Test not."""
+
+    # Basic check
+    vu = """require(not flags.any())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Complex expression
+    vu = """require(not (0 == 0 or
+                    (flags.any() and
+                     pSubpasses != NULL) or
+                    pCorrelatedViewMasks[0] != 0))"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_unary_not(db):
+    """Test validation for not."""
+
+    # Pointers cannot be used with not
+    vu = """require(not pSubpasses)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Bitfields cannot be used with not
+    vu = """require(not flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Enums cannot be used with not
+    vu = """require(not VK_IMAGE_TYPE_1D)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Numbers cannot be used with not
+    vu = """require(not pSubpasses[0].colorAttachmentCount)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_unary_invert(db):
+    """Test ~."""
+
+    # Basic check
+    vu = """require((~flags).any())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_unary_invert(db):
+    """Test validation for ~."""
+
+    # Pointers cannot be used with ~
+    vu = """require(~pSubpasses == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Booleans cannot be used with ~
+    vu = """require(~flags.any() == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Enums cannot be used with ~
+    vu = """require(~VK_IMAGE_TYPE_1D == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Numbers cannot be used with ~
+    vu = """require(~pSubpasses[0].colorAttachmentCount == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_unary_arithmetic(db):
+    """Test unary + and -."""
+
+    # Basic check
+    vu = """require(-attachmentCount > +subpassCount)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_unary_arithmetic(db):
+    """Test validation for unary + and -."""
+
+    # Pointers cannot be used with +/-
+    vu = """require(-pSubpasses == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Booleans cannot be used with +/-
+    vu = """require(+flags.any() == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Bitfields cannot be used with +/-
+    vu = """require(-flags == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Enums cannot be used with +/-
+    vu = """require(-VK_IMAGE_TYPE_1D != 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_binary_arithmetic(db):
+    """Test binary +, -, *, /, //, %, **."""
+
+    # Basic check
+    vu = """require(attachmentCount + subpassCount > dependencyCount)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(pCorrelatedViewMasks[0] - 1 == 0)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(4 * attachmentCount % 5 != 0)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(attachmentCount / 3 == 1.3)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(attachmentCount // 3 == 1)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(2 ** attachmentCount < 4096)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_binary_arithmetic(db):
+    """Test validation for binary +, -, *, /, //, %, **."""
+
+    # Pointers cannot be used with arithmetic ops
+    vu = """require(pSubpasses + 5 == 10)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Booleans cannot be used with arithmetic ops
+    vu = """require(flags.any() * -1 == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Bitfields cannot be used with arithmetic ops
+    vu = """require(10 ** flags == 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Enums cannot be used with arithmetic ops
+    vu = """require(10 // VK_IMAGE_TYPE_1D != 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_shift(db):
+    """Test << and >>."""
+
+    # Basic check
+    vu = """require(1 << attachmentCount == 0x10)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(attachmentCount >> 31 == 0)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_shift(db):
+    """Test validation for << and >>."""
+
+    # Pointers cannot be used with shift
+    vu = """require(flags == pSubpasses >> 1)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(flags == 1 << pSubpasses)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Booleans cannot be used with shift
+    vu = """require(flags.any() << 1 == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(1 >> flags.any() == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Bitfields cannot be used with shift
+    vu = """require(flags >> 1 != 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(1 << flags != flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Enums cannot be used with shift
+    vu = """require(VK_IMAGE_TYPE_1D >> 1 == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(1 << VK_IMAGE_TYPE_1D == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_bitwise(db):
+    """Test |, & and ^."""
+
+    # Basic check
+    vu = """require((flags | ~flags).any())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require((flags & ~flags).none())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require((flags ^ flags).none())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_bitwise(db):
+    """Test validation for |, & and ^."""
+
+    # Pointers cannot be used with bitwise operations
+    vu = """require(pSubpasses | flags == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Booleans cannot be used with bitwise operations
+    vu = """require((flags ^ (pSubpasses != NULL)).none())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Enums cannot be used with bitwise operations
+    vu = """require(flags & VK_IMAGE_TYPE_1D == flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Bitmasks of different types cannot be used with bitwise operations
+    vu = """require((flags ^ pSubpasses[0].flags) != flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_comparison(db):
+    """Test >, <, >= and <=."""
+
+    # Basic check
+    vu = """require(attachmentCount < subpassCount)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(dependencyCount > subpassCount)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(pCorrelatedViewMasks[0] <= subpassCount)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Test that the result of comparison is a boolean
+    vu = """require((attachmentCount >= subpassCount) == flags.any())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_negative_comparison(db):
+    """Test validation for <, >, >= and <=."""
+
+    # Pointers cannot be used with comparison
+    vu = """require(pSubpasses > 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Booleans cannot be used with comparison
+    vu = """require(10 <= flags.any())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Bitfields cannot be used with comparison
+    vu = """require(-1 >= flags)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Enums cannot be used with comparison
+    vu = """require(VK_IMAGE_TYPE_1D < 100000)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_equality(db):
+    """Test == and !=."""
+
+    # Basic check
+    vu = """require(attachmentCount == subpassCount)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(pCorrelatedViewMasks[0] != subpassCount)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Pointers should be comparable if their type matches
+    vu = """require(pSubpasses[0].pInputAttachments != pSubpasses[0].pColorAttachments)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(pSubpasses[0].pPreserveAttachments != pCorrelatedViewMasks)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Pointers should be comparable with NULL
+    vu = """require(pSubpasses[0].pInputAttachments != NULL)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(NULL != pCorrelatedViewMasks)"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Handles should be comparable with NULL
+    vu = """require(srcImage != VK_NULL_HANDLE)"""
+    assertParseAndVerify(db, 'VkCopyImageInfo2', vu, 'renderpass.adoc')
+    vu = """require(VK_NULL_HANDLE != dstImage)"""
+    assertParseAndVerify(db, 'VkCopyImageInfo2', vu, 'renderpass.adoc')
+
+    # Test that the result of comparison is a boolean
+    vu = """require((attachmentCount == subpassCount) == flags.any())"""
+    assertParseAndVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Enums and bitfields should be comparable as long as their underlying
+    # types match
+    vu = """require(srcImage.create_info().imageType == dstImage.create_info().imageType)"""
+    assertParseAndVerify(db, 'VkCopyImageInfo2', vu, 'renderpass.adoc')
+    vu = """require(srcImage.create_info().imageType != VK_IMAGE_TYPE_1D)"""
+    assertParseAndVerify(db, 'VkCopyImageInfo2', vu, 'renderpass.adoc')
+    vu = """require(VK_IMAGE_TYPE_3D != dstImage.create_info().imageType)"""
+    assertParseAndVerify(db, 'VkCopyImageInfo2', vu, 'renderpass.adoc')
+
+def test_negative_equality(db):
+    """Test validation for == and !=."""
+
+    # Non-binary comparisons are not allowed
+    vu = """require(infoCount == pIndirectStrides[0] == pIndirectStrides[1])"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+
+    # Pointers and non-pointers cannot be compared
+    vu = """require(pInfos == infoCount)"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+
+    # Pointers and pointers to pointers cannot be compared
+    vu = """require(pInfos == ppMaxPrimitiveCounts)"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+    vu = """require(ppMaxPrimitiveCounts != ppMaxPrimitiveCounts[0])"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+
+    # Pointers cannot have mismatching type classes
+    vu = """require(pInfos == pIndirectDeviceAddresses)"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+
+    # Pointers cannot have mismatching struct types
+    vu = """require(pInfos != ppBuildRangeInfos[0])"""
+    assertParseFailVerify(db, 'vkBuildAccelerationStructuresKHR', vu, 'accelstructures.adoc')
+
+    # Mismatching type classes are not allowed
+    vu = """require(pInfos[0] != 1)"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+    vu = """require(pIndirectDeviceAddress[0] != pInfos[0])"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+
+    # Mismatching struct types are not allowed
+    vu = """require(pIndirectStrides[0] != pInfos[0])"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+
+    # TODO: mismatching enums should not be allowed (like VkImageTiling and
+    # VkImageType), but currently not implemented.
+
+# Note: builtins correct usage is tested in real-VU tests at the top of the file.
+def test_negative_builtins(db):
+    """Test validation for the builtin calls.  Not all are tested because the
+    code that handles them is generic."""
+
+    # Cannot call nonexistent function
+    vu = """require(some_function(flags))"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(flags.some_function())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Function argument count must be correct
+    vu = """require(flags.any(), flags.none())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require()"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(flags.any(VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM))"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Function argument types must be correct
+    vu = """require(flags.has_bit(0))"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(ext_enabled(VkImageType))"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # Attribute functions must be called on the correct type
+    vu = """require(pSubpasses.has_bit(VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM))"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(pSubpasses.valid())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(pSubpasses.none())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """require(flags.create_info())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+    # loop_index cannot be used with a non-loop variable
+    vu = """require(loop_index(pSubpasses) > 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+    vu = """subpasses = pSubpasses
+require(loop_index(subpasses) > 0)"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+# Note: attribute correct usage is well tested among all other tests
+def test_negative_attribute(db):
+    """Test validation for attributes."""
+
+    # Cannot reference non-existing attribute
+    vu = """variable = pDependencies[0].srcGPU
+require(flags.any())"""
+    assertParseFailVerify(db, 'VkRenderPassCreateInfo2', vu, 'renderpass.adoc')
+
+def test_subscript(db):
+    """Test array subscripts."""
+
+    # Subscripting arrays should work
+    vu = """require(pIndirectDeviceAddresses[0] != 0)"""
+    assertParseAndVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+
+    # Subscripting arrays of arrays should work
+    vu = """require(ppMaxPrimitiveCounts[0][0] >= 1)"""
+    assertParseAndVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+
+    # Subscripting a statically sized array should work
+    vu = """require(deviceName[0] == 'V')"""
+    assertParseAndVerify(db, 'VkPhysicalDeviceProperties', vu, 'devsandqueues.adoc', 531, {})
+
+def test_negative_subscript(db):
+    """Test validation for subscripts."""
+
+    # Subscript must be applied to an array
+    vu = """require(flags[0].none())"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require(pDepthStencilAttachment[0].attachment != 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require(pInputAttachments[0][0].attachment != 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+
+    # Subscript must be a number
+    vu = """require(pInputAttachments[pPreserveAttachments].attachment != 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require(pInputAttachments[pNext].attachment != 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require(pInputAttachments[flags].attachment != 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require(pInputAttachments[pipelineBindPoint].attachment != 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require(pInputAttachments[VK_EXT_mesh_shader].attachment != 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+
+def test_ternary(db):
+    """Test ternary operator usage."""
+
+    # Basic test
+    vu = """require(True if srcImage != VK_NULL_HANDLE else False)"""
+    assertParseAndVerify(db, 'vkCmdCopyImage', vu, 'copies.adoc')
+
+    # Matching types on left and right should work
+    vu = """require((srcImage if srcImage != VK_NULL_HANDLE else dstImage).valid())"""
+    assertParseAndVerify(db, 'vkCmdCopyImage', vu, 'copies.adoc')
+    vu = """require((srcImageLayout if srcImage != VK_NULL_HANDLE else dstImageLayout) == VK_IMAGE_LAYOUT_GENERAL)"""
+    assertParseAndVerify(db, 'vkCmdCopyImage', vu, 'copies.adoc')
+    vu = """require((pInputAttachments if flags.any() else pColorAttachments) != NULL)"""
+    assertParseAndVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require((pInputAttachments[0] if flags.any() else pColorAttachments[0]).attachment == 0)"""
+    assertParseAndVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+
+    # NULL and pointers should work
+    vu = """require((pInputAttachments if flags.any() else NULL) != NULL)"""
+    assertParseAndVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require((NULL if flags.any() else pColorAttachments) != NULL)"""
+    assertParseAndVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require((NULL if flags.any() else NULL) != pInputAttachments)"""
+    assertParseAndVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+
+    # VK_NULL_HANDLE and handles should work
+    vu = """require((srcImage if srcImage != VK_NULL_HANDLE else VK_NULL_HANDLE) != VK_NULL_HANDLE)"""
+    assertParseAndVerify(db, 'vkCmdCopyImage', vu, 'copies.adoc')
+    vu = """require((VK_NULL_HANDLE if srcImage != VK_NULL_HANDLE else dstImage) != VK_NULL_HANDLE)"""
+    assertParseAndVerify(db, 'vkCmdCopyImage', vu, 'copies.adoc')
+    vu = """require((VK_NULL_HANDLE if srcImage != VK_NULL_HANDLE else VK_NULL_HANDLE) != srcImage)"""
+    assertParseAndVerify(db, 'vkCmdCopyImage', vu, 'copies.adoc')
+
+    # Bitfields and their enum values should work
+    vu = """require((flags if viewMask != 0 else ~flags).any())"""
+    assertParseAndVerify(db, 'VkSubpassDescription2', vu, 'copies.adoc')
+    vu = """require((flags if flags.any() else VK_SUBPASS_DESCRIPTION_SHADER_RESOLVE_BIT_QCOM).any())"""
+    assertParseAndVerify(db, 'VkSubpassDescription2', vu, 'copies.adoc')
+    vu = """require((VK_SUBPASS_DESCRIPTION_SHADER_RESOLVE_BIT_QCOM if flags.any() else flags).any())"""
+    assertParseAndVerify(db, 'VkSubpassDescription2', vu, 'copies.adoc')
+
+def test_negative_ternary(db):
+    """Test validation for ternary operator."""
+
+    # Condition must be a boolean
+    vu = """require(viewMask == 0 if flags else pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+
+    # Condition cannot be a pointer
+    vu = """require(viewMask == 0 if pInputAttachments  else pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+
+    # Types of left and right expressions must match
+    vu = """require((0 if flags.any() else pipelineBindPoint) == 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require((0 if flags.any() else pInputAttachments) == 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require((0 if flags.any() else pPreserveAttachments) == 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require((0 if flags.any() else NULL) == 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require(flags.any() if flags.any() else 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require((VK_NULL_HANDLE if flags.any() else NULL) == VK_NULL_HANDLE)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require((pIndirectStrides if infoCount > 0 else ppMaxPrimitiveCounts) == pIndirectStrides)"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+    vu = """require((pInfos if infoCount > 0 else pIndirectStrides) == pInfos)"""
+    assertParseFailVerify(db, 'vkCmdBuildAccelerationStructuresIndirectKHR', vu, 'accelstructures.adoc')
+    vu = """require((srcBuffer if regionCount == 0 else dstImage) != VK_NULL_HANDLE)"""
+    assertParseFailVerify(db, 'vkCmdCopyBufferToImage', vu, 'copies.adoc')
+
+# Note: variable correct usage is well tested among other tests
+def test_negative_variable(db):
+    """Test validation for variables."""
+
+    # Cannot use builtin as variable
+    vu = """require(loop_index == 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+    vu = """require(has_bit.any())"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+
+    # Cannot use a variable that is not previously declared
+    vu = """require(someVariable == 0)"""
+    assertParseFailVerify(db, 'VkSubpassDescription2', vu, 'renderpass.adoc')
+
+##################
+### Unit tests for extracting VUID tags
+
+def test_get_tag_basic():
+    """Test extracting tag from a simple VU."""
+
+    vu = """require(pCreateInfos != NULL)"""
+    assertParseAndGetTag(vu, 'pipelines.adoc', 444, 'pCreateInfos')
+
+def test_get_tag_macro():
+    """Test extracting tag from a macro."""
+
+    vu = """require(externally_synchronized(macro(imageparam)))"""
+    assertParseAndGetTag(vu, 'copies.adoc', 444, '{imageparam}')
+
+def test_get_tag_assignment():
+    """Test extracting tag found in an assignment."""
+
+    vu = """var = pCreateInfos
+require(var != NULL)"""
+    assertParseAndGetTag(vu, 'pipelines.adoc', 444, 'pCreateInfos')
+
+def test_get_tag_if():
+    """Test extracting tag found in an if condition."""
+
+    vu = """if 0 != pCreateInfos[0].basePipelineIndex:
+             require(pCreateInfos[0].flags.has_bit(VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT))"""
+    assertParseAndGetTag(vu, 'pipelines.adoc', 444, 'pCreateInfos')
+
+def test_get_tag_for():
+    """Test extracting tag found in for iterator."""
+
+    vu = """for info in pCreateInfos:
+             require(info[0].flags.none())"""
+    assertParseAndGetTag(vu, 'pipelines.adoc', 444, 'pCreateInfos')
+
+def test_get_tag_while():
+    """Test extracting tag found in a while condition."""
+
+    vu = """while flags.any():
+             require(0 == 0)"""
+    assertParseAndGetTag(vu, 'renderpass.adoc', 444, 'flags')

--- a/scripts/vuAST.py
+++ b/scripts/vuAST.py
@@ -1,0 +1,1690 @@
+# Copyright 2023 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities to parse a VU into an AST, match its symbols with the entity_db
+and walk the AST.  This can be used to:
+
+- Reformat the VU to add syntax highlighting and make the formatting uniform
+  (at build time)
+- Generate VVL code directly from the VU (in the VVL repository)
+"""
+
+import ast
+from collections import namedtuple
+from enum import Enum
+import re
+
+from reflib import logDiag, logWarn, logErr
+from spec_tools.entity_db import EntityDatabase
+import spec_tools.util as util
+
+# A line with an assignment, in the form of `a.b.c = ...`
+assignmentPattern = re.compile(r'^\s*[a-zA-Z0-9.]+\s*=')
+
+# For verification, used to strip added annotations:
+stylePattern = re.compile(r'\[vu-[a-z-]*\]')
+linkPattern = re.compile(r'<<vu-[a-z-_]*,')
+newLinePattern = re.compile(r' \+$', flags=re.MULTILINE)
+
+def isCodifiedVU(para):
+    """Whether this is a legacy VU written in prose, or a codified VU that can
+    be parsed.  For simplicity, codified VUs are distinguished with their
+    starting line that is in one of the following forms:
+
+    - if ...
+    - for ...
+    - lvalue = ...
+    - require(
+
+    Note that VUs written in prose are capitalized."""
+
+    # Get the first line and remove bullet point (`* `) if any
+    firstline = para[0].lstrip()
+    if firstline[0] == '*':
+        firstline = firstline[1:].lstrip()
+
+    isIf = firstline.startswith('if ')
+    isFor = firstline.startswith('for ')
+    isAssign = assignmentPattern.search(firstline) is not None
+    isRequire = firstline.startswith('require(')
+
+    return isIf or isFor or isAssign or isRequire
+
+
+def removeBulletPoint(vuText):
+    bulletRemoved = vuText
+
+    indent = len(vuText[0]) - len(vuText[0].lstrip())
+
+    if vuText[0][indent] == '*':
+        postBulletPoint = vuText[0][(indent+1):]
+        indent += len(postBulletPoint) - len(postBulletPoint.lstrip()) + 1
+        bulletRemoved[0] = ' ' * indent + postBulletPoint.lstrip()
+
+    return bulletRemoved
+
+
+def removeIndent(vuText):
+    """Make the first line have 0 indent to satisfy the python parser."""
+    indent = len(vuText[0]) - len(vuText[0].lstrip())
+
+    indentRemoved = []
+    for line in vuText:
+        # Make sure input is at least indented as much as the first line.
+        assert(line[:indent].strip() == '')
+        indentRemoved.append(line[indent:])
+
+    return indentRemoved, indent
+
+
+def convertMacrosToVuLanguage(macros):
+    """During transition, let the adoc macros retain their current form (i.e.
+    C-style).  This function transforms them to the VU language (i.e.
+    python-style)."""
+    converted = {}
+
+    for macro, value in macros.items():
+        # remove pname: (currently the only adoc macro in a macro value)
+        vuValue = value.replace('pname:', '')
+
+        # Change -> to .
+        vuValue = vuValue.replace('->', '.')
+
+        # Almost all macros are now covered.  Other macros would need to be
+        # changed as their VUs are made codified.
+        converted[macro] = vuValue
+
+    return converted
+
+
+def expandVuMacros(vuText, macros):
+    """Expand macros (in the form macro(x)) given the dictionary."""
+    expanded = vuText
+
+    # A simple text replace of macro(x) will do
+    for macro, value in macros.items():
+        expanded = expanded.replace('macro(' + macro + ')', value)
+
+    return expanded
+
+
+def applyMacrosToApiName(macros, apiName):
+    """If apiName is {refpage}, replace it according to current macro
+    values."""
+    if apiName[0] != '{':
+        return apiName
+    assert(apiName[-1] == '}')
+
+    # It is an error if refpage is not defined.
+    macroName = apiName[1:-1]
+    if macroName not in macros:
+        logErr('API name macro ' + apiName + ' is not defined')
+        return apiName
+
+    return macros[macroName]
+
+
+class VuTypeClass(Enum):
+    VOID = 0,
+    BOOL = 1,
+    NUM = 2,
+    BITMASK = 3,
+    ENUM = 4,
+    STRUCT = 5,
+    HANDLE = 6,
+    STRUCT_NAME = 7,
+    EXTENSION_NAME = 8,
+
+# C type of an expression, for type checking and code generation.
+#
+# - typeClass: The type class of the type.  Used for coarse-level type checking
+#   of spec VUs.
+# - typeStr: The actual type.  Used for type checking of spec VUs, specially
+#   w.r.t API tokens.  Can also be used for code generation.
+# - pointerLevel: How many *s in the type.
+# - arrayLen: Whether this is an array type and what its length is.  For VU
+#   type checking, its existence is used in addition to pointerLevel to make
+#   sure there are no loops on non-array types.  For code generation, the
+#   length can be used for generating C++ loops.
+VuType = namedtuple(
+    'VuType', ['typeClass', 'typeStr', 'pointerLevel', 'arrayLen'], defaults=[0, None])
+
+VuFuncType = namedtuple( 'VuFuncType', ['returnType', 'argTypes'])
+
+VuAttrFuncType = namedtuple(
+    'VuAttrType', ['objectType', 'funcType'])
+
+# Some common types:
+VOID_TYPE = VuType(VuTypeClass.VOID, 'void')
+BOOL_TYPE = VuType(VuTypeClass.BOOL, 'bool')
+UINT_TYPE = VuType(VuTypeClass.NUM, 'uint32_t')
+NUM_TYPE = VuType(VuTypeClass.NUM, '')
+BITMASK_TYPE = VuType(VuTypeClass.BITMASK, '')
+ENUM_TYPE = VuType(VuTypeClass.ENUM, '')
+STRUCT_TYPE = VuType(VuTypeClass.STRUCT, '')
+HANDLE_TYPE = VuType(VuTypeClass.HANDLE, '')
+STRUCT_NAME_TYPE = VuType(VuTypeClass.STRUCT_NAME, '')
+EXTENSION_NAME_TYPE = VuType(VuTypeClass.EXTENSION_NAME, '')
+
+# List of builtins that are used like standalone functions.  Like
+# `require(...)`.
+FUNC_BUILTINS = {
+    # void require(bool)
+    'require' : VuFuncType(VOID_TYPE, [BOOL_TYPE]),
+    # bool has_pnext(struct_name)
+    'has_pnext': VuFuncType(BOOL_TYPE, [STRUCT_NAME_TYPE]),
+    # struct pnext(struct_name)
+    'pnext': VuFuncType(STRUCT_TYPE, [STRUCT_NAME_TYPE]),
+    # uint32_t loop_index(loop_variable)
+    'loop_index': VuFuncType(UINT_TYPE, [VOID_TYPE]),
+    # bool ext_enabled(ext_name)
+    'ext_enabled': VuFuncType(BOOL_TYPE, [EXTENSION_NAME_TYPE]),
+    # bool externally_synchronized(handle)
+    'externally_synchronized': VuFuncType(BOOL_TYPE, [HANDLE_TYPE]),
+    # macro() is used like a function, but is never visible in the output
+    'macro': VuFuncType(VOID_TYPE, [VOID_TYPE]),
+}
+
+# List of builtins that are used as if they are attributes.  Like
+# `flags.has_bit(...)`.
+ATTR_BUILTINS = {
+    # bool struct.has_pnext(struct_name)
+    'has_pnext': VuAttrFuncType(STRUCT_TYPE, VuFuncType(BOOL_TYPE, [STRUCT_NAME_TYPE])),
+    # struct struct.pnext(struct_name)
+    'pnext': VuAttrFuncType(STRUCT_TYPE, VuFuncType(STRUCT_TYPE, [STRUCT_NAME_TYPE])),
+    # bool bitfield.has_bit(enum)
+    'has_bit': VuAttrFuncType(BITMASK_TYPE, VuFuncType(BOOL_TYPE, [ENUM_TYPE])),
+    # bool bitfield.any()
+    'any': VuAttrFuncType(BITMASK_TYPE, VuFuncType(BOOL_TYPE, [])),
+    # bool bitfield.none()
+    'none': VuAttrFuncType(BITMASK_TYPE, VuFuncType(BOOL_TYPE, [])),
+    # bool handle.valid()
+    'valid': VuAttrFuncType(HANDLE_TYPE, VuFuncType(BOOL_TYPE, [])),
+    # Vk*CreateInfo handle.create_info()
+    'create_info': VuAttrFuncType(HANDLE_TYPE, VuFuncType(STRUCT_TYPE, [])),
+    # VkGraphics*CreateInfo handle.graphics_create_info()
+    'graphics_create_info': VuAttrFuncType(HANDLE_TYPE, VuFuncType(STRUCT_TYPE, [])),
+    # VkCompute*CreateInfo handle.compute_create_info()
+    'compute_create_info': VuAttrFuncType(HANDLE_TYPE, VuFuncType(STRUCT_TYPE, [])),
+    # VkRayTracing*CreateInfo handle.raytracing_create_info()
+    'raytracing_create_info': VuAttrFuncType(HANDLE_TYPE, VuFuncType(STRUCT_TYPE, [])),
+}
+
+class VuFormat(Enum):
+    # Format for adoc source.  Used by reflow.py
+    SOURCE = 0,
+    # Format for output, with syntax highlighting etc.
+    OUTPUT = 1,
+
+
+class VuFormatter(ast.NodeVisitor):
+    """A helper class to format a VU.
+
+    This is used by reflow.py to format the VUs in the input files.  It is also
+    used during build to format the VU appropriately for output, e.g. with
+    links, syntax highlighting etc."""
+    def __init__(self, entity_db, fmt, filename, fileline):
+        # entity_db is not used when formatting source
+        assert(fmt == VuFormat.SOURCE or entity_db is not None)
+
+        self.entity_db = entity_db
+        """EntityDatabase used to look up symbols used by the VU."""
+
+        self.filename = filename
+        self.fileline = fileline
+        """Location of VU."""
+
+        self.indent = 0
+        """The current amount of indent."""
+
+        assert(fmt in [VuFormat.SOURCE, VuFormat.OUTPUT])
+        self.fmt = fmt
+        """How to format the code."""
+
+        self.formatted = []
+        """The result formatted VU.  A "global" to avoid passing around and
+        simplify the code."""
+
+    def format(self, ast, isWholeTree = True):
+        """Format a given AST"""
+        self.indent = 0
+        self.formatted = []
+
+        self.beginStyle('vu', '#')
+        self.visit(ast)
+        self.endStyle('#')
+
+        formatted = ''.join(self.formatted)
+
+        if isWholeTree:
+            self.verifyIdentical(ast, formatted)
+
+        # Join the pieces to get the final output
+        return formatted
+
+    def verifyIdentical(self, tree, formatted):
+        """Verify that the formatted text is syntactically identical to the input."""
+
+        toVerify = formatted
+        if self.fmt == VuFormat.OUTPUT:
+            # Strip all annotations first
+            toVerify = toVerify.replace('[vu]', '')
+            toVerify = toVerify.replace('&nbsp;', ' ')
+            toVerify = re.sub(stylePattern, '', toVerify)
+            toVerify = re.sub(linkPattern, '', toVerify)
+            toVerify = re.sub(newLinePattern, '', toVerify)
+            toVerify = toVerify.replace('#', '')
+            toVerify = toVerify.replace('>>', '')
+            toVerify = toVerify.replace('ename:', '')
+            toVerify = toVerify.replace('sname:', '')
+            toVerify = toVerify.replace('fname:', '')
+            toVerify = toVerify.replace('dname:', '')
+            toVerify = toVerify.replace('tname:', '')
+            toVerify = toVerify.replace('elink:', '')
+            toVerify = toVerify.replace('slink:', '')
+            toVerify = toVerify.replace('flink:', '')
+            toVerify = toVerify.replace('dlink:', '')
+            toVerify = toVerify.replace('tlink:', '')
+
+        try:
+            formattedTree = ast.parse(toVerify, self.filename, 'exec')
+        except SyntaxError as exc:
+            logPrefix = self.filename + ':' + str(self.fileline) + ':'
+            logErr('Internal error: Parse error after reformatting VU:' , exc)
+            return
+
+        if ast.dump(formattedTree) != ast.dump(tree):
+            logPrefix = self.filename + ':' + str(self.fileline) + ':'
+            logWarn(ast.dump(tree, indent=' '))
+            logWarn(ast.dump(formattedTree, indent=' '))
+            logErr(logPrefix, 'Internal error: Reformatted VU is different from original VU')
+
+    def add(self, text):
+        self.formatted.append(text)
+
+    def beginScope(self):
+        # Scope always begins with : and a new line
+        self.add(':')
+        self.endLine()
+        self.indent += 1
+
+    def endScope(self):
+        # Nothing to do on scope end, just reduce the indent level
+        self.indent -= 1
+
+    def beginParenthesis(self):
+        # When parentheses are opened, add a larger indentation level for the
+        # expressions that are placed in the following lines.  This makes it
+        # less confusing if a scope is opened after the parentheses.  4 is
+        # chosen so that the common case of an `if` has its expressions
+        # aligned:
+        #
+        #  if (first_expression and
+        #      second_expression and
+        #      third_expression):
+        #   body
+        self.add('(')
+        self.indent += 4
+
+    def endParenthesis(self):
+        self.add(')')
+        self.indent -= 4
+
+    def beginLine(self):
+        space = ' ' if self.fmt == VuFormat.SOURCE else '&nbsp;'
+        self.add(space * self.indent)
+
+    def endLine(self):
+        # For SOURCE formatting, just a new line is sufficient.  For OUTPUT
+        # formatting, add ` +` to make sure there is a line break in the
+        # output.
+        if self.fmt == VuFormat.OUTPUT:
+            self.add(' +')
+        self.add('\n')
+
+    def beginStyle(self, style, delimiter = '##'):
+        if (self.fmt == VuFormat.OUTPUT):
+            self.add('[' + style + ']' + delimiter)
+
+    def endStyle(self, delimiter = '##'):
+        if (self.fmt == VuFormat.OUTPUT):
+            self.add(delimiter)
+
+    def beginLink(self, link):
+        if (self.fmt == VuFormat.OUTPUT):
+            self.add('<<' + link + ',')
+
+    def endLink(self):
+        if (self.fmt == VuFormat.OUTPUT):
+            self.add('>>')
+
+    def addReference(self, tag, ref):
+        assert(self.fmt == VuFormat.OUTPUT)
+        self.add(tag)
+        self.add(ref)
+
+    def addOperator(self, op, preSpace = ' ', postSpace = ' '):
+        # Output: ` op `
+        self.add(preSpace)
+        self.beginStyle('vu-operator')
+        self.add(op)
+        self.endStyle()
+        self.add(postSpace)
+
+    def addNumber(self, num):
+        self.beginStyle('vu-number')
+        self.add(str(num))
+        self.endStyle()
+
+    def addKeyword(self, keyword, preSpace = '', postSpace = ' '):
+        # Output: `keyword `
+        self.add(preSpace)
+        self.beginStyle('vu-keyword')
+        self.add(keyword)
+        self.endStyle()
+        self.add(postSpace)
+
+    def addBuiltIn(self, builtin):
+        # Output: <<vu-builtin-name,[vu-builtin]#name#>>
+        self.beginStyle('vu-builtin')
+        self.beginLink('vu-builtin-' + builtin)
+        self.add(builtin)
+        self.endLink()
+        self.endStyle()
+
+    def addAPIToken(self, token, prefix):
+        self.add(prefix)
+        self.add(token)
+
+    def addBody(self, statements):
+        # Handle a list of statements, adding indentation appropriately
+        # Do not end the last line.  If nested, the parent body will end the
+        # line.
+        first = True
+        for statement in statements:
+            if not first:
+                self.endLine()
+            first = False
+
+            self.beginLine()
+            self.visit(statement)
+
+    # Map of op classes to their textual representation
+    opMap = {
+        # Found in BoolOp
+        ast.And: 'and',
+        ast.Or: 'or',
+        # Found in BinOp
+        ast.Add: '+',
+        ast.Sub: '-',
+        ast.Mult: '*',
+        ast.MatMult: '@',
+        ast.Div: '/',
+        ast.Mod: '%',
+        ast.Pow: '**',
+        ast.LShift: '<<',
+        ast.RShift: '>>',
+        ast.BitOr: '|',
+        ast.BitXor: '^',
+        ast.BitAnd: '&',
+        ast.FloorDiv: '//',
+        # Found in UnaryOp
+        ast.Invert: '~',
+        ast.Not: 'not',
+        ast.UAdd: '+',
+        ast.USub: '-',
+        # Found in CompOp
+        ast.Eq: '==',
+        ast.NotEq: '!=',
+        ast.Lt: '<',
+        ast.LtE: '<=',
+        ast.Gt: '>',
+        ast.GtE: '>=',
+        ast.Is: 'is',
+        ast.IsNot: 'is not',
+        ast.In: 'in',
+        ast.NotIn: 'not in',
+    }
+
+    def addMaybeParentheses(self, value, needsParentheses):
+        if needsParentheses:
+            self.beginParenthesis()
+
+        self.visit(value)
+
+        if needsParentheses:
+            self.endParenthesis()
+
+    def addParenthesizedExpression(self, value):
+        # Add parentheses around value unless obviously unnecessary.  This
+        # function is called when `value` is used in another expression with an
+        # operator, and operator priorities would change the expression if not
+        # parenthesized.
+        #
+        # Note that BoolOp is currently always parenthesized.
+        needsParentheses = value.__class__ not in [ast.Call, ast.Attribute,
+                                                   ast.Subscript, ast.Name,
+                                                   ast.Constant, ast.BoolOp]
+        if needsParentheses and value.__class__ == ast.UnaryOp:
+            needsParentheses = value.op.__class__ == ast.Not
+
+        self.addMaybeParentheses(value, needsParentheses)
+
+    def addBinaryExpression(self, left, op, right):
+        # Output: left op right
+        #
+        # This function deals with parenthesization based on operator
+        # priorities.  In some cases, no parenthesization is needed if left or
+        # right are also binary operators with the same op (like +).  In some
+        # cases, parenthesization is still necessary (like ==).
+        #
+        # For simplicity, this function is not avoiding parentheses according
+        # to complex rules, but rather only handles what can be found in VUs:
+        #
+        #   (a +,- b) +,- c
+        #   (a *,/,% b) +,-,*,/,% c
+        #   a +,- (c *,/,% d)
+        #   binary compare binary
+        #   TODO: add more as they are encountered
+        #
+        # Note that python parses a + b + c (and similar) as (a + b) + c, so
+        # it is only the left node is checked for those expressions.
+        #
+        # Note also that all binary operators have a smaller precedence than
+        # compare operators.
+        #
+        # If necessary, the ast.unparse implementation in Python has generic
+        # operator-priority-based code that can be used.
+        leftOp = left.op if isinstance(left, ast.BinOp) else None
+        rightOp = right.op if isinstance(right, ast.BinOp) else None
+
+        parenthesizeLeftOp = True
+        parenthesizeRightOp = True
+
+        # Same priority arithmetic ops nested under - and +
+        if (op.__class__ in [ast.Add ,ast.Sub] and
+              leftOp.__class__ in [ast.Add, ast.Sub]):
+            parenthesizeLeftOp = False
+        # Higher or same priority arithmetic ops nested under +, -, *, / and %
+        if (op.__class__ in [ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod] and
+            leftOp.__class__ in [ast.Mult, ast.Div, ast.Mod]):
+            parenthesizeLeftOp = False
+
+        # Higher priority arithmetic ops nested under + and - on the right
+        if (op.__class__ in [ast.Add, ast.Sub] and
+            rightOp.__class__ in [ast.Mult, ast.Div, ast.Mod]):
+            parenthesizeRightOp = False
+
+        # Binary operator nested under compare operator
+        opIsCompare = op.__class__ in [ast.Eq, ast.NotEq, ast.Lt, ast.LtE,
+                                       ast.Gt, ast.GtE]
+        if opIsCompare and isinstance(left, ast.BinOp):
+            parenthesizeLeftOp = False
+        if opIsCompare and isinstance(right, ast.BinOp):
+            parenthesizeRightOp = False
+
+
+        if parenthesizeLeftOp:
+            self.addParenthesizedExpression(left)
+        else:
+            self.visit(left)
+
+        opText = self.opMap[op.__class__]
+        self.addOperator(opText)
+
+        if parenthesizeRightOp:
+            self.addParenthesizedExpression(right)
+        else:
+            self.visit(right)
+
+
+    # AST nodes of class ast.Foo are handled by the visit_Foo function.
+    # Not all AST nodes are handled as they are not used in VUs, e.g.
+    # ast.Yield or ast.ClassDef.
+    #
+    # Please refer to the ast module reference at:
+    # https://docs.python.org/3/library/ast.html
+
+    def visit_Module(self, node):
+        # Output: Each statement on a new line
+        self.addBody(node.body)
+
+    def visit_Assign(self, node):
+        # Verified by VuVerifier
+        assert(len(node.targets) == 1)
+
+        # Output: target = value
+        self.visit(node.targets[0])
+        self.addOperator('=')
+        self.visit(node.value)
+
+    def visit_If(self, node):
+        # Output: if test:
+        #            body
+        self.addKeyword('if')
+        self.visit(node.test)
+
+        self.beginScope()
+        self.addBody(node.body)
+        self.endScope()
+
+    def visit_For(self, node):
+        # Output: for target in iter:
+        #            body
+        self.addKeyword('for')
+        self.visit(node.target)
+        self.addOperator('in')
+        self.visit(node.iter)
+
+        self.beginScope()
+        self.addBody(node.body)
+        self.endScope()
+
+    def visit_While(self, node):
+        # Output: while test:
+        #             body
+        #
+        # Note: implemented to have more coverage, but unlikely to be used by VUs
+        self.addKeyword('while')
+        self.visit(node.test)
+
+        self.beginScope()
+        self.addBody(node.body)
+        self.endScope()
+
+    def visit_Break(self, node):
+        # Note: implemented to have more coverage, but unlikely to be used by VUs
+        self.addKeyword('break', postSpace = '')
+
+    def visit_Continue(self, node):
+        # Note: implemented to have more coverage, but unlikely to be used by VUs
+        self.addKeyword('continue', postSpace = '')
+
+    def visit_BoolOp(self, node):
+        # Output: (values[0] op
+        #          values[1] op
+        #          ...)
+
+        # Handle parenthesization and line breaks.  Bool operations are always
+        # parenthesized because in practice conditions in VUs end up quite
+        # lengthy.  This also simplifies the logic a bit.
+        opText = self.opMap[node.op.__class__]
+
+        self.beginParenthesis()
+
+        assert(len(node.values) > 1)
+
+        first = True
+        for value in node.values:
+            # Add the operator and break the line.  The expression would look
+            # like:
+            #
+            # (values[0] op
+            #  values[1] op
+            #  values[2])
+            if not first:
+                self.addOperator(opText, postSpace = '')
+                self.endLine()
+                self.beginLine()
+            first = False
+
+            # Of supported nodes, only IfExp has lower priority than boolean
+            # expressions, so parenthesize those.
+            needsParentheses = isinstance(value, ast.IfExp)
+            self.addMaybeParentheses(value, needsParentheses)
+
+        self.endParenthesis()
+
+
+    def visit_UnaryOp(self, node):
+        # Output: opoperand
+        # For `not`, output `not operand`
+        postSpace = ' ' if isinstance(node.op, ast.Not) else ''
+        opText = self.opMap[node.op.__class__]
+        self.addOperator(opText, preSpace = '', postSpace = postSpace)
+        self.addParenthesizedExpression(node.operand)
+
+    def visit_BinOp(self, node):
+        self.addBinaryExpression(node.left, node.op, node.right);
+
+    def visit_Compare(self, node):
+        assert(len(node.ops) == 1)
+        self.addBinaryExpression(node.left, node.ops[0], node.comparators[0]);
+
+    def visit_Call(self, node):
+        # Output: func(arg, arg, ...)
+        #
+        # Builtin function calls do not accept complex boolean arguments, except
+        # for `require`.  Since boolean arguments unconditionally get
+        # parenthesized, parentheses are not added here for `require(BoolOp)`.
+        # For now, this is the simpler method to avoid double parenthesization.
+        self.visit(node.func)
+
+        argumentIsParenthesized = (len(node.args) == 1 and
+                                   isinstance(node.args[0], ast.BoolOp))
+
+        if not argumentIsParenthesized:
+            self.beginParenthesis()
+
+        first = True
+        for arg in node.args:
+            if not first:
+                self.add(', ')
+            first = False
+
+            self.visit(arg)
+
+        if not argumentIsParenthesized:
+            self.endParenthesis()
+
+    def visit_Attribute(self, node):
+        # Output: value.attr
+        self.visit(node.value)
+        self.add('.')
+
+        # If it is a builtin, make a link to the reference.
+        if node.attr in ATTR_BUILTINS.keys():
+            self.addBuiltIn(node.attr)
+        else:
+            self.add(node.attr)
+
+    def visit_Subscript(self, node):
+        # Output: value[slice]
+        self.visit(node.value)
+        self.add('[')
+        self.visit(node.slice)
+        self.add(']')
+
+    def visit_IfExp(self, node):
+        # Output: body if test else orelse
+        self.visit(node.body)
+        self.addKeyword('if', preSpace = ' ')
+        self.visit(node.test)
+        self.addKeyword('else', preSpace = ' ')
+        self.visit(node.orelse)
+
+    def visit_Constant(self, node):
+        # Output: [vu-number]#value#
+        self.beginStyle('vu-number')
+        if isinstance(node.value, str):
+            self.add("'" + node.value + "'")
+        else:
+            self.add(str(node.value))
+        self.endStyle()
+
+    def visit_Name(self, node):
+        # If it is a builtin, make a link to the reference.
+        if node.id in FUNC_BUILTINS.keys():
+            # Make sure `macro()` never makes it to the output.
+            if self.fmt == VuFormat.OUTPUT:
+                assert(node.id != 'macro')
+
+            self.addBuiltIn(node.id)
+            return
+
+        # If it is an API entity, add the appropriate prefix such as slink: etc.
+        # Otherwise outputting it plainly is sufficient.  No need for pname: on
+        # members, function arguments etc, as the VU is already rendered in
+        # monospace.
+        if (self.fmt == VuFormat.OUTPUT):
+            entity = self.entity_db.findEntity(node.id)
+            if entity is None or entity.macro is None:
+                self.add(node.id)
+            else:
+                self.addReference(entity.macro + ':', node.id)
+        else:
+            self.add(node.id)
+
+    # Although unsupported, the following are also output correctly for the
+    # sake of VuVerifier.  When the expression is invalid, it will output why
+    # and would need the expression formatted well.
+    def visit_Tuple(self, node):
+        delimiter = '('
+        for elt in node.elts:
+            self.add(delimiter)
+            delimiter = ', '
+            self.visit(elt)
+        self.add(')')
+
+    def visit_List(self, node):
+        delimiter = '['
+        for elt in node.elts:
+            self.add(delimiter)
+            delimiter = ', '
+            self.visit(elt)
+        self.add(']')
+
+
+class VuTypeExtractor:
+    """Helper class to extract types out of symbols used in the VU.  Used for
+    type checking and code generation."""
+    def __init__(self, entity_db, api):
+        self.entity_db = entity_db
+        self.api = api
+
+    def getSymbolType(self, symbol):
+        """Called on a symbol that needs identification.  Not called on
+        builtsin, lhs of assignments or loop variables"""
+        if symbol == 'NULL':
+            return VuType(VuTypeClass.VOID, '', 1)
+
+        if symbol == 'VK_NULL_HANDLE':
+            return VuType(VuTypeClass.HANDLE, 'VK_NULL_HANDLE')
+
+        # The symbol could be a member of the API entity (if struct) or a
+        # function argument of it (if command).
+        memberType = self.getMemberOrArgumentSymbolType(self.api, symbol)
+        if memberType is not None:
+            return memberType
+
+        # The symbol could also be an API token such as a struct name or enum.
+        return self.getAPIType(symbol)
+
+    def getMemberOrArgumentSymbolType(self, api, symbol):
+        """Get the type of a struct member or function field."""
+        # For the specific case of 'VkPipelineCreateInfo' and 'flags', use any
+        # of the real Vk*PipelineCreateInfo types.  They all have flags.  This
+        # is by far the most common use case of pipeline.create_info(), so it
+        # is nice to support that without resorting to graphics_create_info()
+        # etc.
+        if api == 'VkPipelineCreateInfo' and symbol == 'flags':
+            api = 'VkGraphicsPipelineCreateInfo'
+        members = self.entity_db.getMemberElems(api)
+        if members is None:
+            logWarn('Invalid API name', api)
+            if api == 'VkPipelineCreateInfo':
+                logWarn('Use graphics_create_info, compute_create_info or raytracing_create_info for pipelines')
+            return None
+
+        for member in members:
+            name = util.getElemName(member)
+            if symbol == name:
+                return self.getMemberType(member)
+
+        # If no members, check to see if this is an alias
+        entity = self.entity_db.findEntity(api)
+        if entity is not None:
+            alias = entity.elem.get('alias')
+            if alias:
+                return self.getMemberOrArgumentSymbolType(alias, symbol)
+
+        # VU contains an unrecognized symbol
+        return None
+
+    def getMemberType(self, elem):
+        """Get the type of a struct field or function argument."""
+        typeStr = util.getElemType(elem)
+        nameTail = elem.find('name').tail.strip() if elem.find('name').tail is not None else ''
+        typeTail = elem.find('type').tail.strip()
+
+        pointerLevel = 0
+        arrayLen = elem.attrib.get('len')
+
+        # Handle fixed sized arrays like
+        # <member limittype="noauto"><type>char</type> <name>deviceName</name>[<enum>VK_MAX_PHYSICAL_DEVICE_NAME_SIZE</enum>]</member>
+        if arrayLen is None and nameTail != '' and nameTail[0] == '[':
+            arrayLen = elem.find('enum').text
+            pointerLevel = 1
+
+        # typeTail can contain * to specify a pointer type.
+        if '*' in typeTail:
+            # Note that non * characters can exist too, for example like `* const *`
+            pointerLevel += typeTail.count('*')
+
+        # Find the class type.
+        apiType = self.getAPIType(typeStr)
+        typeClass = VuTypeClass.VOID
+
+        if apiType is not None:
+            typeClass = apiType.typeClass
+
+            # A member is not a struct 'name', but an actual struct
+            # The distinction helps elsewhere make sure a type name is not used
+            # where an instance of the type is expected.
+            if typeClass == VuTypeClass.STRUCT_NAME:
+                typeClass = VuTypeClass.STRUCT
+
+        return VuType(typeClass, typeStr, pointerLevel, arrayLen)
+
+    def getAPIType(self, name):
+        numTypes = ['char', 'float', 'double', 'int8_t', 'uint8_t', 'int16_t',
+                    'uint16_t', 'uint32_t', 'uint64_t', 'int32_t', 'int64_t',
+                    'size_t', 'int', 'VkBool32', 'VkDeviceSize',
+                    'VkDeviceAddress']
+        if name in numTypes:
+            return VuType(VuTypeClass.NUM, name)
+
+        if name in ['VkSampleMask', 'VkFlags', 'VkFlags64']:
+            return VuType(VuTypeClass.BITMASK, name)
+
+        entity = self.entity_db.findEntity(name)
+        if entity is None:
+            return None
+
+        classMap = {'flags': VuTypeClass.BITMASK,
+                    'enumvalues': VuTypeClass.ENUM,
+                    'handles': VuTypeClass.HANDLE,
+                    'basetypes': VuTypeClass.HANDLE,
+                    'structs': VuTypeClass.STRUCT_NAME,
+                    'enums': VuTypeClass.ENUM,
+                    'extension': VuTypeClass.EXTENSION_NAME,
+                    'code': VuTypeClass.VOID,
+        }
+
+        typeClass = classMap[entity.category]
+        if typeClass is None:
+            return None
+
+        # Extensions do not have a type an the XML
+        if typeClass == VuTypeClass.EXTENSION_NAME:
+            return VuType(typeClass, name)
+
+        # if one of API Constants, it is considered an enum in XML, while it is
+        # really just a number.
+        if entity.category == 'enumvalues':
+            constantType = util.getElemType(entity.elem)
+            if constantType in numTypes:
+                return VuType(VuTypeClass.NUM, constantType)
+
+        # If an enum value, we are more interested in its real type, but
+        # unfortunately that is not efficiently available at the moment.  For
+        # example, for VK_IMAGE_TYPE_1D, we would ideally change the typeStr to
+        # VkImageType.
+
+        return VuType(typeClass, name)
+
+    # Evaluate the type of array[index]
+    def getIndexedArrayType(self, arrayType):
+        # Reduce one pointer level.  If VU has errors (and subscripts a
+        # non-pointer), an error is generated but guard against it here so
+        # compilation can continue.
+        pointerLevel = max(arrayType.pointerLevel - 1, 0)
+        # Note: 2D arrays are rare in the spec, and they do not specify the
+        # length of the inner dimensions.  This needs to be fixed.
+        arrayLen = None if pointerLevel == 0 else 'UNSPECIFIED'
+        return VuType(arrayType.typeClass, arrayType.typeStr, pointerLevel, arrayLen)
+
+    # Evaluate the type of a.b
+    def getStructAttributeType(self, objectType, fieldName):
+        return self.getMemberOrArgumentSymbolType(objectType.typeStr, fieldName)
+
+    # Determine whether enum value belongs to enum type:
+    def isValueOfEnum(self, enumType, valueType):
+        """Test whether VK_FOO is an enum in VkFoo."""
+        assert(enumType.typeClass in [VuTypeClass.ENUM, VuTypeClass.BITMASK])
+        assert(valueType.typeClass == VuTypeClass.ENUM)
+        assert('_' not in enumType.typeStr)
+        assert('_' in valueType.typeStr)
+
+        # TODO: Currently, entity_db does not seem to have enough info to
+        # answer this.
+        return True
+
+    def getBitmaskBitsType(self, bitmaskType):
+        """Get the VkFooFlagBits type from VkFooFlags."""
+        entity = self.entity_db.findEntity(bitmaskType.typeStr)
+        if entity is None:
+            return bitmaskType
+
+        if entity.category != 'flags':
+            return bitmaskType
+
+        bitsType = entity.elem.attrib.get('requires')
+        if bitsType is None:
+            return bitmaskType
+
+        return VuType(VuTypeClass.BITMASK, bitsType, bitmaskType.pointerLevel, bitmaskType.arrayLen)
+
+        #if bitmaskType[-5:] != 'Flags':
+        #    return None
+
+        # TODO: Find a way to extract this from the xml
+        #return self.getAPIType(bitMaskType[:-5] + 'FlagBits')
+
+
+class VuVerifier(ast.NodeVisitor):
+    """Verify that the VU is semantically valid"""
+    def __init__(self, entity_db, api, filename, fileline):
+        self.entity_db = entity_db
+        self.api = api
+
+        self.typeExtractor = VuTypeExtractor(entity_db, api)
+        """Helper to extract types out of symbols."""
+
+        self.filename = filename
+        self.fileline = fileline
+        """Location of VU."""
+
+        self.passed = False
+        """Whether verification passed."""
+
+        self.requireSeen = False
+        """Whether the require() call was seen."""
+
+        self.variableTypeMap = {}
+        """A simple name->VuType map.  Scoping is not taken into account for
+        simplicity."""
+
+        self.loopVariableSet = set()
+        """A simple set of names of loop variables.  Scoping is not taken into
+        account for simplicity."""
+
+    def formatNode(self, node):
+        formatter = VuFormatter(self.entity_db, VuFormat.SOURCE, self.filename, self.fileline)
+        return formatter.format(node, isWholeTree = False)
+
+    def fail(self, nodes, *args):
+        logWarn(self.filename + ':' + str(self.fileline) + ':', *args)
+        # Output the offending node.  Indent it by 4 spaces + 7 for 'WARN:  '
+        # as added by logWarn.  Remove 7 spaces from the indentation of the
+        # first line (because of the WARN: tag, so it aligns with the lines
+        # below it, if any.
+        def formatForLog(expression):
+            return '\n'.join([''.ljust(11) + line for line in
+                              expression.splitlines()])
+
+        formatted = formatForLog(self.formatNode(nodes[0]))[7:]
+        for node in nodes[1:]:
+            formatted += '\n' + ''.ljust(7) + 'vs\n'
+            formatted += formatForLog(self.formatNode(node))
+        logWarn(formatted)
+        self.passed = False
+
+    def verify(self, ast):
+        self.passed = True
+        self.visit(ast)
+        if not self.requireSeen:
+            self.fail([ast], 'VUs must contain at least one require()')
+        return self.passed
+
+    def onRequireVisited(self):
+        # Rembmer that require is visited.  If it is never seen, that is an
+        # error.  Currently, more than one require can be present, but if that
+        # is to be constrained, an error can be generated here, as well as in
+        # visitBody() to make sure there are no statements after a require().
+        self.requireSeen = True
+
+    def visitBody(self, body):
+        for statement in body:
+            self.visit(statement)
+
+    def visit_Assign(self, node):
+        # Verify that there are not multiple assignments (like a = b = c).
+        if len(node.targets) != 1:
+            self.fail([node.targets[0], node.targets[1]], 'Cascaded assignments are not allowed')
+        # Verify that the target of assignment is a single variable.
+        if not isinstance(node.targets[0], ast.Name):
+            self.fail([node.targets[0]], 'Assignment target must be a single variable')
+            return
+        # Verify that the target is not an API entity
+        if self.entity_db.findEntity(node.targets[0].id) is not None:
+            self.fail([node.targets[0]], 'Invalid assignment to API token')
+        # Verify that the target is not a member/argument of the API being defined
+        elif self.typeExtractor.getSymbolType(node.targets[0].id) is not None:
+            self.fail([node.targets[0]], 'Invalid assignment to VU parameter')
+        # Verify that the target is not a builtin
+        elif node.targets[0].id in FUNC_BUILTINS.keys() or node.targets[0].id in ATTR_BUILTINS.keys():
+            self.fail([node.targets[0]], 'Invalid assignment to builtin')
+
+        # Visit RHS first, and get its type.  It is assigned to the LHS
+        rhsType = self.visit(node.value)
+        self.variableTypeMap[node.targets[0].id] = rhsType
+
+    def visitCondition(self, testNode, context):
+        testType = self.visit(testNode)
+        if testType.pointerLevel != 0:
+            self.fail([testNode], 'Condition of ' + context + ' cannot be a pointer.  Use comparison with NULL')
+        elif testType.typeClass != VuTypeClass.BOOL:
+            self.fail([testNode], 'Condition of ' + context + ' must be boolean')
+        return testType
+
+    def visit_If(self, node):
+        # Verify that the test type is a boolean
+        self.visitCondition(node.test, 'if')
+        self.visitBody(node.body)
+
+    def visit_For(self, node):
+        # Verify that the loop target is a single variable
+        if not isinstance(node.target, ast.Name):
+            self.fail([node.target], 'Loop target must be a single variable')
+            return
+        # Verify that the loop iterator is not a list or tuple
+        if isinstance(node.iter, ast.Tuple) or isinstance(node.iter, ast.List):
+            self.fail([node.target], 'Loop iterator cannot be a list or tuple')
+            return
+
+        # Verify that the loop target is not a builtin
+        if node.target.id in FUNC_BUILTINS.keys() or node.target.id in ATTR_BUILTINS.keys():
+            self.fail([node.target], 'Loop target cannot have the name of a builtin')
+
+        # Verify that the loop iterator is an array
+        iterType = self.visit(node.iter)
+        if iterType.pointerLevel == 0 or iterType.arrayLen is None:
+            self.fail([node.iter], 'Loop iterator must be an array')
+
+        # Assign the iterator type (minus one array level) to the target
+        targetType = self.typeExtractor.getIndexedArrayType(iterType)
+        self.variableTypeMap[node.target.id] = targetType
+        self.loopVariableSet.add(node.target.id)
+
+        self.visitBody(node.body)
+
+    def visit_While(self, node):
+        # Verify that the test type is a boolean
+        self.visitCondition(node.test, 'while')
+        self.visitBody(node.body)
+
+    def visit_BoolOp(self, node):
+        # All values must be boolean too
+        for value in node.values:
+            valueType = self.visit(value)
+            if valueType.typeClass != VuTypeClass.BOOL:
+                self.fail([value], 'Parameter of boolean operation must be boolean')
+            if valueType.pointerLevel != 0:
+                self.fail([value], 'Parameter of boolean operation cannot be a pointer.  Use comparison with NULL')
+        return BOOL_TYPE
+
+    def visit_UnaryOp(self, node):
+        operandType = self.visit(node.operand)
+        if operandType.pointerLevel != 0:
+            self.fail([node.operand], 'Operand of unary operation cannot be a pointer.  Use comparison with NULL')
+
+        # Operand of not must be a boolean
+        if isinstance(node.op, ast.Not):
+            if operandType.typeClass != VuTypeClass.BOOL:
+                self.fail([node.operand], 'Operand of `not` must be boolean')
+            return BOOL_TYPE
+
+        # Operand of ~ must be a bitmask
+        if isinstance(node.op, ast.Invert):
+            if operandType.typeClass != VuTypeClass.BITMASK:
+                self.fail([node.operand], 'Operand of `~` must be a bitmask')
+                return BITMASK_TYPE
+            else:
+                return operandType
+
+        # Operand of + and - must be a number
+        assert(isinstance(node.op, ast.UAdd) or isinstance(node.op, ast.USub))
+
+        if operandType.typeClass != VuTypeClass.NUM:
+            self.fail([node.operand], 'Operand of unary `+`/`-` must be a number')
+        return NUM_TYPE
+
+    def doEnumTypesMatch(self, leftType, rightType):
+        # Support matching the following:
+        #
+        # VK_FOO and VK_BAR
+        # VkFoo and VK_FOO
+        # VkFooFlags and VKFooFlagBits
+        # VkFooFlags and VK_FOO_BIT
+
+        assert(leftType.typeClass in [VuTypeClass.ENUM, VuTypeClass.BITMASK])
+        assert(rightType.typeClass in [VuTypeClass.ENUM, VuTypeClass.BITMASK])
+        if leftType.typeStr == rightType.typeStr:
+            return True
+
+        # Simplify VkFooFlags to VkFooFlagBits
+        if leftType.typeClass == VuTypeClass.BITMASK:
+            leftType = self.typeExtractor.getBitmaskBitsType(leftType)
+        if rightType.typeClass == VuTypeClass.BITMASK:
+            rightType = self.typeExtractor.getBitmaskBitsType(rightType)
+
+        # If both are bitfields, they should match in type exactly
+        if (leftType.typeClass == VuTypeClass.BITMASK and
+            rightType.typeClass == VuTypeClass.BITMASK):
+            return leftType.typeStr == rightType.typeStr
+
+        # One must be in the form VkFoo and another VK_FOO
+        enumType, valueType = leftType, rightType
+        if '_' in leftType.typeStr:
+            enumType, valueType = rightType, leftType
+
+        return self.typeExtractor.isValueOfEnum(enumType, valueType)
+
+    def doHandleTypesMatch(self, leftType, rightType):
+        assert(leftType.typeClass == rightType.typeClass == VuTypeClass.HANDLE)
+        if leftType.typeStr == rightType.typeStr:
+            return True
+
+        # Match handle types if one of them is VK_NULL_HANDLE
+        return leftType.typeStr == 'VK_NULL_HANDLE' or rightType.typeStr == 'VK_NULL_HANDLE'
+
+    def doBaseTypesMatch(self, leftType, rightType, requireTypeNameMatch):
+        # Disregarding pointer levels, check whether base types match
+
+        # Bitfields and enums may need to match, if enum is a member of the bitfield type.
+        if requireTypeNameMatch:
+            if (leftType.typeClass in [VuTypeClass.ENUM, VuTypeClass.BITMASK] and
+                rightType.typeClass in [VuTypeClass.ENUM, VuTypeClass.BITMASK]):
+                return self.doEnumTypesMatch(leftType, rightType)
+
+        # For other types, the class should always match
+        if leftType.typeClass != rightType.typeClass:
+            return False
+
+        # For structs and handles, make sure their API type also matches.
+        if requireTypeNameMatch:
+            if leftType.typeClass == VuTypeClass.STRUCT:
+                return leftType.typeStr == rightType.typeStr
+            elif leftType.typeClass == VuTypeClass.HANDLE:
+                # For handles, we should allow VK_NULL_HANDLE
+                return self.doHandleTypesMatch(leftType, rightType)
+
+        return True
+
+    def doTypesMatch(self, leftType, rightType, requireTypeNameMatch = True):
+        # For non-pointer types, they should match by type class only
+        if leftType.pointerLevel == 0 and rightType.pointerLevel == 0:
+            return self.doBaseTypesMatch(leftType, rightType, requireTypeNameMatch)
+
+        leftPointerLevel = leftType.pointerLevel
+        rightPointerLevel = rightType.pointerLevel
+        if leftType.typeClass == VuTypeClass.VOID and rightPointerLevel > 0:
+            leftPointerLevel = rightPointerLevel
+        elif rightType.typeClass == VuTypeClass.VOID and leftPointerLevel > 0:
+            rightPointerLevel = leftPointerLevel
+
+        # Make sure pointer and non-pointer (or pointer to pointer) types do not
+        # match
+        if leftPointerLevel != rightPointerLevel:
+            return False
+
+        # Verify that pointer types match (allowing void* to match anything)
+        return (leftType.typeClass == VuTypeClass.VOID or
+                rightType.typeClass == VuTypeClass.VOID or
+                self.doBaseTypesMatch(leftType, rightType, requireTypeNameMatch))
+
+    def visitBinaryCompareOperand(self, left, op, right):
+        leftType = self.visit(left)
+        rightType = self.visit(right)
+        isEqualityCheck = op.__class__ in [ast.Eq, ast.NotEq]
+
+        if not isEqualityCheck:
+            if leftType.pointerLevel != 0:
+                self.fail([left], 'Operand of binary operation cannot be a pointer.  Use comparison with NULL')
+            if rightType.pointerLevel != 0:
+                self.fail([right], 'Operand of binary operation cannot be a pointer.  Use comparison with NULL')
+
+        if isEqualityCheck:
+            if not self.doTypesMatch(leftType, rightType):
+                self.fail([left, right], 'Operands of `==` and `!=` must have matching types')
+            return BOOL_TYPE
+
+        if op.__class__ in [ast.Add, ast.Sub, ast.Mult, ast.MatMult, ast.Div,
+                            ast.Mod, ast.Pow, ast.FloorDiv]:
+            if leftType.typeClass != VuTypeClass.NUM:
+                self.fail([left], 'Operands of arithmetic operations must be numbers')
+            if rightType.typeClass != VuTypeClass.NUM:
+                self.fail([right], 'Operands of arithmetic operations must be numbers')
+            return NUM_TYPE
+
+        if op.__class__ in [ast.Lt, ast.LtE, ast.Gt, ast.GtE]:
+            if leftType.typeClass != VuTypeClass.NUM:
+                self.fail([left], 'Operands of comparison operations must be numbers')
+            if rightType.typeClass != VuTypeClass.NUM:
+                self.fail([right], 'Operands of comparison operations must be numbers')
+            return BOOL_TYPE
+
+        if op.__class__ in [ast.LShift, ast.RShift]:
+            if leftType.typeClass != VuTypeClass.NUM:
+                self.fail([left], 'Operands of shift operations must be numbers')
+            if rightType.typeClass != VuTypeClass.NUM:
+                self.fail([right], 'Operands of shift operations must be numbers')
+            return NUM_TYPE
+
+        if op.__class__ in [ast.BitOr, ast.BitXor, ast.BitAnd]:
+            leftIsBitMask = leftType.typeClass == VuTypeClass.BITMASK
+            rightIsBitMask = rightType.typeClass == VuTypeClass.BITMASK
+            if not leftIsBitMask:
+                self.fail([left], 'Operands of bitwise operations must be bitmasks')
+            if not rightIsBitMask:
+                self.fail([right], 'Operands of bitwise operations must be bitmasks')
+            if leftIsBitMask and rightIsBitMask and not self.doTypesMatch(leftType, rightType):
+                self.fail([left, right], 'Operands of bitwise operations must have matching types')
+
+            return leftType if leftIsBitMask else rightType if rightIsBitMask else BITMASK_TYPE
+
+        # Verify that is, is not, in, and not in are not used in VUs.
+        # Currently there is no need for them.
+        assert(op.__class__ in [ast.Is, ast.IsNot, ast.In, ast.NotIn])
+        self.fail([node], 'Unsupported binary operator is, is not, in, not in')
+        return BOOL_TYPE
+
+    def visit_BinOp(self, node):
+        return self.visitBinaryCompareOperand(node.left, node.op, node.right)
+
+    def visit_Compare(self, node):
+        # Verify that compares are binary (like a < b, not like a < b < c).
+        if len(node.ops) != 1:
+            self.fail([node.left] + node.comparators, 'Only binary comparisons are allowed')
+
+        return self.visitBinaryCompareOperand(node.left, node.ops[0], node.comparators[0])
+
+    def visit_Call(self, node):
+        # Only builtins can be called
+        funcType = None
+        objectType = None
+        builtinName = ''
+        if isinstance(node.func, ast.Name) and node.func.id in FUNC_BUILTINS.keys():
+            builtinName = node.func.id
+            funcType = FUNC_BUILTINS[builtinName]
+            if builtinName == 'require':
+                self.onRequireVisited()
+        elif isinstance(node.func, ast.Attribute) and node.func.attr in ATTR_BUILTINS.keys():
+            objectType = self.visit(node.func)
+            builtinName = node.func.attr
+            funcType = ATTR_BUILTINS[builtinName].funcType
+        else:
+            self.fail([node.func], 'Invalid function call.  If a builtin was intended, it is misspelled')
+            return VOID_TYPE
+
+        # Verify that the number of parameters is correct
+        if len(node.args) != len(funcType.argTypes):
+            self.fail([node.func], 'Invalid number of arguments passed to builtin')
+            return funcType.returnType
+
+        # Verify that arguments have the correct type
+        argTypes = []
+        for arg, expectedType in zip(node.args, funcType.argTypes):
+            argType = self.visit(arg)
+            argTypes.append(argType)
+
+            # If builtin argument type is VOID, it means it matches anything.
+            if expectedType.typeClass == VuTypeClass.VOID:
+                continue
+
+            if not self.doTypesMatch(argType, expectedType,
+                                     requireTypeNameMatch = False):
+                self.fail([arg], 'Mismatching type in argument to builtin', builtinName)
+                return funcType.returnType
+
+        # Some builtins require special attention.  For example,
+        # pnext(structName) should have the structName in the return type so
+        # members of it can be looked up.
+        returnType = funcType.returnType
+        if builtinName == 'pnext':
+            # The returned struct is of the type specified in the argument of this call
+            returnType = VuType(returnType.typeClass, node.args[0].id)
+        elif builtinName == 'create_info':
+            # The returned struct has the name of the handle type + CreateInfo
+            returnType = VuType(returnType.typeClass, objectType.typeStr + 'CreateInfo')
+        elif builtinName == 'graphics_create_info':
+            # Specialized create_info() to disambiguate VkPipeline
+            returnType = VuType(returnType.typeClass,
+                                objectType.typeStr[:2] + 'Graphics' + objectType.typeStr[2:] + 'CreateInfo')
+        elif builtinName == 'compute_create_info':
+            # Specialized create_info() to disambiguate VkPipeline
+            returnType = VuType(returnType.typeClass,
+                                objectType.typeStr[:2] + 'Compute' + objectType.typeStr[2:] + 'CreateInfo')
+        elif builtinName == 'raytracing_create_info':
+            # Specialized create_info() to disambiguate VkPipeline
+            returnType = VuType(returnType.typeClass,
+                                objectType.typeStr[:2] + 'RayTracing' + objectType.typeStr[2:] + 'CreateInfo')
+        elif builtinName == 'has_bit':
+            # has_bit accepts an enum value that must match the type of the
+            # object its being called on.  If object is not a bitmask,
+            # visit_Attribute has already generated an error.
+            if (objectType == VuTypeClass.BITMASK and
+                not self.doEnumTypesMatch(objectType, argTypes[0])):
+                self.fail([node.func.attr, node.args[0]], 'has_bit argument is not an enum value of the object it is called on')
+        elif builtinName == 'loop_index':
+            # Only loop variables may be passed to loop_index.
+            if not node.args[0].id in self.loopVariableSet:
+                self.fail([node.args[0]], 'loop_index argument is not a loop variable')
+
+        # Make sure every struct return value carries the name
+        assert(returnType.typeClass != VuTypeClass.STRUCT or returnType.typeStr != '')
+        return returnType
+
+    def visit_Attribute(self, node):
+        valueType = self.visit(node.value)
+
+        # Implicitly dereference pointers
+        valueType = VuType(valueType.typeClass, valueType.typeStr)
+
+        # If attr is a builtin, verify the value type based on the builtin requirements
+        if node.attr in ATTR_BUILTINS.keys():
+            builtinType = ATTR_BUILTINS[node.attr]
+
+            if not self.doTypesMatch(builtinType.objectType, valueType, requireTypeNameMatch = False):
+                self.fail([node.value], 'Invalid object type for attribute builtin', node.attr)
+
+            # Attribute builtin must be called.  The original object type is
+            # returned here which can be used by some builtins.
+            # visit_Call will make sure the return type is taken from the builtin.
+            return valueType
+
+        # Otherwise look up the member in the struct and return its type
+        if valueType.typeClass != VuTypeClass.STRUCT:
+            self.fail([node.value], 'Invalid use of . on non-struct object.  If a builtin was intended, it is misspelled')
+            return valueType
+
+        assert(valueType.typeStr != '')
+        fieldType = self.typeExtractor.getMemberOrArgumentSymbolType(valueType.typeStr, node.attr)
+        if fieldType is None:
+            self.fail([node.value], 'No such attribute', node.attr, 'in struct', valueType.typeStr)
+            return valueType
+
+        return fieldType
+
+    def visit_Subscript(self, node):
+        # Verify that subscripts are neither Tuples nor Slices.  Otherwise
+        # translation to C++ would be harder for VVL.
+        if isinstance(node.slice, ast.Tuple):
+            self.fail([node.value], 'Tuples in array subscripts are not supported')
+        if isinstance(node.slice, ast.Slice):
+            self.fail([node.value], 'Ranges in array subscripts are not supported')
+
+        valueType = self.visit(node.value)
+        sliceType = self.visit(node.slice)
+
+        # Verify that value is an array
+        if valueType.pointerLevel == 0 or valueType.arrayLen is None:
+            self.fail([node.value], 'Subscript only allowed on arrays')
+        # Verify that slice is a number
+        if sliceType.typeClass != VuTypeClass.NUM or sliceType.pointerLevel > 0:
+            self.fail([node.slice], 'Array subscript must be a number')
+
+        return self.typeExtractor.getIndexedArrayType(valueType)
+
+    def visit_IfExp(self, node):
+        # Verify that the test type is a boolean
+        self.visitCondition(node.test, 'ternary operator')
+
+        bodyType = self.visit(node.body)
+        orelseType = self.visit(node.orelse)
+        if not self.doTypesMatch(bodyType, orelseType):
+            self.fail([node.body, node.orelse], 'Expressions in ternary operator must have matching types')
+
+        # To support bitmask vs enum selection, return a bitmask if either is bitmask
+        orelseIsBitMask = orelseType.typeClass == VuTypeClass.BITMASK
+
+        return orelseType if orelseIsBitMask else bodyType
+
+    def visit_Constant(self, node):
+        if node.value.__class__ == bool:
+            return BOOL_TYPE
+        return NUM_TYPE
+
+    def visit_Name(self, node):
+        # Verify that builtins are not used as variables
+        if node.id in FUNC_BUILTINS.keys() or node.id in ATTR_BUILTINS.keys():
+            self.fail([node], 'Invalid usage of builtin as variable')
+            return VOID_TYPE
+
+        # If this is a variable being referenced, get the type from the variable map
+        if node.id in self.variableTypeMap.keys():
+            return self.variableTypeMap[node.id]
+
+        # See if this is a member/arg of the API for which validation is written.
+        nodeType = self.typeExtractor.getSymbolType(node.id)
+        if nodeType is None:
+            self.fail([node], 'Unknown token is neither an API token, or a member or argument of', self.api)
+            return VOID_TYPE
+
+        return nodeType
+
+class VuParametterTagExtractor(ast.NodeVisitor):
+    """A traverser that walks the AST and finds the first reference to a symbol
+    that is not otherwise defined.  This symbol must be referencing the
+    member/parameter of the API for which validation is written.
+
+    The AST is expected to be valid, i.e. has passed VuVerifier checks.  This
+    means that adding VUID tags may fail if the spec does not build."""
+    def __init__(self):
+        self.tag = None
+        """The tag that is extracted.  AST traversal stops once this is done."""
+
+        self.variableSet = set()
+        """Set of variables.  Used to know when referenced that they are not to
+        be matched as the VUID tag."""
+
+    def getTag(self, ast):
+        self.tag = None
+        self.visit(ast)
+        return self.tag
+
+    def visitBody(self, body):
+        for statement in body:
+            self.visit(statement)
+            if self.tag is not None:
+                break
+
+    def visit_Assign(self, node):
+        if self.tag is not None:
+            return
+
+        # Record the LHS as the variable, and traverse the RHS
+        self.variableSet.add(node.targets[0].id)
+        self.visit(node.value)
+
+    def visit_If(self, node):
+        if self.tag is not None:
+            return
+
+        self.visit(node.test)
+        self.visitBody(node.body)
+
+    def visit_For(self, node):
+        if self.tag is not None:
+            return
+
+        # Record the loop variable as such, and traverse the iterator and body
+        self.variableSet.add(node.target)
+        self.visit(node.iter)
+        self.visitBody(node.body)
+
+    def visit_While(self, node):
+        if self.tag is not None:
+            return
+
+        self.visit(node.test)
+        self.visitBody(node.body)
+
+    def visit_Call(self, node):
+        if self.tag is not None:
+            return
+
+        # Note: function arguments are never a member/parameter, except inside
+        # require and externally_synchronized.
+
+        if isinstance(node.func, ast.Name):
+            # If this is a macro, match the macro name as tag.  For existing
+            # VUs, this means that pname: must be removed from the macro value
+            # before the VU is reformatted to be codified.
+            if node.func.id == 'macro':
+                self.tag = '{' + node.args[0].id + '}'
+            elif node.func.id in ['require', 'externally_synchronized']:
+                self.visit(node.args[0])
+        else:
+            assert(isinstance(node.func, ast.Attribute))
+            # Check the object of the call
+            self.visit(node.func.value)
+
+    def visit_Attribute(self, node):
+        if self.tag is not None:
+            return
+
+        # Check only the object of the attribute, the attribute itself is not a
+        # member/parameter of the API being validated.
+        self.visit(node.value)
+
+    def visit_Name(self, node):
+        if self.tag is not None:
+            return
+
+        assert(node.id not in FUNC_BUILTINS.keys() and node.id not in ATTR_BUILTINS.keys())
+
+        # Do not match constants
+        if node.id.startswith('VK_'):
+            return
+
+        # There should be no references to the Vulkan structs and entry points
+        # outside builtin arguments, and those are not traversed.
+        assert(not node.id.startswith('vk'))
+        assert(not node.id.startswith('Vk'))
+
+        # Do not match variables
+        if node.id in self.variableSet:
+            return
+
+        # This must be a member or parameter, as it is otherwise undefined
+        self.tag = node.id
+
+
+class VuAST:
+    """The AST corresponding to a codified VU."""
+    def __init__(self):
+        self.vu = ''
+        """The vu text, ready to be parsed."""
+
+        self.vuIndent = 0
+        """How much indent was removed from VU.  This is used for adjusting the
+        offset in the error report."""
+
+        self.filename = ''
+        """The file name in which the VU appears."""
+
+        self.fileline = 0
+        """The line number of the VU."""
+
+        self.ast = None
+        """The AST corresponding to the VU text.  Macros are not expanded.
+        Used for source formatting."""
+
+        self.astExpanded = None
+        """The AST with macros expanded.  Used for correctness check and output
+        formatting."""
+
+        self.macros = {}
+        """A list of adoc macros to be replaced in the VU."""
+
+    def _parse(self, vu, message):
+        try:
+            return (ast.parse(vu, self.filename, 'exec'), True)
+        except SyntaxError as exc:
+            inVuLineNo = self.fileline + exc.lineno - 1
+            logPrefix = self.filename + ':' + str(inVuLineNo) + ':' + str(exc.offset + self.vuIndent) + ':'
+            logWarn(logPrefix, message + ': ', exc)
+
+            offendingLine = vu.splitlines()[exc.lineno - 1]
+            if exc.offset > 1:
+                offendingChar = ' ' * (exc.offset - 2) + '^'
+            else:
+                offendingChar = '^'
+            logWarn(logPrefix, '    ' + offendingLine)
+            logWarn(logPrefix, '    ' + offendingChar)
+
+            return (None, False)
+
+    def parse(self, vuText, filename, fileline):
+        self.filename = filename
+        self.fileline = fileline
+
+        # Parse the text
+        vuTextNoIndent, self.vuIndent = removeIndent(vuText.splitlines())
+        self.vu = '\n'.join(vuTextNoIndent)
+        #print(self.vu)
+        self.ast, result = self._parse(self.vu, 'VU parse error')
+        return result
+
+    def applyMacros(self, macros):
+        self.macros = convertMacrosToVuLanguage(macros)
+
+        # Parse the macro-expanded text as well
+        vuExpanded = expandVuMacros(self.vu, self.macros)
+
+        self.astExpanded, result = self._parse(vuExpanded, 'VU parse error (post macro expansion)')
+        return result
+
+    def verify(self, entity_db, api):
+        """Verify that the VU is semantically correct.  Must only be called
+        when macros have been expanded."""
+        #print(ast.dump(self.astExpanded, indent = ' '))
+        verifier = VuVerifier(entity_db, api, self.filename, self.fileline)
+        return verifier.verify(self.astExpanded)
+
+    def format(self, fmt, entity_db):
+        """Format the AST.
+
+        If given VuFormat.SOURCE, it will format it for placement in the adoc
+        file.  This uses the AST that contains macros.
+        If given VuFormat.OUTPUT, it will format it for build, using the AST
+        that has gone through macro expansion."""
+        assert(fmt == VuFormat.SOURCE or entity_db is not None)
+
+        ast = self.ast if fmt == VuFormat.SOURCE else self.astExpanded
+
+        formatter = VuFormatter(entity_db, fmt, self.filename, self.fileline)
+        return formatter.format(ast)
+
+    def getParameterTag(self):
+        """Find the first reference to a member/parameter of the API for which
+        validation is written."""
+        tagExtractor = VuParametterTagExtractor()
+        return tagExtractor.getTag(self.ast)
+
+def formatVU(vuParagraph, apiName, filename, fileline, vuPrefix, fmt, entity_db = None, macros = {}):
+    """Helper function to format a VU paragraph as soon in the spec text.  The
+    paragraph may contain a bullet point, a VUID tag etc."""
+    # Check if first line is VUID, if so remove it for reformatting
+    hasVUID = vuPrefix in vuParagraph[0]
+
+    toFormat = vuParagraph
+    vuid = ''
+    if hasVUID:
+        vuid = toFormat[0]
+        toFormat = toFormat[1:]
+        fileline += 1
+
+    toFormat = removeBulletPoint(toFormat)
+
+    # Record the indentation level of the VU to restore after formatting.
+    indent = len(toFormat[0]) - len(toFormat[0].lstrip())
+
+    # Parse and reformat the VU
+    vu = VuAST()
+    if not vu.parse('\n'.join(toFormat), filename, fileline):
+        logWarn('VU with parse error cannot be formatted')
+        accept = fmt == VuFormat.SOURCE
+        return vuParagraph, accept
+
+    # For output, additionally apply macros and validate the VU.
+    if fmt == VuFormat.OUTPUT:
+        if not vu.applyMacros(macros):
+            return vuParagraph, False
+        apiName = applyMacrosToApiName(macros, apiName)
+        if not vu.verify(entity_db, apiName):
+            return vuParagraph, False
+
+    formatted = vu.format(fmt, entity_db)
+
+    # Add the VUID back, if any
+    # Add indentation back
+    formatted = [''.ljust(indent) + line + '\n' for line in formatted.splitlines()]
+
+    if hasVUID:
+        formatted = [vuid] + formatted
+    else:
+        # Put back the bullet point
+        assert(indent >= 2)
+        formatted[0] = ''.ljust(indent - 2) + '* ' + formatted[0][indent:]
+
+    return formatted, True
+
+def determineVUIDParameterTag(vuParagraph, filename, fileline):
+    """Parse the tree and find the first reference to a member/parameter of the
+    API for which validation is written.  This is assuming the VU is written
+    correctly, as any otherwise-undefined symbol would have to implicitly
+    reference the VU API.
+
+    This is called when generating VUIDs, so vuParagraph cannot not have a VUID
+    already."""
+    vuParagraph = removeBulletPoint(vuParagraph)
+    vu = VuAST()
+    if not vu.parse('\n'.join(vuParagraph), filename, fileline):
+        logWarn('Cannot determine parameter tag in VU with parse error')
+        return 'None'
+
+    return vu.getParameterTag()

--- a/scripts/vupreprocessor.py
+++ b/scripts/vupreprocessor.py
@@ -1,0 +1,254 @@
+#!/usr/bin/python3
+#
+# Copyright 2023 The Khronos Group Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Used during build to preprocess VUs in chapter files.  In this process:
+
+- Non-VU text is passed through without modification
+- Current values of macros are recorded
+- VUs in prose are passed through without modification
+- Codified VUs are reformatted
+- Includes of commonvalidity/ files are recursively processed, taking macros
+  into account.  Each combination of macros produces a different output for the
+  commonvalidity file and includes are modified to the generated output.  The
+  include file is not inlined so build error lines meaningfully translate back
+  to the source.
+
+Usage: `vuprocessor.py -o outputpath [-stamp stampfile]`
+"""
+
+import argparse
+import os
+from pathlib import Path
+import sys
+
+from reflib import loadFile, resolveAndMkdir, logDiag, logWarn, logErr, setLogFile
+import doctransformer
+from check_spec_links import VulkanEntityDatabase
+from vuAST import isCodifiedVU, VuAST, VuFormat, formatVU
+
+from apiconventions import APIConventions
+conventions = APIConventions()
+
+
+class PreprocessCallbacks:
+    """State and arguments for preprocessing.
+
+    Used with DocTransformer to preprocess a file."""
+    def __init__(self,
+                 args,
+                 entity_db,
+                 filename,
+                 macros,
+                 commonvalidityDict):
+
+        self.entity_db = entity_db
+        self.args = args
+
+        self.inCommonValidityPath = os.path.join(args.inpath, 'commonvalidity')
+        """Base path to commonvalidity input."""
+
+        self.outCommonValidityPath = resolveAndMkdir(os.path.join(args.outpath, 'commonvalidity'))
+        """Base path to commonvalidity output."""
+
+        self.filename = filename
+        """Base name of file being read from."""
+
+        self.vuPrefix = 'VUID'
+        """Prefix of generated Valid Usage tags."""
+
+        # Prime the macro dictionary from the input values if any, but do not
+        # let it be modified out of the scope of this file.
+        self.macros = dict(macros)
+        """Dictionary of current macro values."""
+
+        self.commonvalidityDict = commonvalidityDict
+        """Common validity files need to be processed once per unique set of
+        macros that may affect them.  Assuming
+
+            ValidityOutputMap = map of macro -> unique id
+
+        This is a map of commonvalidity filename -> ValidityOutputMap
+
+        Common validity files are then processed after the chapters."""
+
+        self.passed = True
+        """Whether preprocessing was successful.  If codified VUs have errors,
+        this will make sure the build fails."""
+
+    def transformParagraph(self, para, state):
+        # Pass through all non-VU paragraphs
+        if not state.isVU:
+            return para
+
+        # Pass through all VUs written in prose
+        if not isCodifiedVU(para[1:] if self.vuPrefix in para[0] else para):
+            return para
+
+        # Reformat the VU
+        formatted, passed = formatVU(para, state.apiName, self.filename,
+                                           state.lineNumber, self.vuPrefix,
+                                           VuFormat.OUTPUT, self.entity_db,
+                                           self.macros)
+        if not passed:
+            self.passed = False
+            return para
+
+        return formatted
+
+    def getCommonValidityUniqueId(self, commonvalidityFilename):
+        """Check if map[filename][macros] exists.  If so, return it and
+        indicate that this combination is previously processed.  Otherwise, a
+        new id is assigned to this combination and returned."""
+        if commonvalidityFilename not in self.commonvalidityDict:
+            self.commonvalidityDict[commonvalidityFilename] = {}
+
+        macroDict = self.commonvalidityDict[commonvalidityFilename]
+        macroKey = str(sorted(self.macros.items()))
+        if macroKey in macroDict:
+            return macroDict[macroKey], False
+
+        # Note that due to `refpage` being different for every api token, this
+        # is path is currently always hit.  `refpage` does affect VU
+        # verification, so it should not be removed.
+        uniqueId = len(macroDict)
+        macroDict[macroKey] = uniqueId
+        return uniqueId, True
+
+    def transformInclude(self, line, state):
+        # Check to see if this is in the form:
+        #     include::{chapters}/commonvalidity/<foo>.adoc[]
+        #
+        # If so, extract foo, get an id from commonvalidityDict and if it is
+        # new, recursively preprocess <foo>.adoc.
+        commonvalidityInclude = 'include::{chapters}/commonvalidity/'
+        commonvalidityIncludeEnd = '[]'
+        if not line.startswith(commonvalidityInclude):
+            return line
+
+        assert(line.rstrip().endswith(commonvalidityIncludeEnd))
+        inFilename = line.rstrip()[len(commonvalidityInclude):-len(commonvalidityIncludeEnd)]
+        assert(inFilename.endswith(conventions.file_suffix))
+
+        # Check whether this combination of file+macros was previously
+        # processed.
+        uniqueId, isNew = self.getCommonValidityUniqueId(inFilename)
+        outFilename = (inFilename[:-len(conventions.file_suffix)] +
+                       '_' + str(uniqueId) + conventions.file_suffix)
+
+        # Change the line to include the id tag to make the processed file
+        # unique for each set of macros.
+        line = commonvalidityInclude + outFilename + commonvalidityIncludeEnd + '\n'
+
+        # If new, recursively process the commonvalidity file
+        if isNew:
+            # Note: commonvalidity/ currently does not have subdirs
+            infile = os.path.join(self.inCommonValidityPath, inFilename)
+            outfile = os.path.join(self.outCommonValidityPath, outFilename)
+
+            self.passed = preprocessFile(self.args, infile, outfile,
+                                         self.entity_db, self.macros,
+                                         self.commonvalidityDict) and self.passed
+
+        return line
+
+    def onMacro(self, line, state):
+        # Parse the macro definition and record it
+        assert(line[0] == ':')
+
+        endingColon = line.find(':', 1)
+        assert(endingColon != -1)
+
+        macroName = line[1:endingColon]
+        macroValue = line[endingColon + 1:].strip()
+
+        self.macros[macroName] = macroValue
+
+    def onEmbeddedVUConditional(self, state):
+        # This is not supported.  reflow.py already complains about this.
+        logErr('ifdef inside VU is disallowed')
+
+
+def preprocessFile(args, infile, outfile, entity_db, macros, commonvalidityDict):
+    print('Preprocessing: ' + infile)
+    lines, _ = loadFile(infile)
+
+    try:
+        fp = open(outfile, 'w', encoding='utf8', newline='\n')
+    except:
+        logWarn('Cannot open output file', outfile, ':', sys.exc_info()[0])
+        return
+
+    passed = True
+
+    if lines is not None:
+        callback = PreprocessCallbacks(args, entity_db, infile, macros, commonvalidityDict)
+
+        transformer = doctransformer.DocTransformer(infile,
+                                                    outfile = fp,
+                                                    callback = callback)
+
+        transformer.transformFile(lines)
+        passed = callback.passed
+
+    fp.close()
+    return passed
+
+
+def preprocessFiles(args, entity_db, inpath, outpath):
+    defaultMacros = {}
+    commonvalidityDict = {}
+
+    passed = True
+    root, subdirs, files = next(os.walk(inpath))
+    for file in files:
+        if file.endswith(conventions.file_suffix):
+            infile = os.path.join(root, file)
+            outfile = os.path.join(outpath, file)
+            passed = preprocessFile(args, infile, outfile, entity_db, defaultMacros, commonvalidityDict) and passed
+    for subdir in subdirs:
+        if os.path.basename(subdir) == 'commonvalidity':
+            # Process commonvalidity files as they are encountered
+            continue
+        insubdir = os.path.join(root, subdir)
+        outsubdir = resolveAndMkdir(os.path.join(outpath, subdir))
+        passed = preprocessFiles(args, entity_db, insubdir, outsubdir) and passed
+
+    return passed
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-diag', action='store', dest='diagFile',
+                        help='Set the diagnostic file')
+    parser.add_argument('-warn', action='store', dest='warnFile',
+                        help='Set the warning file')
+    parser.add_argument('-log', action='store', dest='logFile',
+                        help='Set the log file for both diagnostics and warnings')
+    parser.add_argument('-o', action='store', dest='outpath',
+                        help='Set the output path')
+    parser.add_argument('-stamp', action='store', dest='stampfile',
+                        help='File to touch on success')
+    parser.add_argument('--version', action='version', version='%(prog)s 1.0')
+
+    args = parser.parse_args()
+
+    setLogFile(True,  True, args.logFile)
+    setLogFile(True, False, args.diagFile)
+    setLogFile(False, True, args.warnFile)
+
+    args.inpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'chapters'))
+    args.outpath = resolveAndMkdir(args.outpath)
+
+    entity_db = VulkanEntityDatabase()
+
+    if not preprocessFiles(args, entity_db, args.inpath, args.outpath):
+        # Fail build if there are errors
+        sys.exit(1)
+
+    # Touch the stamp file
+    if args.stampfile is not None:
+        Path(args.stampfile).touch()


### PR DESCRIPTION
The following is implemented in this change:

- Codified VU parsing
- Codified VU reformatting in source (reflow.py)
- Codified VU formatting for build
- Codified VU type checking
- Unit tests

There is no mention of codified VUs in the spec text however at this point. That will be added as VUs are converted.

