### PR TITLE
Specified Length for VkFrameBoundaryEXT::pTag

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -8319,7 +8319,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true" len="bufferCount">const <type>VkBuffer</type>*  <name>pBuffers</name></member>
             <member optional="true"><type>uint64_t</type>                           <name>tagName</name></member>
             <member optional="true"><type>size_t</type>                             <name>tagSize</name></member>
-            <member optional="true">const <type>void</type>*                        <name>pTag</name></member>
+            <member optional="true" len="tagSize">const <type>void</type>*          <name>pTag</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFrameBoundaryFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>


### PR DESCRIPTION
The number of bytes is specified by tagSize, just as with VkDebugMarkerObjectTagInfoEXT and VkDebugUtilsObjectTagInfoEXT