### PR TITLE
Add epub generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,12 @@ ADOCPDFOPTS  = $(ADOCPDFEXTS) -a mathematical-format=svg \
 	       -a pdf-fontsdir=$(CONFIGS)/fonts,GEM_FONTS_DIR \
 	       -a pdf-stylesdir=$(CONFIGS)/themes -a pdf-style=pdf
 
-ADOCEPUBOPTS = -r asciidoctor-epub3
+# EPUB target-specific Asciidoctor options
+ADOCEPUBOPTS = -r asciidoctor-epub3 \
+	       -r asciidoctor-mathematical \
+	       -r $(CONFIGS)/asciidoctor-mathematical-ext.rb \
+	       -a mathematical-format=svg \
+	       -a imagesoutdir=$(PDFMATHDIR)
 
 # Valid usage-specific Asciidoctor extensions and options
 ADOCVUEXTS = -r $(CONFIGS)/vu-to-json.rb -r $(CONFIGS)/quiet-include-failure.rb

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ OUTDIR	  = $(GENERATED)/out
 HTMLDIR   = $(OUTDIR)/html
 VUDIR	  = $(OUTDIR)/validation
 PDFDIR	  = $(OUTDIR)/pdf
+EPUBDIR   = $(OUTDIR)/epub
 PROPOSALDIR = $(OUTDIR)/proposals
 JSAPIMAP  = $(GENERATED)/apimap.cjs
 PYAPIMAP  = $(GENERATED)/apimap.py
@@ -242,6 +243,8 @@ ADOCPDFOPTS  = $(ADOCPDFEXTS) -a mathematical-format=svg \
 	       -a pdf-fontsdir=$(CONFIGS)/fonts,GEM_FONTS_DIR \
 	       -a pdf-stylesdir=$(CONFIGS)/themes -a pdf-style=pdf
 
+ADOCEPUBOPTS = -r asciidoctor-epub3
+
 # Valid usage-specific Asciidoctor extensions and options
 ADOCVUEXTS = -r $(CONFIGS)/vu-to-json.rb -r $(CONFIGS)/quiet-include-failure.rb
 # {vuprefix} precedes some anchors which are otherwise encountered twice
@@ -362,6 +365,11 @@ $(PDFDIR)/vkspec.pdf: $(SPECSRC) $(COMMONDOCS)
 	$(QUIET)$(ASCIIDOC) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(SPECSRC)
 	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 	$(QUIET)$(RMRF) $(PDFMATHDIR)
+
+epub: $(EPUBDIR)/vkspec.epub $(SPECSRC) $(COMMONDOCS)
+
+$(EPUBDIR)/vkspec.epub: $(SPECSRC) $(COMMONDOCS)
+	$(QUIET)$(ASCIIDOC) -b epub3 $(ADOCOPTS) $(ADOCEPUBOPTS) -o $@ $(SPECSRC)
 
 validusage: $(VUDIR)/validusage.json $(SPECSRC) $(COMMONDOCS)
 


### PR DESCRIPTION
Hey all,

I really wanted the spec for my kindle scribe so I poked a bit at getting asciidoc to generate epub. Not really sure if this is something you are all interested in but I figured the PR wouldn't hurt.

Here is a sample of the output generated by `./makeSpec -spec all epub`
[vkspec.zip](https://github.com/KhronosGroup/Vulkan-Docs/files/13789917/vkspec.zip)

Let me know if there is anything I can do to improve this. I mostly followed what was already there but I'm not an expert on asciidoc so I left out the bits I didn't know much about. This requires that https://docs.asciidoctor.org/epub3-converter/latest/ be installed but I didn't add any checks for that or anything as that seems to also be the case for pdf.