### PR TITLE
Fix typo in sample code

### DIFF
--- a/appendices/VK_EXT_shader_object.adoc
+++ b/appendices/VK_EXT_shader_object.adoc
@@ -112,7 +112,7 @@ VkShaderCreateInfoEXT shaderCreateInfos[2] =
 VkResult result;
 VkShaderEXT shaders[2];
 
-result = vkCmdCreateShadersEXT(device, 2, &shaderCreateInfos, NULL, shaders);
+result = vkCreateShadersEXT(device, 2, &shaderCreateInfos, NULL, shaders);
 if (result != VK_SUCCESS)
 {
     // Handle error
@@ -281,7 +281,7 @@ VkShaderCreateInfoEXT shaderCreateInfos[5] =
 VkResult result;
 VkShaderEXT shaders[5];
 
-result = vkCmdCreateShadersEXT(device, 5, &shaderCreateInfos, NULL, shaders);
+result = vkCreateShadersEXT(device, 5, &shaderCreateInfos, NULL, shaders);
 if (result != VK_SUCCESS)
 {
     // Handle error


### PR DESCRIPTION
[VK_EXT_shader_object] @daniel-story
Hi, I see the function `vkCmdCreateShadersEXT` is used in the shader object sample code, but maybe `Cmd` is not needed.