### PR TITLE
Fix formatting issues in VK_KHR_maintenance5 proposal

### DIFF
--- a/proposals/VK_KHR_maintenance5.adoc
+++ b/proposals/VK_KHR_maintenance5.adoc
@@ -81,7 +81,7 @@ Some hardware performs sample counting after multisample coverage operations whe
 
 === VK_WHOLE_SIZE for pSizes argument of vkCmdBindVertexBuffers2
 
- `pSizes` in `vkCmdBindVertexBuffers2` unintentionally does not support `VK_WHOLE_SIZE`.
+`pSizes` in `vkCmdBindVertexBuffers2` unintentionally does not support `VK_WHOLE_SIZE`.
 
 === vkGetImageSubresourceLayout query without having to create a dummy image
 

--- a/proposals/VK_KHR_maintenance5.adoc
+++ b/proposals/VK_KHR_maintenance5.adoc
@@ -116,7 +116,7 @@ SPIR-V to reduce duplicated work at pipeline creation.
 
 In practice though, few implementations do anything useful with these objects, and they
 end up just being an unnecessary copy and a waste of memory while they
-exist.```
+exist.
 They also are yet another object for applications to manage, which is
 development overhead that would be useful to remove.
 


### PR DESCRIPTION
This PR fixes minor formatting issues in the `VK_KHR_maintenance5` proposal. E.g. an unintentional whitespace that turned a whole sentence into a code block and some wrong backticks.