### PR TITLE
Update citations and cross-references

### DIFF
--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -330,7 +330,7 @@ created.
 
 
 [[styles]]
-== Our stylesheets
+== Our Stylesheets
 
 We use an HTML stylesheet `config/khronos.css` derived from the
 https://asciidoctor.org/docs/produce-custom-themes-using-asciidoctor-stylesheet-factory/[Asciidoctor
@@ -343,7 +343,7 @@ font family].
 == Vulkan Style Guide
 
 If you are writing new spec language or modifying existing language, see the
-link:https://registry.khronos.org/vulkan/specs/1.2/styleguide.html["`style
+link:https://registry.khronos.org/vulkan/specs/1.3/styleguide.html["`style
 guide`"] (formally titled "`Vulkan Documentation and Extensions: Procedures
 and Conventions`") document for details of our asciidoctor macros,
 extensions, mathematical equation markup, writing style, etc.

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -166,12 +166,13 @@ _H.265 High Efficiency Video Coding_ (August, 2021).
 https://www.itu.int/rec/T-REC-H.265-202108-I/ .
 
 [[vulkan-registry]] Jon Leech.
-_The Khronos Vulkan API Registry_.
-https://registry.khronos.org/vulkan/specs/1.2/registry.html .
+_The Khronos Vulkan API Registry_ (February 26, 2023).
+https://registry.khronos.org/vulkan/specs/1.3/registry.html .
 
 [[vulkan-styleguide]] Jon Leech and Tobias Hector.
-_Vulkan Documentation and Extensions: Procedures and Conventions_.
-https://registry.khronos.org/vulkan/specs/1.2/styleguide.html .
+_Vulkan Documentation and Extensions: Procedures and Conventions_ (February
+26, 2023).
+https://registry.khronos.org/vulkan/specs/1.3/styleguide.html .
 
 [[LoaderInterfaceArchitecture]]
 _Architecture of the Vulkan Loader Interfaces_ (October, 2021).

--- a/registry.adoc
+++ b/registry.adoc
@@ -97,6 +97,22 @@ into a separate repository, but since there is so much specification valid
 usage language imbedded in the registry XML, this is unlikely to happen.
 
 
+[[introduction-normative]]
+== Normative References
+
+Normative references are references to external documents or resources to
+which documentation authors must comply.
+
+[[vulkan-styleguide]] Jon Leech and Tobias Hector.
+_Vulkan Documentation and Extensions: Procedures and Conventions_ (February
+26, 2023).
+https://registry.khronos.org/vulkan/specs/1.3/styleguide.html .
+
+[[vulkan-spec]] Khronos Vulkan Working Group.
+_Vulkan 1.3.242 - A Specification_ (February 26, 2023).
+https://registry.khronos.org/vulkan/ .
+
+
 [[starting]]
 = Getting Started
 
@@ -128,9 +144,10 @@ Other Makefile targets in `xml/` include:
 
   * `validate` - validate `vk.xml` against the XML schema.
     Recommended if you are making nontrivial changes.
-  * The asciidoc includes used by the Specification and Reference Pages are
-    built using the 'make generated' target in the parent directory
-    Makefile, although they use the scripts and XML in this directory.
+  * The asciidoc includes used by the <<vulkan-spec, Vulkan API
+    Specification>> and Reference Pages are built using the 'make generated'
+    target in the parent directory Makefile, although they use the scripts
+    and XML in this directory.
     These files are generated dynamically when building the specs, since
     their contents depend on the exact set of extensions the Specification
     is being built to include.
@@ -154,8 +171,8 @@ Additionally, specific API versions and extensions can be required or
 excluded.
 Based on this information, the generator script extracts the relevant
 interfaces and creates a C-language header file for them.
-`genvk.py` contains predefined generator options for the current Vulkan
-Specification release.
+`genvk.py` contains predefined generator options for the current
+<<vulkan-spec, Vulkan API Specification>> release.
 
 The generator script is intended to be generalizable to other languages by
 writing new generator classes.
@@ -582,8 +599,8 @@ The tag:member tag defines the type and name of a structure or union member.
 .Note
 ====
 While the attr:optional attribute can be used for scalar types such as
-integers, it does not affect the output generators included with the Vulkan
-Specification.
+integers, it does not affect the output generators included with the
+<<vulkan-spec, Vulkan API Specification>>.
 In this case, the attribute serves only as an indicator to human readers of
 the XML.
 ====
@@ -984,11 +1001,12 @@ parameters of the command.
 In this case the allowed attributes include:
 
   * attr:tasks - optional.
-    A string identifying the tasks this command performs, as described
-    in the "`Queue Operation`" section of the Vulkan Specification.
+    A string identifying the tasks this command performs, as described in
+    the "`Queue Operation`" section of the <<vulkan-spec, Vulkan API
+    Specification>>.
     The format of the string is one or more of the terms `"action"`,
-    `"synchronization"`, `"state"`, and `"indirection"`, with multiple terms separated by
-    commas (`","`).
+    `"synchronization"`, `"state"`, and `"indirection"`, with multiple terms
+    separated by commas (`","`).
   * attr:queues - optional.
     A string identifying the command queues this command can be placed on.
     The format of the string is one or more of the terms `"compute"`,
@@ -1157,8 +1175,8 @@ and union members.
 .Note
 ====
 While the attr:optional attribute can be used for scalar types such as
-integers, it does not affect the output generators included with the Vulkan
-Specification.
+integers, it does not affect the output generators included with the
+<<vulkan-spec, Vulkan API Specification>>.
 In this case, the attribute serves only as an indicator to human readers of
 the XML.
 ====
@@ -1361,7 +1379,8 @@ implemented against.
 == Attributes of tag:extension tags
 
   * attr:name - required.
-    Extension name, following the conventions in the Vulkan Specification.
+    Extension name, following the conventions in the <<vulkan-spec, Vulkan
+    API Specification>>.
     Example: `name="VK_VERSION_1_0"`.
   * attr:number - required.
     A decimal number which is the registered, unique extension number for
@@ -1688,8 +1707,10 @@ enumerant:
     If attr:extnumber is not present, the extension number defining that
     block is given by the attr:number attribute of the surrounding
     tag:extension tag.
-    The actual numeric value of the enumerant is computed as defined in the
-    "`Layers and Extensions`" appendix of the Vulkan Specification.
+    The numeric value of an enumerant is computed as defined in the
+    ``Assigning Extension Token Values`" section of the <<vulkan-styleguide,
+    Vulkan Documentation and Extensions: Procedures and Conventions>>
+    document.
   * Attribute attr:dir - if present, the calculated enumerant value will be
     negative, instead of positive.
     Negative enumerant values are normally used only for Vulkan error codes.
