### PR TITLE
Add location order to the definition of from-reads

### DIFF
--- a/appendices/memorymodel.adoc
+++ b/appendices/memorymodel.adoc
@@ -1016,8 +1016,8 @@ value written by the first operation.
 _From-reads_ is a relation between operations, where the first operation is
 a read, the second operation is a write, and the first operation reads a
 value written earlier than the second operation in the second operation's
-scoped modification order (or the first operation reads from the initial
-value, and the second operation is any write to the same locations).
+scoped modification order or location order (or the first operation reads from
+the initial value, and the second operation is any write to the same locations).
 
 Then the implementation must: guarantee that no cycles exist in the union of
 the following relations:


### PR DESCRIPTION
We are currently [discussing a problem](https://github.com/KhronosGroup/Vulkan-MemoryModel/issues/36) and a [potential fix](https://github.com/KhronosGroup/Vulkan-MemoryModel/pull/37) with the members of the Memory Model TSG. If the fix gets accepted, the specification also needs to be updated to reflect this change.