### PR TITLE
Fix how rowExtent and sliceExtent are calculated for copy operations

### DIFF
--- a/chapters/copies.adoc
+++ b/chapters/copies.adoc
@@ -500,10 +500,10 @@ where:
             sliceExtent) + (layer {times} layerExtent)#
   {empty}:: [eq]#blockSize# is the size of the block in bytes for the format
   {empty}:: [eq]#rowExtent = max(pname:bufferRowLength,
-            {lceil}pname:imageExtent.width / blockWidth{rceil} {times}
-            blockSize)#
+            {lceil}pname:imageExtent.width / blockWidth{rceil}) {times}
+            blockSize#
   {empty}:: [eq]#sliceExtent = max(pname:bufferImageHeight,
-            pname:imageExtent.height {times} rowExtent)#
+            pname:imageExtent.height) {times} rowExtent#
   {empty}:: [eq]#layerExtent = pname:imageExtent.depth {times} sliceExtent#
 
 ifdef::VK_QCOM_rotated_copy_commands[]


### PR DESCRIPTION
`bufferRowLength` and `bufferImageHeight` are specified in texels, not bytes, therefore it is necessary to multiply them by the block size to get the correct row extent and slice extent in bytes.