### PR TITLE
Add a "constants" type= attribute to <enums> tags

### DIFF
--- a/registry.adoc
+++ b/registry.adoc
@@ -806,9 +806,9 @@ was based on.
     group.
     If present, this attribute should match the attr:name attribute of a
     corresponding tag:type tag.
-  * attr:type - optional.
+  * attr:type - required.
     String describing the data type of the values of this group of enums.
-    At present the only accepted categories are `enum` and `bitmask`, as
+    The accepted categories are `bitmask`, `constants`, and `enum`, as
     described below.
   * attr:comment - optional.
     Arbitrary string (unused).
@@ -849,7 +849,7 @@ this results in
 [[tag-enum]]
 = Enumerants (tag:enum Tag)
 
-Each tag:enum tag defines a single Vulkan (or other API) token.
+Each tag:enum tag defines a single API token.
 
 == Attributes of tag:enum Tags
 
@@ -2404,10 +2404,10 @@ These correspond to the definitions found in the first tag:enums section of
 
 [source,xml]
 --------------------------------------
-<enums name="API Constants"
+<enums name="API Constants" type="constants"
        comment="Vulkan hardcoded constants - not an enumerated type, part of the header boilerplate">
-    <enum value="256"        name="VK_MAX_PHYSICAL_DEVICE_NAME"/>
-    <enum value="256"        name="VK_MAX_EXTENSION_NAME"/>
+    <enum type="uint32_t" value="256"   name="VK_MAX_PHYSICAL_DEVICE_NAME"/>
+    <enum type="uint32_t" value="256"   name="VK_MAX_EXTENSION_NAME"/>
     ...
 --------------------------------------
 
@@ -2626,7 +2626,7 @@ Then go to the tag:enums block labeled
 
 [source,xml]
 --------------------------------------
-<enums comment="Misc. hardcoded constants - not an enumerated type">
+<enums name="API Constants" type="constants" ...>
 --------------------------------------
 
 In this block, add a tag whose attr:name attribute matches the attr:name you
@@ -3065,6 +3065,9 @@ Changes to the `.xml` files and Python scripts are logged in GitHub history.
 [[changelog]]
 = Change Log
 
+  * 2024-05-08 - Add a tag:enums attr:type `"constants"` value for
+    compile-time constant definitions so they can be treated more
+    consistently (public issue 2359).
   * 2024-04-03 - Add `"SFIXED5"` as an allowed tag:component
     attr:numericFormat type (internal issue 3802).
   * 2024-03-20 - Add a NOTE to the tag:command attr:errorcodes attribute

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -199,18 +199,18 @@ Type = element type {
 # <enums> defines a group of enumerants
 #   name - identifies a type name associated with this group. Should
 #       match a <type> name to trigger generation of the type.
-#   type - 'enum' or 'bitmask', if present
+#   type - 'bitmask', 'constants' or 'enum'.
 #   bitwidth - bit width of the enum value type.
 #   comment - descriptive text with no semantic meaning
 Enums = element enums {
     attribute name { text } ? ,
-    attribute type { text } ? ,
+    attribute type { text } ,
     attribute bitwidth { Integer } ? ,
     Comment ? ,
     (
         Enum |
         Unused |
-        element comment { text}
+        element comment { text }
     ) *
 }
 

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -9128,7 +9128,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
 
     <comment>Vulkan enumerant (token) definitions</comment>
 
-    <enums name="API Constants" comment="Vulkan hardcoded constants - not an enumerated type, part of the header boilerplate">
+    <enums name="API Constants" type="constants" comment="Vulkan hardcoded constants - not an enumerated type, part of the header boilerplate">
         <enum type="uint32_t" value="256"       name="VK_MAX_PHYSICAL_DEVICE_NAME_SIZE"/>
         <enum type="uint32_t" value="16"        name="VK_UUID_SIZE"/>
         <enum type="uint32_t" value="8"         name="VK_LUID_SIZE"/>


### PR DESCRIPTION
For more consistency with handling other enums type= attributes.

This is purely additive to the schema but it is conceivable that downstream scripts would look for this attribute *not* being present to indicate compile-time constants, so this should be checked against CTS / VVL / Vulkan-Hpp binding / Rust binding usage.

Closes #2359