### PR TITLE
Add driver ID for Honeykrisp

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -10370,7 +10370,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="23"      name="VK_DRIVER_ID_MESA_DOZEN"                    comment="Mesa open source project"/>
         <enum value="24"      name="VK_DRIVER_ID_MESA_NVK"                      comment="Mesa open source project"/>
         <enum value="25"      name="VK_DRIVER_ID_IMAGINATION_OPEN_SOURCE_MESA"  comment="Imagination Technologies"/>
-        <enum value="26"      name="VK_DRIVER_ID_MESA_AGXV"                     comment="Mesa open source project"/>
+        <enum value="26"      name="VK_DRIVER_ID_MESA_HONEYKRISP"               comment="Mesa open source project"/>
         <enum value="27"      name="VK_DRIVER_ID_RESERVED_27"                   comment="Reserved for undisclosed driver project"/>
     </enums>
     <enums name="VkConditionalRenderingFlagBitsEXT" type="bitmask">


### PR DESCRIPTION
The Vulkan driver for Apple Silicon. 1.3 conformant [1] and should ship later this year

AGXV never shipped or passed CTS, so dropping its ID should be relatively safe from a backwards compatibility perspective.

[1] https://rosenzweig.io/blog/vk13-on-the-m1-in-1-month.html

--

cc @1ace @ella-0