### PR TITLE
Remove `VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR` description from `VkPipelineStageFlagBits` context

### DIFF
--- a/chapters/synchronization.adoc
+++ b/chapters/synchronization.adoc
@@ -646,13 +646,6 @@ ifdef::VK_KHR_acceleration_structure[]
     flink:vkCmdWriteAccelerationStructuresPropertiesKHR.
 endif::VK_KHR_acceleration_structure[]
 endif::VK_NV_ray_tracing,VK_KHR_acceleration_structure[]
-ifdef::VK_KHR_acceleration_structure[]
-  * ename:VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR specifies
-    the execution of flink:vkCmdCopyAccelerationStructureKHR,
-    flink:vkCmdCopyAccelerationStructureToMemoryKHR,
-    flink:vkCmdCopyMemoryToAccelerationStructureKHR, and
-    flink:vkCmdWriteAccelerationStructuresPropertiesKHR.
-endif::VK_KHR_acceleration_structure[]
 ifdef::VK_NV_ray_tracing,VK_KHR_ray_tracing_pipeline[]
   * ename:VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR specifies the
     execution of the ray tracing shader stages, via


### PR DESCRIPTION
Remove `VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR` description from `VkPipelineStageFlagBits` (non-2) context.

Not sure if there should be non-2 alternative flag bit here or not. And `FlagBits2` description of this bit seem to differ. So further intervention of the Group might be warranted.

Nevertheless this bit description does not belong here, so I just simply delete it as part of this PR. (Which might not be the correct wholistic resolution as stated above. So consider this sort of a mergeable Issue ticket.)