### PR TITLE
Add VK_KHR_timeline_semaphore dependency for VK_NV_low_latency2.

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -23312,7 +23312,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_505&quot;"              name="VK_EXT_EXTENSION_505_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_low_latency2" number="506" author="NV" contact="Charles Hansen @cshansen" type="device" supported="vulkan">
+        <extension name="VK_NV_low_latency2" number="506" author="NV" depends="VK_VERSION_1_2,VK_KHR_timeline_semaphore" contact="Charles Hansen @cshansen" type="device" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_LOW_LATENCY_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_low_latency2&quot;"                name="VK_NV_LOW_LATENCY_2_EXTENSION_NAME"/>


### PR DESCRIPTION
vkLatencySleepNV requires the use of a timeline semaphore, therefore this extension naturally depends on the timeline semaphore extension or Vulkan 1.2 where it is promoted to Core.