### PR TITLE
Try to fix a typo and additional remark physical-device-level function validusage for Newer Core Versions

### DIFF
--- a/chapters/fundamentals.adoc
+++ b/chapters/fundamentals.adoc
@@ -1255,7 +1255,7 @@ ifdef::VK_VERSION_1_1,VK_KHR_get_physical_device_properties2[]
 Physical-device-level functionality or behavior added by a <<extensions,
 device extension>> to the API must: not be used unless the conditions
 described in <<initialization-phys-dev-extensions, Extending Physical Device
-Core Functionality>> are met.
+From Device Extensions>> are met.
 endif::VK_VERSION_1_1,VK_KHR_get_physical_device_properties2[]
 
 Device-level functionality added by a <<extensions, device extension>> that
@@ -1281,6 +1281,9 @@ core version>> of the API must: not be used unless it is supported by the
 physical device as determined by
 slink:VkPhysicalDeviceProperties::pname:apiVersion and the specified version
 of slink:VkApplicationInfo::pname:apiVersion.
+Or the conditions described in 
+<<_extending_physical_device_core_functionality, Extending Physical Device
+Core Functionality>> are met.
 
 Device-level functionality or behavior added by a <<versions, new core
 version>> of the API must: not be used unless it is supported by the device


### PR DESCRIPTION
## First
![image](https://github.com/KhronosGroup/Vulkan-Docs/assets/40132375/25ff38e6-05d0-4d7b-bbd7-0b0740b73af5)
The url point to [Extending Physical Device From Device Extensions](https://docs.vulkan.org/spec/latest/chapters/initialization.html#initialization-phys-dev-extensions) but it write `Extending Physical Device Core Functionality` maybe this is a typo.

## Second
![image](https://github.com/KhronosGroup/Vulkan-Docs/assets/40132375/200c8781-b8e5-42d9-b794-b1914cf41c3c)
The `Physical-device-level functionality valid Usage` describe maybe need add [Extending Physical Device Core Functionality](https://docs.vulkan.org/spec/latest/chapters/initialization.html#_extending_physical_device_core_functionality) link as a supplement.

The `Extending Physical Device Core Functionality`:
---
![image](https://github.com/KhronosGroup/Vulkan-Docs/assets/40132375/2f5d05e2-2df9-432d-a5ce-51fa81853165)

