### PR TITLE
Remove incorrect optional attribute on VkCudaLaunchInfoNV::pParams and pExtras

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -7627,9 +7627,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>               <name>blockDimZ</name></member>
             <member><type>uint32_t</type>               <name>sharedMemBytes</name></member>
             <member optional="true"><type>size_t</type>                 <name>paramCount</name></member>
-            <member optional="true" len="paramCount">const <type>void</type>* const *    <name>pParams</name></member>
+            <member len="paramCount">const <type>void</type>* const *   <name>pParams</name></member>
             <member optional="true"><type>size_t</type>                 <name>extraCount</name></member>
-            <member optional="true" len="extraCount">const <type>void</type>* const *    <name>pExtras</name></member>
+            <member len="extraCount">const <type>void</type>* const *   <name>pExtras</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/Vulkan-Docs/issues/2262