@@ -1816,8 +1837,8 @@ An image format corresponds to a Vulkan `VkFormat` enumerant.
 This tag contains information specifying the structure and meaning of
 different parts of the format.
 The meaning of different parts of the format information is described in
-more detail in the "`Format Definition`" section of the Vulkan API
-Specification.
+more detail in the "`Format Definition`" section of the <<vulkan-spec,
+Vulkan API Specification>>.
 
 == Attributes of tag:format tags
 
@@ -2920,6 +2941,9 @@ Changes to the `.xml` files and Python scripts are logged in Github history.
 [[changelog]]
 = Change Log
 
+  * 2023-02-26 - add normative references section, cite it as needed, and
+    update description of tag:extension tags to refer to the style guide for
+    computing numeric enumerant values (public issue 2069).
   * 2023-02-22 - specify that attr:depends expressions are
     <<depends-expressions, evaluated left-to-right>> for operators of the
     same precedence (public issue 2062).

--- a/style/extensions.adoc
+++ b/style/extensions.adoc
@@ -784,6 +784,7 @@ Add a new feature:
     versions.
 
 
+[[extensions-assigning-token-values]]
 == Assigning Extension Token Values
 
 Extensions can define their own enumeration types and assign any values to
@@ -833,11 +834,13 @@ The information needed to add new values to the XML are as follows:
     (`dir="-"`) when needed for negative etext:VkResult values indicating
     errors, like etext:VK_ERROR_SURFACE_LOST_KHR.
     The default direction is positive, if not specified.
+  * The **extension number** is usually implicit and taken from metadata of
+    the extension being defined.
+    It is used to create a range of unused values specific to that
+    extension.
 
