### PR TITLE
Add missing bitwidth attribute for VkPhysicalDeviceSchedulingControlsFlagBitsARM

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -10557,7 +10557,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="1"    name="VK_PRESENT_GRAVITY_MAX_BIT_EXT"/>
         <enum bitpos="2"    name="VK_PRESENT_GRAVITY_CENTERED_BIT_EXT"/>
     </enums>
-    <enums name="VkPhysicalDeviceSchedulingControlsFlagBitsARM" type="bitmask">
+    <enums name="VkPhysicalDeviceSchedulingControlsFlagBitsARM" type="bitmask" bitwidth="64">
         <enum bitpos="0"    name="VK_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_SHADER_CORE_COUNT_ARM"/>
     </enums>
 


### PR DESCRIPTION
Fixes #2277


Change-Id: Iccc632fb3fd1e33b02e909bf6f677844ea2f65bc