### PR TITLE
Display Timing Queries: Clarify behaviour of VK_PRESENT_MODE_FIFO_RELAXED_KHR

### DIFF
--- a/chapters/VK_GOOGLE_display_timing/queries.adoc
+++ b/chapters/VK_GOOGLE_display_timing/queries.adoc
@@ -252,7 +252,7 @@ The semantics for other present modes are as follows:
   * ename:VK_PRESENT_MODE_FIFO_RELAXED_KHR.
     For images that are presented in time to be displayed at the next
     vertical blanking period, the semantics are identical as for
-    ename:VK_PRESENT_MODE_FIFO_RELAXED_KHR.
+    ename:VK_PRESENT_MODE_FIFO_KHR.
     For images that are presented late, and are displayed after the start of
     the vertical blanking period (i.e. with tearing), the values of
     sname:VkPastPresentationTimingGOOGLE may: be treated as if the image was


### PR DESCRIPTION
The current wording about `VK_PRESENT_MODE_FIFO_RELAXED_KHR` made no sense. Fixed it up to match the actual behaviour of this presentation mode.