### PR TITLE
Fix parameter typo "cordinates"

### DIFF
--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -1900,13 +1900,13 @@ ifdef::VK_QCOM_image_processing[]
     If an code:OpImageBlockMatchSSDQCOM or code:OpImageBlockMatchSADQCOM
     operation is used, then code:target code:sampled code:image and
     code:reference code:sampled code:image parameters must: have been
-    created with a sampler object with code:unnormalizedCordinates equal to
+    created with a sampler object with pname:unnormalizedCoordinates equal to
     ename:VK_TRUE
   * [[VUID-{refpage}-OpImageBlockMatchSSDQCOM-06987]]
     If an code:OpImageBlockMatchSSDQCOM or code:OpImageBlockMatchSADQCOM
     operation is used, then code:target code:sampled code:image and
     code:reference code:sampled code:image parameters must: have been
-    created with a sampler object with code:unnormalizedCordinates equal to
+    created with a sampler object with pname:unnormalizedCoordinates equal to
     ename:VK_TRUE
   * [[VUID-{refpage}-OpImageBlockMatchSSDQCOM-06988]]
     If an code:OpImageBlockMatchSSDQCOM or code:OpImageBlockMatchSADQCOM
@@ -2029,13 +2029,13 @@ ifdef::VK_QCOM_image_processing2[]
     code:OpImageBlockMatchGather*QCOM operation is used, then code:target
     code:sampled code:image and code:reference code:sampled code:image
     parameters must: have been created with a sampler object with
-    code:unnormalizedCordinates equal to ename:VK_TRUE
+    pname:unnormalizedCoordinates equal to ename:VK_TRUE
   * [[VUID-{refpage}-OpImageBlockMatchWindow-09224]]
     If a code:OpImageBlockMatchWindow*QCOM or
     code:OpImageBlockMatchGather*QCOM operation is used, then code:target
     code:sampled code:image and code:reference code:sampled code:image
     parameters must: have been created with sampler object with
-    code:unnormalizedCordinates equal to ename:VK_TRUE
+    pname:unnormalizedCoordinates equal to ename:VK_TRUE
   * [[VUID-{refpage}-maxBlockMatchRegion-09225]]
     If a code:OpImageBlockMatchWindow*QCOM or
     code:OpImageBlockMatchGather*QCOM operation is used, then code:Block


### PR DESCRIPTION
Fix parameter name "unnormalizedCordinates". Correct inappropriate markup.