### PR TITLE
Replace <feature number> attribute with <feature depends>

### DIFF
--- a/registry.adoc
+++ b/registry.adoc
@@ -1,5 +1,4 @@
 // Copyright 2013-2024 The Khronos Group Inc.
-//
 // SPDX-License-Identifier: CC-BY-4.0
 
 // Core versions and extensions to enable
@@ -1302,10 +1301,32 @@ that API and version.
     Version name, used as the C preprocessor token under which the version's
     interfaces are protected against multiple inclusion.
     Example: `"VK_VERSION_1_0"`.
-  * attr:number - required.
-    Feature version number, usually a string interpreted as
-    `majorNumber.minorNumber`.
-    Example: `4.2`.
+  * attr:depends - optional.
+    String containing a boolean expression of one or more API core version
+    and extension names.
+    The feature requires the expression in the string to be satisfied to
+    use any functionality it defines.
+    Supported operators include `,` for logical OR, `+` for logical AND, and
+    `(` `)` for grouping.
+    `,` and `+` are of equal precedence, and lower than `(` `)`.
+    Expressions must be evaluated left-to-right for operators of the same
+    precedence.
+    Terms which are core version names are true if the corresponding
+    API version is supported.
+    Terms which are extension names are true if the corresponding extension
+    is enabled.
++
+--
+[NOTE]
+.Note
+====
+attr:depends replaces the attr:number attribute used in the past.
+The expected purposes of this attribute include sorting features in
+dependency order when emitting them from generator scripts, and ensuring
+that all dependent features are included when building with a specified
+feature.
+====
+--
   * attr:sortorder - optional.
     A decimal number which specifies an order relative to other tag:feature
     tags when calling output generators.
@@ -3065,6 +3086,8 @@ Changes to the `.xml` files and Python scripts are logged in GitHub history.
 [[changelog]]
 = Change Log
 
+  * 2024-05-28 - Deprecate the tag:feature attr:number tag in favor of the
+    attr:depends tag (public issue 2327).
   * 2024-05-08 - Add a tag:enums attr:type `"constants"` value for
     compile-time constant definitions so they can be treated more
     consistently (public issue 2359).

--- a/registry.adoc
+++ b/registry.adoc
@@ -1301,6 +1301,10 @@ that API and version.
     Version name, used as the C preprocessor token under which the version's
     interfaces are protected against multiple inclusion.
     Example: `"VK_VERSION_1_0"`.
