### PR TITLE
Only parenthesize formal arguments of VK_DEFINE*HANDLE macros in vulk…

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -181,7 +181,9 @@ branch of the member gitlab server.
         <type api="vulkansc" category="define" requires="VKSC_API_VARIANT">// Complete version of this file
 #define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(VKSC_API_VARIANT, 1, 0, VK_HEADER_VERSION)</type>
 
-        <type category="define">
+        <type api="vulkan" category="define">
+#define <name>VK_DEFINE_HANDLE</name>(object) typedef struct object##_T* object;</type>
+        <type api="vulkansc" category="define" comment="Extra parenthesis are a MISRA-C requirement that exposes a bug in MSVC">
 #define <name>VK_DEFINE_HANDLE</name>(object) typedef struct object##_T* (object);</type>
 
         <type category="define" name="VK_USE_64_BIT_PTR_DEFINES">
@@ -207,7 +209,15 @@ branch of the member gitlab server.
 #ifndef VK_NULL_HANDLE
     #define VK_NULL_HANDLE 0
 #endif</type>
-        <type category="define" requires="VK_NULL_HANDLE" name="VK_DEFINE_NON_DISPATCHABLE_HANDLE">
+        <type api="vulkan" category="define" requires="VK_NULL_HANDLE" name="VK_DEFINE_NON_DISPATCHABLE_HANDLE">
+#ifndef VK_DEFINE_NON_DISPATCHABLE_HANDLE
+    #if (VK_USE_64_BIT_PTR_DEFINES==1)
+        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object##_T *object;
+    #else
+        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef uint64_t object;
+    #endif
+#endif</type>
+        <type api="vulkansc" category="define" requires="VK_NULL_HANDLE" name="VK_DEFINE_NON_DISPATCHABLE_HANDLE" comment="Extra parenthesis are a MISRA-C requirement that exposes a bug in MSVC">
 #ifndef VK_DEFINE_NON_DISPATCHABLE_HANDLE
     #if (VK_USE_64_BIT_PTR_DEFINES==1)
         #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object##_T *(object);


### PR DESCRIPTION
…ansc api

Specialize the two macro definitions in the XML for Vulkan vs. Vulkan SC. Workaround for an apparent MSVC bug.

Closes https://github.com/KhronosGroup/Vulkan-Docs/issues/2067