### PR TITLE
Clarify that the KHR and EXT load_store_op_none extensions were not promoted to Vulkan 1.3

### DIFF
--- a/appendices/VK_EXT_load_store_op_none.adoc
+++ b/appendices/VK_EXT_load_store_op_none.adoc
@@ -37,6 +37,15 @@ functionality.
 
 include::{generated}/interfaces/VK_EXT_load_store_op_none.adoc[]
 
+[NOTE]
+.Note
+====
+While ename:VK_ATTACHMENT_STORE_OP_NONE is part of Vulkan 1.3, this
+extension was not promoted to core either in whole or in part.
+This functionality was promoted from `apiext:VK_KHR_dynamic_rendering`.
+====
+
+
 === Version History
 
   * Revision 1, 2021-06-06 (Shahbaz Youssefi)

--- a/appendices/VK_KHR_load_store_op_none.adoc
+++ b/appendices/VK_KHR_load_store_op_none.adoc
@@ -21,6 +21,14 @@ the `apiext:VK_EXT_load_store_op_none` extension.
 
 include::{generated}/interfaces/VK_KHR_load_store_op_none.adoc[]
 
+[NOTE]
+.Note
+====
+While ename:VK_ATTACHMENT_STORE_OP_NONE is part of Vulkan 1.3, this
+extension was not promoted to core either in whole or in part.
+This functionality was promoted from `apiext:VK_KHR_dynamic_rendering`.
+====
+
 === Version History
 
   * Revision 1, 2023-05-16 (Shahbaz Youssefi)


### PR DESCRIPTION
Closes #2357