### PR TITLE
Specify that VUID-RuntimeSpirv-x-06432 applies only to compute shaders

### DIFF
--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -1752,8 +1752,9 @@ endif::VK_NV_ray_tracing_invocation_reorder[]
     than or equal to
     slink:VkPhysicalDeviceLimits::pname:maxComputeWorkGroupSize[2]
   * [[VUID-{refpage}-x-06432]]
-    The product of pname:x size, pname:y size, and pname:z size in
-    code:LocalSize or code:LocalSizeId must: be less than or equal to
+    In compute shaders using the code:GLCompute {ExecutionModel} the product of
+    pname:x size, pname:y size, and pname:z size in code:LocalSize or
+    code:LocalSizeId must: be less than or equal to
     slink:VkPhysicalDeviceLimits::pname:maxComputeWorkGroupInvocations
 ifndef::VK_VERSION_1_3,VK_KHR_maintenance4[]
   * [[VUID-{refpage}-LocalSizeId-06433]]

--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -1740,16 +1740,16 @@ ifdef::VK_NV_ray_tracing_invocation_reorder[]
     ename:VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR set
 endif::VK_NV_ray_tracing_invocation_reorder[]
   * [[VUID-{refpage}-x-06429]]
-    The pname:x size in code:LocalSize or code:LocalSizeId must: be less
-    than or equal to
+    In compute shaders using the code:GLCompute {ExecutionModel} the pname:x
+    size in code:LocalSize or code:LocalSizeId must: be less than or equal to
     slink:VkPhysicalDeviceLimits::pname:maxComputeWorkGroupSize[0]
   * [[VUID-{refpage}-y-06430]]
-    The pname:y size in code:LocalSize or code:LocalSizeId must: be less
-    than or equal to
+    In compute shaders using the code:GLCompute {ExecutionModel} the pname:y
+    size in code:LocalSize or code:LocalSizeId must: be less than or equal to
     slink:VkPhysicalDeviceLimits::pname:maxComputeWorkGroupSize[1]
   * [[VUID-{refpage}-z-06431]]
-    The pname:z size in code:LocalSize or code:LocalSizeId must: be less
-    than or equal to
+    In compute shaders using the code:GLCompute {ExecutionModel} the pname:z
+    size in code:LocalSize or code:LocalSizeId must: be less than or equal to
     slink:VkPhysicalDeviceLimits::pname:maxComputeWorkGroupSize[2]
   * [[VUID-{refpage}-x-06432]]
     In compute shaders using the code:GLCompute {ExecutionModel} the product of


### PR DESCRIPTION
Both VUID-RuntimeSpirv-TaskEXT-07294 and VUID-RuntimeSpirv-MeshEXT-07298 specify that the requirement only applies to task and mesh shaders, respectively, but VUID-RuntimeSpirv-x-06432 does not specify that it applies only to compute shaders. Since `maxComputeWorkGroupInvocations` is defined elsewhere as
> the maximum total number of **compute** shader invocations in a single local workgroup

this seems like an omission. This PR adds it, using the first two VUIDs as a template.

I've also given the same treatment to VUID-RuntimeSpirv-x-06429, VUID-RuntimeSpirv-x-06430 and VUID-RuntimeSpirv-x-06431, regarding the `maxComputeWorkGroupSize` limit.