### PR TITLE
Fix missing display of vk:: in asciidoc in VK_EXT_mutable_descriptor_type proposal

### DIFF
--- a/proposals/VK_EXT_mutable_descriptor_type.adoc
+++ b/proposals/VK_EXT_mutable_descriptor_type.adoc
@@ -269,7 +269,7 @@ For this to be well defined, `VK_DESCRIPTOR_BINDING_FLAG_PARTIALLY_BOUND_BIT` mu
 
 ==== HLSL
 
-The example above can mirror HLSL using `[[vk::]]` attributes, but for a more direct SM 6.6-style integration, it is possible to implement this in a HLSL frontend as such:
+The example above can mirror HLSL using `\[[vk::]]` attributes, but for a more direct SM 6.6-style integration, it is possible to implement this in a HLSL frontend as such:
 
  - Application specifies that resource heap lives in a specific set / binding.
   - To fallback to non-mutable support, it is possible to support a different set / binding for each Vulkan descriptor type.


### PR DESCRIPTION
This PR fixes a very minor display issue in the VK_EXT_mutable_descriptor_type proposal. The `[[vk::]]` was displayed as a blank inline code block due to a missing escape char.