### PR TITLE
Always generate failure code section even for functions without any errors specified

### DIFF
--- a/scripts/validitygenerator.py
+++ b/scripts/validitygenerator.py
@@ -290,6 +290,14 @@ class ValidityOutputGenerator(OutputGenerator):
                     write('On failure, this command returns::', file=fp)
                     write('endif::doctype-manpage[]', file=fp)
                     write(errorcodes, file=fp)
+                else: #no errorcodes
+                    write('ifndef::doctype-manpage[]', file=fp)
+                    write('<<fundamentals-errorcodes,Failure>>::', file=fp)
+                    write('None', file=fp)
+                    write('endif::doctype-manpage[]', file=fp)
+                    write('ifdef::doctype-manpage[]', file=fp)
+                    write('This command does not return any failure codes::', file=fp)
+                    write('endif::doctype-manpage[]', file=fp)
                 write('****', file=fp)
                 write('', file=fp)
 


### PR DESCRIPTION
addresses #2317 

Before:
![before](https://github.com/KhronosGroup/Vulkan-Docs/assets/3791331/7617e312-f6f1-478a-a9b2-e3789ebff60c)

After (spec):
![none_fail](https://github.com/KhronosGroup/Vulkan-Docs/assets/3791331/3ef6d0d9-da51-4f34-a20a-19332884d943)

After (refpages):
![refpages](https://github.com/KhronosGroup/Vulkan-Docs/assets/3791331/d792a922-d629-47e9-b1ed-eb883fbc8474)


Affected functions:
![diff](https://github.com/KhronosGroup/Vulkan-Docs/assets/3791331/bc6bdccb-72c5-4ac1-8507-5b53b955658b)
