### PR TITLE
Explicitly state that VkDeviceOrHostAddressConstKHR is also ignored

### DIFF
--- a/chapters/resources.adoc
+++ b/chapters/resources.adoc
@@ -6485,8 +6485,9 @@ include::{generated}/api/protos/vkGetAccelerationStructureBuildSizesKHR.adoc[]
 
 The pname:srcAccelerationStructure, pname:dstAccelerationStructure, and
 pname:mode members of pname:pBuildInfo are ignored.
-Any slink:VkDeviceOrHostAddressKHR members of pname:pBuildInfo are ignored
-by this command, except that the pname:hostAddress member of
+Any slink:VkDeviceOrHostAddressKHR or slink:VkDeviceOrHostAddressConstKHR
+members of pname:pBuildInfo are ignored by this command,
+except that the pname:hostAddress member of
 slink:VkAccelerationStructureGeometryTrianglesDataKHR::pname:transformData
 will be examined to check if it is `NULL`.
 


### PR DESCRIPTION
The spec only mentions that `vkGetAccelerationStructureBuildSizesKHR` ignores `VkDeviceOrHostAddressKHR` values, but there are also `VkDeviceOrHostAddressConstKHR` values. `VkAccelerationStructureGeometryTrianglesDataKHR::transformData`, which is mentioned explicitly in the second half of the sentence as an exception, is a `VkDeviceOrHostAddressConstKHR` value. So I assume that both types are really meant to be ignored by this function. This PR clarifies that.