### PR TITLE
fix VK_FORMAT_B10G11R11_UFLOAT_PACK32

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -23100,7 +23100,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <format name="VK_FORMAT_B10G11R11_UFLOAT_PACK32" class="32-bit" blockSize="4" texelsPerBlock="1" packed="32">
             <component name="B" bits="10" numericFormat="UFLOAT"/>
             <component name="G" bits="11" numericFormat="UFLOAT"/>
-            <component name="R" bits="10" numericFormat="UFLOAT"/>
+            <component name="R" bits="11" numericFormat="UFLOAT"/>
             <spirvimageformat name="R11fG11fB10f"/>
         </format>
         <format name="VK_FORMAT_E5B9G9R9_UFLOAT_PACK32" class="32-bit" blockSize="4" texelsPerBlock="1" packed="32">


### PR DESCRIPTION
R component bits (10) is inconsistent with format name B10G11R11