### PR TITLE
Docs: fix link to vulkan-docs.Dockerfile

### DIFF
--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -411,7 +411,7 @@ images` and `docker rmi -f`.
 We do not actively support building outside of our Docker image, but it is
 straightforward to reproduce our toolchain in a Debian (or similar APT-based
 Linux) distribution by executing the same steps as the
-link:https://github.com/KhronosGroup/DockerContainers/blob/main/vulkan-docs.Dockerfile[Dockerfile]
+link:https://github.com/KhronosGroup/DockerContainers/blob/main/asciidoctor-spec.Dockerfile[Dockerfile]
 used to build our Docker image.
 
 It should be possible to apply the same steps in a Windows Subsystem for

--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -411,7 +411,7 @@ images` and `docker rmi -f`.
 We do not actively support building outside of our Docker image, but it is
 straightforward to reproduce our toolchain in a Debian (or similar APT-based
 Linux) distribution by executing the same steps as the
-link:https://github.com/KhronosGroup/DockerContainers/blob/master/asciidoctor-spec.dockerfile[Dockerfile]
+link:https://github.com/KhronosGroup/DockerContainers/blob/main/vulkan-docs.Dockerfile[Dockerfile]
 used to build our Docker image.
 
 It should be possible to apply the same steps in a Windows Subsystem for


### PR DESCRIPTION
The current link 404's

https://github.com/KhronosGroup/DockerContainers/blob/master/asciidoctor-spec.dockerfile 


I presume the link is supposed to be 

https://github.com/KhronosGroup/DockerContainers/blob/main/asciidoctor-spec.Dockerfile