### PR TITLE
Clarify mapping between wait semaphores and fences for swapchain present

### DIFF
--- a/chapters/VK_EXT_swapchain_maintenance1/SwapchainPresentFenceInfo.adoc
+++ b/chapters/VK_EXT_swapchain_maintenance1/SwapchainPresentFenceInfo.adoc
@@ -40,9 +40,9 @@ fence must: not signal until all such semaphore payloads have been reset by
 the presentation engine.
 
 The application can: destroy the wait semaphores associated with a given
-presentation operation when the associated fence is signaled, and can:
-destroy the swapchain when the fences associated with all past presentation
-requests have signaled.
+presentation operation when at least one of the associated fences is signaled,
+and can: destroy the swapchain when the fences associated with all past
+presentation requests have signaled.
 
 Fences associated with presentations to the same swapchain on the same
 slink:VkQueue must: be signaled in the same order as the present operations.

--- a/chapters/VK_EXT_swapchain_maintenance1/SwapchainPresentFenceInfo.adoc
+++ b/chapters/VK_EXT_swapchain_maintenance1/SwapchainPresentFenceInfo.adoc
@@ -42,7 +42,7 @@ the presentation engine.
 The application can: destroy the wait semaphores associated with a given
 presentation operation when at least one of the associated fences is signaled,
 and can: destroy the swapchain when the fences associated with all past
-presentation requests have signaled.
+presentation requests referring to that swapchain have signaled.
 
 Fences associated with presentations to the same swapchain on the same
 slink:VkQueue must: be signaled in the same order as the present operations.


### PR DESCRIPTION
The spec for `VkSwapchainPresentFenceInfoEXT` currently says:
> The application **can** destroy the wait semaphores associated with a given presentation operation when the associated fence is signaled, and **can** destroy the swapchain when the fences associated with all past presentation requests have signaled.

You can specify more than one swapchain, and each swapchain has its own fence, so there is not one single "associated fence". The present operation does not start until the wait semaphores have all been signalled, therefore the signalling of any fence must happen after the wait operation of all the semaphores. This PR clarifies that point.