### PR TITLE
Deleted Stray Letter 'j' in CmdBuffers Chapter

### DIFF
--- a/chapters/cmdbuffers.adoc
+++ b/chapters/cmdbuffers.adoc
@@ -641,7 +641,7 @@ include::{generated}/api/protos/vkAllocateCommandBuffers.adoc[]
     Each allocated command buffer begins in the initial state.
 
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance1[]
-jfname:vkAllocateCommandBuffers can: be used to allocate multiple command
+fname:vkAllocateCommandBuffers can: be used to allocate multiple command
 buffers.
 If the allocation of any of those command buffers fails, the implementation
 must: free all successfully allocated command buffer objects from this


### PR DESCRIPTION
A stray letter j is rendered in the published specification as: "jvkAllocateCommandBuffers can be used to allocate multiple..."

A quick check for similar typos confirms the fix in this commit is a one-off:

    rgrep "\b[a-zA-Z]fname"
    chapters/cmdbuffers.adoc:jfname:vkAllocateCommandBuffers can: ...