### PR TITLE
Resolve warnings in Actions UI by upgrading all actions from @v3 to @v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
     container: khronosgroup/docker-images@sha256:42123ba13792c4e809d037b69152c2230ad97fbf43b677338075ab9c928ab6ed
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: REUSE license checker
         run: reuse lint
 
@@ -35,7 +35,7 @@ jobs:
     container: khronosgroup/docker-images@sha256:42123ba13792c4e809d037b69152c2230ad97fbf43b677338075ab9c928ab6ed
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Internal self-test of the check_spec_links script
         run: py.test-3 test*.py
         working-directory: scripts
@@ -51,7 +51,7 @@ jobs:
     container: khronosgroup/docker-images@sha256:42123ba13792c4e809d037b69152c2230ad97fbf43b677338075ab9c928ab6ed
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: ./makeSpec -clean -spec core -genpath gencore QUIET= -j${nproc} -Otarget chunked html
 
   spec-generate:
@@ -60,7 +60,7 @@ jobs:
     container: khronosgroup/docker-images@sha256:42123ba13792c4e809d037b69152c2230ad97fbf43b677338075ab9c928ab6ed
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the actual spec (both chunked and single-page HTML), and other common targets
         run: ./makeSpec -clean -spec all QUIET= -j${nproc} -Otarget manhtmlpages validusage styleguide registry chunked html
       - name: Check consistency of internal xrefs and anchors in the output, now that an HTML output is available
@@ -75,7 +75,7 @@ jobs:
         # just one large file:
         run: tar -cvf spec-outputs.tar gen/
       - name: Archive generated spec
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spec-outputs
           path: spec-outputs.tar
@@ -87,11 +87,11 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Generate the vulkan C++ header (vulkan.hpp)
       # Failure (should be) allowed, for now
       - name: Download generated spec
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spec-outputs
       - name: Unpack generated spec
@@ -120,7 +120,7 @@ jobs:
           ./VulkanHppGenerator -f "${SPEC_DIR}"/xml/vk.xml
           cp /tmp/Vulkan-Hpp/vulkan/*.hpp ${SPEC_DIR}/gen/include/vulkan/
       - name: Upload generated hpp
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hpp-outputs
           path: gen/include/
@@ -135,12 +135,12 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/ash-target
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: ash-rs/ash
           path: ash
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -152,7 +152,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-ash-generator-
       - name: Download generated spec
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spec-outputs
       - name: Unpack generated spec
@@ -175,7 +175,7 @@ jobs:
         # https://github.com/actions/upload-artifact#limitations, see above
         run: tar -cvf ash-outputs.tar ash/
       - name: Upload generated ash
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ash-outputs
           path: ash-outputs.tar
@@ -189,7 +189,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Sparse/shallow clone of CTS GitHub repository to pull only relevant parts
         run: |
           git clone --sparse --depth 1 --single-branch --branch main https://github.com/KhronosGroup/VK-GL-CTS.git
@@ -213,9 +213,9 @@ jobs:
     needs: spec-generate
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download generated files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spec-outputs
       - name: Unpack generated spec
@@ -234,15 +234,15 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download generated spec
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spec-outputs
       - name: Unpack generated spec
         run: tar -xvf spec-outputs.tar
       - name: Download generated hpp
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: hpp-outputs
           path: gen/include/
@@ -261,12 +261,12 @@ jobs:
 
     steps:
       - name: Download generated files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ash-outputs
       - name: Unpack generated Ash crate
         run: tar -xvf ash-outputs.tar
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
The most problematic case is paired download/upload-artifact, which requires unique artifact names. Since we don't run this under a test matrix I don't think it should be a problem.