### PR TITLE
Fix copy/paste error in `VkPhysicalDeviceCudaKernelLaunchPropertiesNV`

### DIFF
--- a/chapters/limits.adoc
+++ b/chapters/limits.adoc
@@ -4374,7 +4374,7 @@ structure describe the following features:
   * [[limits-computeCapabilityMinor]] pname:computeCapabilityMinor indicates
     the minor version number of the compute code.
   * [[limits-computeCapabilityMajor]] pname:computeCapabilityMajor indicates
-    the minor version number of the compute code.
+    the major version number of the compute code.
 
 :refpage: VkPhysicalDeviceCudaKernelLaunchPropertiesNV
 include::{chapters}/limits.adoc[tag=limits_desc]


### PR DESCRIPTION
`computeCapabilityMajor` is surely supposed to represent the major and not the minor version number.