+  * attr:number - required, but deprecated and will eventually be removed.
+    Feature version number, usually a string interpreted as
+    `majorNumber.minorNumber`.
+    Example: `4.2`.
   * attr:depends - optional.
     String containing a boolean expression of one or more API core version
     and extension names.

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -406,7 +406,8 @@ Command = element command {
 #   api - API tag (e.g. 'gl', 'gles2', etc. - used internally, not
 #     necessarily an actual API name
 #   name - version name (C preprocessor name, e.g. GL_VERSION_4_2)
-#   number - version number, e.g. 4.2
+#   depends - boolean expression of API and/or extension names
+#       upon which this feature depends.
 #   protect - additional #ifdef symbol to place around the feature
 #   sortorder - order relative to other features, default 0
 #   <require> / <remove> contains features to require or remove in
@@ -416,7 +417,7 @@ Command = element command {
 Feature = element feature {
     attribute api { text } ,
     Name ,
-    attribute number { xsd:float } ,
+    attribute depends { text } ?,
     attribute protect { text } ? ,
     attribute sortorder { xsd:integer } ?,
     Comment ? ,

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -406,6 +406,7 @@ Command = element command {
 #   api - API tag (e.g. 'gl', 'gles2', etc. - used internally, not
 #     necessarily an actual API name
 #   name - version name (C preprocessor name, e.g. GL_VERSION_4_2)
+#   number - version number, e.g. 4.2 - deprecated
 #   depends - boolean expression of API and/or extension names
 #       upon which this feature depends.
 #   protect - additional #ifdef symbol to place around the feature
@@ -417,6 +418,7 @@ Command = element command {
 Feature = element feature {
     attribute api { text } ,
     Name ,
+    attribute number { xsd:float } ,
     attribute depends { text } ?,
     attribute protect { text } ? ,
     attribute sortorder { xsd:integer } ?,

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -15917,7 +15917,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <command name="vkCmdExecuteCommands"/>
         </require>
     </feature>
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_1" depends="VK_VERSION_1_1" comment="Vulkan 1.1 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_1" depends="VK_VERSION_1_0" comment="Vulkan 1.1 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_1"/>
         </require>
@@ -16249,7 +16249,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <type name="VkPhysicalDeviceShaderDrawParametersFeatures"/>
         </require>
     </feature>
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_2" depends="VK_VERSION_1_2" comment="Vulkan 1.2 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_2" depends="VK_VERSION_1_1" comment="Vulkan 1.2 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_2"/>
         </require>
@@ -16444,7 +16444,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <command name="vkGetDeviceMemoryOpaqueCaptureAddress"/>
         </require>
     </feature>
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_3" depends="VK_VERSION_1_3" comment="Vulkan 1.3 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_3" depends="VK_VERSION_1_2" comment="Vulkan 1.3 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_3"/>
         </require>

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -15402,7 +15402,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </command>
     </commands>
 
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_0" number="1.0" comment="Vulkan core API interface definitions">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_0" comment="Vulkan core API interface definitions">
         <require comment="Header boilerplate">
             <type name="vk_platform"/>
             <type name="VK_DEFINE_HANDLE"/>
@@ -15917,7 +15917,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <command name="vkCmdExecuteCommands"/>
         </require>
     </feature>
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_1" number="1.1" comment="Vulkan 1.1 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_1" depends="VK_VERSION_1_1" comment="Vulkan 1.1 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_1"/>
         </require>
@@ -16249,7 +16249,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <type name="VkPhysicalDeviceShaderDrawParametersFeatures"/>
         </require>
     </feature>
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_2" number="1.2" comment="Vulkan 1.2 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_2" depends="VK_VERSION_1_2" comment="Vulkan 1.2 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_2"/>
         </require>
@@ -16444,7 +16444,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <command name="vkGetDeviceMemoryOpaqueCaptureAddress"/>
         </require>
     </feature>
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_3" number="1.3" comment="Vulkan 1.3 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_3" depends="VK_VERSION_1_3" comment="Vulkan 1.3 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_3"/>
         </require>
@@ -16709,7 +16709,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </require>
     </feature>
 
-    <feature api="vulkansc" name="VKSC_VERSION_1_0" number="1.0" comment="Vulkan SC core API interface definitions">
+    <feature api="vulkansc" name="VKSC_VERSION_1_0" depends="VK_VERSION_1_2" comment="Vulkan SC core API interface definitions">
         <require>
             <type name="VKSC_API_VARIANT"/>
             <type name="VKSC_API_VERSION_1_0"/>

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -15402,7 +15402,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </command>
     </commands>
 
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_0" comment="Vulkan core API interface definitions">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_0" number="1.0" comment="Vulkan core API interface definitions">
         <require comment="Header boilerplate">
             <type name="vk_platform"/>
             <type name="VK_DEFINE_HANDLE"/>
@@ -15917,7 +15917,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <command name="vkCmdExecuteCommands"/>
         </require>
     </feature>
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_1" depends="VK_VERSION_1_0" comment="Vulkan 1.1 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_1" number="1.1" depends="VK_VERSION_1_0" comment="Vulkan 1.1 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_1"/>
         </require>
@@ -16249,7 +16249,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <type name="VkPhysicalDeviceShaderDrawParametersFeatures"/>
         </require>
     </feature>
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_2" depends="VK_VERSION_1_1" comment="Vulkan 1.2 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_2" number="1.2" depends="VK_VERSION_1_1" comment="Vulkan 1.2 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_2"/>
         </require>
@@ -16444,7 +16444,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <command name="vkGetDeviceMemoryOpaqueCaptureAddress"/>
         </require>
     </feature>
-    <feature api="vulkan,vulkansc" name="VK_VERSION_1_3" depends="VK_VERSION_1_2" comment="Vulkan 1.3 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_3" number="1.3" depends="VK_VERSION_1_2" comment="Vulkan 1.3 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_3"/>
         </require>
@@ -16709,7 +16709,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </require>
     </feature>
 
-    <feature api="vulkansc" name="VKSC_VERSION_1_0" depends="VK_VERSION_1_2" comment="Vulkan SC core API interface definitions">
+    <feature api="vulkansc" name="VKSC_VERSION_1_0" number="1.0" depends="VK_VERSION_1_2" comment="Vulkan SC core API interface definitions">
         <require>
             <type name="VKSC_API_VARIANT"/>
             <type name="VKSC_API_VERSION_1_0"/>


### PR DESCRIPTION
Initially this PR only updates the XML schema and vk.xml. For the moment, the 'number' attribute is simply deprecated, but still required, until we can verify downstream repos are not affected.

The generator scripts will need to be modified to do a topological sort on the dependencies, and downstream repositories such as validation layers and Vulkan-Hpp will need to be updated to remove or replace their usage of the old attribute.

Closes #2327