### PR TITLE
fix VK_ARM_render_pass_striped dependency

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -22639,7 +22639,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_ARM_extension_424&quot;"          name="VK_ARM_EXTENSION_424_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_ARM_render_pass_striped" number="425" type="device" depends="VK_KHR_get_physical_device_properties2,VK_KHR_synchronization2" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
+        <extension name="VK_ARM_render_pass_striped" number="425" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_synchronization2" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_ARM_RENDER_PASS_STRIPED_SPEC_VERSION"/>
                 <enum value="&quot;VK_ARM_render_pass_striped&quot;"    name="VK_ARM_RENDER_PASS_STRIPED_EXTENSION_NAME"/>


### PR DESCRIPTION
Current VK_ARM_render_pass_striped depends on [VK_KHR_get_physical_device_properties2](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_get_physical_device_properties2.html) **OR** [VK_KHR_synchronization2](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_synchronization2.html)

I think it might be a typo, and it should be **AND**.