-Implicit is the registered number of an extension, which is used to create a
-range of unused values offset against a global extension base value.
-Individual enumerant values are calculated as offsets in that range.
-Values are calculated as follows:
+Individual enumerant values are calculated as offsets in the range
+defined by the extension number, as follows:
 
   * [eq]#_base_value_ = 1000000000#
   * [eq]#_range_size_ = 1000#
@@ -847,12 +850,15 @@ Values are calculated as follows:
   * Negative values: [eq]#enum_offset(_extension_number_, _offset_})#
 
 The exact syntax for specifying extension enumerant values is defined in the
-`readme.pdf` specifying the format of `vk.xml`, and extension authors can
-also refer to existing extensions for examples.
+<<vulkan-registry, Vulkan API Registry>> schema documentation. Extension
+authors should also refer to existing extensions for examples.
 
-If an extension becomes part of core, the enumerant values should remain the
-same as they were in the original extension, in order to maintain binary
-compatibility with existing applications.
+If an extension is promoted to another extension or to a core API version,
+the enumerant values should remain the same as they were in the original
+extension, in order to maintain binary compatibility with existing
+applications.
+In this case, the extension number will need to be specified explicitly to
+keep the promoted enumerant value unchanged.
 
 
 [[extensions-reserving-bitmask-values]]
@@ -953,9 +959,8 @@ extensions must define two additional tokens.
     differ.
     The revision value indicates a patch version of the extension
     specification, and differences in this version number maintain full
-    compatibility, as defined in the
-    link:html/vkspec.html#_compatibility_guarantees_informative[Compatibility
-    Guarantees] section of the <<vulkan-spec,Vulkan API Specification>>.
+    compatibility, as defined in the "`Compatibility Guarantees`" section of
+    the <<vulkan-spec,Vulkan API Specification>>.
 
 [NOTE]
 .Note

--- a/style/introduction.adoc
+++ b/style/introduction.adoc
@@ -115,13 +115,18 @@ Khronos Vulkan Working Group.
 `KhronosGroup/Vulkan-Docs` project on GitHub (July 5, 2016).
 https://github.com/KhronosGroup/Vulkan-Docs .
 
+[[vulkan-registry]]
+Jon Leech.
+_The Khronos Vulkan API Registry_ (February 26, 2023).
+https://registry.khronos.org/vulkan/specs/1.3/registry.html .
+
 [[vulkan-spec]]
 Khronos Vulkan Working Group.
-_Vulkan 1.1.116 - A Specification_ (July 20, 2019).
+_Vulkan 1.3.242 - A Specification_ (February 26, 2023).
 https://registry.khronos.org/vulkan/ .
 
-Version 1.1.116 is the latest patch release of the Vulkan API Specification
-as of the time this reference was created, but that Specification is
+Version 1.3.242 is the latest patch release of the Vulkan API Specification
+as of the time this reference was last updated, but the Specification is
 frequently updated with minor bugfixes and clarifications.
 When a more recent patch release is made, it becomes the normative reference
 for the API.

--- a/style/revisions.adoc
+++ b/style/revisions.adoc
@@ -6,6 +6,9 @@
 [[revisions]]
 = Revision History
 
+* 2023-02-26 - update description of computing numeric enumerant values, and
+  reference the normative references section for the registry schema
+  document (public issue 2069).
 * 2022-11-29 - Add a NOTE to the <<writing-conventions, Use American
   Spelling Conventions>> section explain why there are a few uses of
   "`colour`" in the Vulkan Video extensions (internal issue 3254).

--- a/style/writing.adoc
+++ b/style/writing.adoc
@@ -286,8 +286,8 @@ Association for Computing Machinery Citation Style>>.
 Most citations in our specifications should follow the _For an online
 document/WWW resource_ style, using the actual date on the document being
 referenced rather than the document retrieval date.
-See the <<vulkan-spec, Vulkan Specification>> citation in this document for
-an example.
+See the <<vulkan-spec, Vulkan API Specification>> citation in this document
+for an example.
 
 
 [[writing-undefined]]


### PR DESCRIPTION
There were some out of date normative reference citations, and incorrect cross-references between the specification, style guide, and registry schema documents.

* Updates normative reference sections and cites them appropriately within each document.
* Updates description of <enum> XML tags in the schema document to refer to the style guide for computing numeric enumerant values.
* Updates corresponding description in the style guide to reference the schema document.
* Miscellaneous minor markup fixes.

Fixes #2069