### PR TITLE
Fix a typo in VUID 08600

### DIFF
--- a/chapters/commonvalidity/draw_dispatch_common.adoc
+++ b/chapters/commonvalidity/draw_dispatch_common.adoc
@@ -120,7 +120,7 @@ ifndef::VK_EXT_shader_object[]
 endif::VK_EXT_shader_object[]
 ifdef::VK_EXT_shader_object[]
   * [[VUID-{refpage}-None-08600]]
-    For each set _n_ that is statically used <<shaders-binding,a bound
+    For each set _n_ that is statically used by <<shaders-binding,a bound
     shader>>, a descriptor set must: have been bound to _n_ at the same
     pipeline bind point, with a slink:VkPipelineLayout that is compatible
     for set _n_, with the slink:VkPipelineLayout or


### PR DESCRIPTION
This brings it in line with other similar statements in the immediate vicinity.