### PR TITLE
fix VK_FORMAT_B5G5R5A1_UNORM_PACK16

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -22496,8 +22496,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </format>
         <format name="VK_FORMAT_B5G5R5A1_UNORM_PACK16" class="16-bit" blockSize="2" texelsPerBlock="1" packed="16">
             <component name="B" bits="5" numericFormat="UNORM"/>
-            <component name="R" bits="5" numericFormat="UNORM"/>
             <component name="G" bits="5" numericFormat="UNORM"/>
+            <component name="R" bits="5" numericFormat="UNORM"/>
             <component name="A" bits="1" numericFormat="UNORM"/>
         </format>
         <format name="VK_FORMAT_A1R5G5B5_UNORM_PACK16" class="16-bit" blockSize="2" texelsPerBlock="1" packed="16">


### PR DESCRIPTION
The order of component is inconsistent with format name.