### PR TITLE
fix bad explanation of `VkBufferUsageFlags2CreateInfoKHR::usage`

### DIFF
--- a/chapters/resources.adoc
+++ b/chapters/resources.adoc
@@ -322,7 +322,7 @@ include::{generated}/api/structs/VkBufferUsageFlags2CreateInfoKHR.adoc[]
   * pname:pNext is `NULL` or a pointer to a structure extending this
     structure.
   * pname:usage is a bitmask of elink:VkBufferUsageFlagBits2KHR specifying
-    how a pipeline will be generated.
+    allowed usages of the buffer.
 
 If this structure is included in the pname:pNext chain of a buffer creation
 structure, pname:usage is used instead of the corresponding pname:usage


### PR DESCRIPTION
fix #2181