### PR TITLE
fix VK_FORMAT_R64G64 and VK_FORMAT_BC snorm formats

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -23196,15 +23196,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </format>
         <format name="VK_FORMAT_R64G64_UINT" class="128-bit" blockSize="16" texelsPerBlock="1">
             <component name="R" bits="64" numericFormat="UINT"/>
-            <component name="B" bits="64" numericFormat="UINT"/>
+            <component name="G" bits="64" numericFormat="UINT"/>
         </format>
         <format name="VK_FORMAT_R64G64_SINT" class="128-bit" blockSize="16" texelsPerBlock="1">
             <component name="R" bits="64" numericFormat="SINT"/>
-            <component name="B" bits="64" numericFormat="SINT"/>
+            <component name="G" bits="64" numericFormat="SINT"/>
         </format>
         <format name="VK_FORMAT_R64G64_SFLOAT" class="128-bit" blockSize="16" texelsPerBlock="1">
             <component name="R" bits="64" numericFormat="SFLOAT"/>
-            <component name="B" bits="64" numericFormat="SFLOAT"/>
+            <component name="G" bits="64" numericFormat="SFLOAT"/>
         </format>
         <format name="VK_FORMAT_R64G64B64_UINT" class="192-bit" blockSize="24" texelsPerBlock="1">
             <component name="R" bits="64" numericFormat="UINT"/>
@@ -23324,15 +23324,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <component name="R" bits="compressed" numericFormat="UNORM"/>
         </format>
         <format name="VK_FORMAT_BC4_SNORM_BLOCK" class="BC4" blockSize="8" texelsPerBlock="16" blockExtent="4,4,1" compressed="BC">
-            <component name="R" bits="compressed" numericFormat="SRGB"/>
+            <component name="R" bits="compressed" numericFormat="SNORM"/>
         </format>
         <format name="VK_FORMAT_BC5_UNORM_BLOCK" class="BC5" blockSize="16" texelsPerBlock="16" blockExtent="4,4,1" compressed="BC">
             <component name="R" bits="compressed" numericFormat="UNORM"/>
             <component name="G" bits="compressed" numericFormat="UNORM"/>
         </format>
         <format name="VK_FORMAT_BC5_SNORM_BLOCK" class="BC5" blockSize="16" texelsPerBlock="16" blockExtent="4,4,1" compressed="BC">
-            <component name="R" bits="compressed" numericFormat="SRGB"/>
-            <component name="G" bits="compressed" numericFormat="SRGB"/>
+            <component name="R" bits="compressed" numericFormat="SNORM"/>
+            <component name="G" bits="compressed" numericFormat="SNORM"/>
         </format>
         <format name="VK_FORMAT_BC6H_UFLOAT_BLOCK" class="BC6H" blockSize="16" texelsPerBlock="16" blockExtent="4,4,1" compressed="BC">
             <component name="R" bits="compressed" numericFormat="UFLOAT"/>


### PR DESCRIPTION
fix typos of formats in `vk.xml`.
`VK_FORMAT_R64G64_UINT`
`VK_FORMAT_R64G64_SINT`
`VK_FORMAT_R64G64_SFLOAT`
`VK_FORMAT_BC4_SNORM_BLOCK`
`VK_FORMAT_BC5_SNORM_BLOCK`