### PR TITLE
fix: reference StdVideoDecodeH265ReferenceInfo instead of H264 in H.265

### DIFF
--- a/chapters/video_decode_h265_extensions.adoc
+++ b/chapters/video_decode_h265_extensions.adoc
@@ -34,7 +34,7 @@ section 8 of <<itu-t-h265,ITU-T H.265 Specification>>:
      H.265 picture parameter set>>.
   ** The code:StdVideoDecodeH265PictureInfo structure specifying the
      <<decode-h265-picture-info,H.265 picture information>>.
-  ** The code:StdVideoDecodeH264ReferenceInfo structures specifying the
+  ** The code:StdVideoDecodeH265ReferenceInfo structures specifying the
      <<decode-h265-reference-info,H.265 reference information>>
      corresponding to the optional <<reconstructed-picture,reconstructed
      picture>> and any <<active-reference-pictures,active reference


### PR DESCRIPTION
Probably this was meant to reference StdVideoDecodeH265ReferenceInfo instead of StdVideoDecodeH264ReferenceInfo in "H.265 Decode Operations".