### PR TITLE
Allow finding Python in other locations

### DIFF
--- a/scripts/Retired/checkLinks.py
+++ b/scripts/Retired/checkLinks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2015-2023 The Khronos Group Inc.
 #

--- a/scripts/Retired/extensionStubSource.py
+++ b/scripts/Retired/extensionStubSource.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/Retired/findBalance.py
+++ b/scripts/Retired/findBalance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/Retired/fixupRef.py
+++ b/scripts/Retired/fixupRef.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/Retired/insertTags.py
+++ b/scripts/Retired/insertTags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/Retired/realign.py
+++ b/scripts/Retired/realign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/Retired/refDesc.py
+++ b/scripts/Retired/refDesc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/apiconventions.py
+++ b/scripts/apiconventions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2021-2023 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/cgenerator.py
+++ b/scripts/cgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/check_html_xrefs.py
+++ b/scripts/check_html_xrefs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2020-2023 The Khronos Group Inc.
 #

--- a/scripts/check_spec_links.py
+++ b/scripts/check_spec_links.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2018-2019 Collabora, Ltd.
 #

--- a/scripts/deperiodize_vuids.py
+++ b/scripts/deperiodize_vuids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2020 Petr Kraus
 #

--- a/scripts/docgenerator.py
+++ b/scripts/docgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/extensionmetadocgenerator.py
+++ b/scripts/extensionmetadocgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/formatsgenerator.py
+++ b/scripts/formatsgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/genRef.py
+++ b/scripts/genRef.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/genRelease
+++ b/scripts/genRelease
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/genanchorlinks.py
+++ b/scripts/genanchorlinks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2020-2023 The Khronos Group Inc.
 #

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/genspec.py
+++ b/scripts/genspec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/genvk.py
+++ b/scripts/genvk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/hostsyncgenerator.py
+++ b/scripts/hostsyncgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/indexExt.py
+++ b/scripts/indexExt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2017-2023 The Khronos Group Inc.
 #

--- a/scripts/interfacedocgenerator.py
+++ b/scripts/interfacedocgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/json_c_generator.py
+++ b/scripts/json_c_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2020-2023 The Khronos Group Inc.
 #

--- a/scripts/json_generator.py
+++ b/scripts/json_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2020-2023 The Khronos Group Inc.
 #

--- a/scripts/json_h_generator.py
+++ b/scripts/json_h_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2020-2023 The Khronos Group Inc.
 #

--- a/scripts/json_parser.py
+++ b/scripts/json_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2020-2023 The Khronos Group Inc.
 #

--- a/scripts/json_validate.py
+++ b/scripts/json_validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2020-2023 The Khronos Group Inc.
 #

--- a/scripts/linkcheck.py
+++ b/scripts/linkcheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2013-2023 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/makemanaliases.py
+++ b/scripts/makemanaliases.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2020-2023 The Khronos Group Inc.
 #

--- a/scripts/parse_dependency.py
+++ b/scripts/parse_dependency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright 2022-2023 The Khronos Group Inc.
 # Copyright 2003-2019 Paul McGuire

--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/pygenerator.py
+++ b/scripts/pygenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/reflib.py
+++ b/scripts/reflib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/reflow.py
+++ b/scripts/reflow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2016-2023 The Khronos Group Inc.
 #

--- a/scripts/reg.py
+++ b/scripts/reg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/rubygenerator.py
+++ b/scripts/rubygenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/schema_generator.py
+++ b/scripts/schema_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2020-2023 The Khronos Group Inc.
 #

--- a/scripts/scriptgenerator.py
+++ b/scripts/scriptgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/spec_tools/__init__.py
+++ b/scripts/spec_tools/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright (c) 2018-2019 Collabora, Ltd.
 #

--- a/scripts/spec_tools/algo.py
+++ b/scripts/spec_tools/algo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright (c) 2019 Collabora, Ltd.
 #

--- a/scripts/spec_tools/attributes.py
+++ b/scripts/spec_tools/attributes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/spec_tools/consistency_tools.py
+++ b/scripts/spec_tools/consistency_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright (c) 2019 Collabora, Ltd.
 #

--- a/scripts/spec_tools/conventions.py
+++ b/scripts/spec_tools/conventions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/spec_tools/data_structures.py
+++ b/scripts/spec_tools/data_structures.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright (c) 2019 Collabora, Ltd.
 #

--- a/scripts/spec_tools/file_process.py
+++ b/scripts/spec_tools/file_process.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2018-2019 Collabora, Ltd.
 #

--- a/scripts/spec_tools/validity.py
+++ b/scripts/spec_tools/validity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/spirvcapgenerator.py
+++ b/scripts/spirvcapgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/stripAPI.py
+++ b/scripts/stripAPI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2023 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/testSpecVersion.py
+++ b/scripts/testSpecVersion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2017-2023 The Khronos Group Inc.
 #

--- a/scripts/test_check_spec_links.py
+++ b/scripts/test_check_spec_links.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2018-2019 Collabora, Ltd.
 #

--- a/scripts/test_check_spec_links_api_specific.py
+++ b/scripts/test_check_spec_links_api_specific.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2018-2019 Collabora, Ltd.
 #

--- a/scripts/test_entity_db.py
+++ b/scripts/test_entity_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright (c) 2018-2019 Collabora, Ltd.
 #

--- a/scripts/test_reflow.py
+++ b/scripts/test_reflow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2023 The Khronos Group Inc.
 #

--- a/scripts/validitygenerator.py
+++ b/scripts/validitygenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/vkconventions.py
+++ b/scripts/vkconventions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/scripts/xml_consistency.py
+++ b/scripts/xml_consistency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2019 Collabora, Ltd.
 #


### PR DESCRIPTION
Although a lot of Linux OS's provide Python in /usr/bin that is not always the case and outside of Linux that is not the case.