### PR TITLE
Rewrite Mesh Shader Output size calculation

### DIFF
--- a/chapters/VK_NV_mesh_shader/mesh.adoc
+++ b/chapters/VK_NV_mesh_shader/mesh.adoc
@@ -169,31 +169,38 @@ These resulting primitives are then further processed as described in
 <<primsrast>>.
 
 ifdef::VK_EXT_mesh_shader[]
-With the exception of primitive indices, all output built-ins and custom
-attributes count towards the total storage size occupied by output variables
-in mesh shaders.
-This size can be calculated as follows, taking into account the fact that
-the number of effective scalar attributes is 4 times the number of effective
-locations used according to the <<interfaces-iointerfaces-locations,location
-assignment rules>>.
-Let latexmath:[v] be the number of views, latexmath:[n_v] be the number of
-effective scalar per-vertex attributes not dependent on code:ViewIndex,
-latexmath:[n_{vpv}] be the number of effective scalar per-vertex attributes
-dependent on code:ViewIndex, latexmath:[m_v] be the maximum number of
-vertices specified by the code:OutputVertices {ExecutionMode},
-latexmath:[g_v] be pname:meshOutputPerVertexGranularity, latexmath:[n_p] be
-the number of effective scalar per-primitive attributes not dependent on
-code:ViewIndex, latexmath:[n_{ppv}] be the number of effective scalar
-per-primitive attributes dependent on code:ViewIndex, latexmath:[m_p] be the
-maximum number of primitives specified by the code:OutputPrimitivesEXT
-{ExecutionMode} and latexmath:[g_p] be
-pname:meshOutputPerPrimitiveGranularity:
+With the exception of primitive indices, all built-in and user-defined
+output variables count towards the total storage size occupied by output
+variables in mesh shaders.
+This size can be calculated as follows, where the effective number of
+components is 4 times the number of locations used according to the
+<<interfaces-iointerfaces-locations,location assignment rules>>.
 
-[latexmath]
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-(n_v + (n_{vpv} \times v)) \times 4 \times \mathrm{align}(m_v, g_v) +
-(n_p + (n_{ppv} \times v)) \times 4 \times \mathrm{align}(m_p, g_p)
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ * Let code:viewCount be the number of views.
+ * Let code:perVertexComponents and code:perPrimitiveComponents respectively be
+   the effective number of per-vertex and per-primitive components that are
+   not dependent on code:ViewIndex.
+ * Let code:perVertexPerViewComponents and code:perPrimitivePerViewComponents
+   respectively be the effective number of per-vertex and per-primitive
+   components that are dependent on code:ViewIndex.
+ * code:OutputVertices and code:OutputPrimitives are the values specified by
+   the respective {ExecutionMode}.
+ * pname:meshOutputPerVertexGranularity and
+   pname:meshOutputPerPrimitiveGranularity are the respective device
+   properties.
+
+Then the total output memory size is calculated as follows:
+
+[source,c]
+----
+perVertexTotalComponents = perVertexComponents + (perVertexPerViewComponents * viewCount);
+perVertexMemorySize = perVertexTotalComponents * 4 * align(OutputVertices, meshOutputPerVertexGranularity);
+
+perPrimitiveTotalComponents = perPrimitiveComponents + (perPrimitivePerViewComponents * viewCount)
+perPrimitiveMemorySize = perPrimitiveTotalComponents * 4 * align(OutputPrimitives, meshOutputPerPrimitiveGranularity);
+
+memorySize = perVertexMemorySize + perPrimitiveMemorySize;
+----
 
 endif::VK_EXT_mesh_shader[]
 


### PR DESCRIPTION
I found this section rather confusing to follow, so here's my attempt at making it clearer. I followed the style of the "Vertex Input Address Calculation" section, using separate bullet points for the variable definitions, and C code using longer variable names instead of the cryptic (IMO) mathematical ones.

I removed the use of the term "attribute", because that term is not as well defined compared to "location" and "component". The way that "attribute" was actually being used here, with the number of attributes defined as four times the number of locations, suggests that it's intended as a synonym for "component" here, which contradicts the rest of the Vulkan spec where "attribute" is synonymous with "location" (e.g. the "Vertex Attributes" section).

There are some potential further changes I think could be made. Instead of expressing memory size as number of components * 4, it might be more straightforward to express it simply as number of locations * 16. Then the second sentence in the section I modified here isn't really needed anymore, which further helps clarity. However, there is one point that probably needs clarifying: what if a single location is shared by *both* a per-vertex and per-primitive variable (using `Component` decorations)? Is it counted towards both types?