### PR TITLE
make VkRenderPassStripeBeginInfoARM::pStripeInfos const

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -8882,7 +8882,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_BEGIN_INFO_ARM"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>uint32_t</type>                                          <name>stripeInfoCount</name></member>
-            <member len="stripeInfoCount"><type>VkRenderPassStripeInfoARM</type>*  <name>pStripeInfos</name></member>
+            <member len="stripeInfoCount">const <type>VkRenderPassStripeInfoARM</type>*  <name>pStripeInfos</name></member>
         </type>
         <type category="struct" name="VkRenderPassStripeSubmitInfoARM" structextends="VkCommandBufferSubmitInfo">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_SUBMIT_INFO_ARM"><type>VkStructureType</type> <name>sType</name></member>


### PR DESCRIPTION
This struct is only used to provide information, so it should be readonly.