### PR TITLE
Fix invalid generation of the "Parameters" section

### DIFF
--- a/scripts/reflib.py
+++ b/scripts/reflib.py
@@ -337,6 +337,16 @@ def fixupRefs(pageMap, specFile, file):
         pi.param = clampToBlock(pi.param, pi.include, pi.end)
         pi.body = clampToBlock(pi.body, pi.param, pi.end)
 
+        if pi.type in ['funcpointers', 'protos']:
+            # It is possible for the inferred parameter section to be invalid,
+            # such as for the type PFN_vkVoidFunction, which has no parameters.
+            # Since the parameter section is always a bullet-point list, we know
+            # the section is invalid if its text does not start with a list item.
+            # Note: This also deletes parameter sections that are simply empty.
+            if pi.param is not None and not file[pi.param].startswith('  * '):
+                pi.body = pi.param
+                pi.param = None
+
         # We can get to this point with .include, .param, and .validity
         # all being None, indicating those sections were not found.
 


### PR DESCRIPTION
In the page for [`PFN_vkVoidFunction`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/PFN_vkVoidFunction.html), the single description sentence is split over the Parameters and Description sections, like this:

> ## Parameters
> This type is returned from command function pointer queries, and **must** be
> ## Description
> cast to an actual command function pointer before use.

I found that `scripts/reflib.py` assumes every function pointer and function prototype page has parameter documentation, so I made it check that. I tested my changes by diffing the output of `./makeSpec -spec all manhtmlpages`, and found 13 affected files. First, these 3 changes seem correct to me:
* [`PFN_vkVoidFunction`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/PFN_vkVoidFunction.html)
  * The invalid Parameters section, including its heading, is gone. The whole sentence is in the Description section.
* [`vkCmdSetPerformanceMarkerINTEL`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdSetPerformanceMarkerINTEL.html)
  * The Parameters section had a single sentence, with the Description section having only "Valid Usage (Implicit)" and such. The sentence has been moved to the Description section, and the Parameters heading is gone.
* [`vkGetDeviceProcAddr`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetDeviceProcAddr.html)
  * The Parameters section had two sentences that look like they're meant to be part of the description. Those sentences have been moved into the Description section, and the Parameters heading is gone.

For 8 pages, the Parameters section was empty, and the heading is now gone. This looks fine to me, but I don't know if the Parameters section is expected to be present even when it's empty. Perhaps these pages should have some information added on each function's parameters?
* [`vkCmdCuLaunchKernelNVX`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdCuLaunchKernelNVX.html)
* [`vkCmdSetPerformanceStreamMarkerINTEL`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdSetPerformanceStreamMarkerINTEL.html)
* [`vkCreateCuFunctionNVX`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateCuFunctionNVX.html)
* [`vkCreateCuModuleNVX`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateCuModuleNVX.html)
* [`vkDestroyCuFunctionNVX`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkDestroyCuFunctionNVX.html)
* [`vkDestroyCuModuleNVX`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkDestroyCuModuleNVX.html)
* [`vkGetDescriptorSetHostMappingVALVE`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetDescriptorSetHostMappingVALVE.html)
* [`vkGetDescriptorSetLayoutHostMappingInfoVALVE`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetDescriptorSetLayoutHostMappingInfoVALVE.html)

For 2 pages, the Parameters section had a deprecation note, with the Description section having the parameters. The note has been moved to the Description section, and the Parameters heading is gone.
* [`vkCreateIOSSurfaceMVK`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateIOSSurfaceMVK.html)
* [`vkCreateMacOSSurfaceMVK`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateMacOSSurfaceMVK.html)

These MVK pages were already wrong, and are now slightly differently wrong. They need further attention from someone more familiar with this documentation repository and its conventions.