### PR TITLE
Merge equivalent require blocks

### DIFF
--- a/scripts/find_equivalent_ext_require_blocks.py
+++ b/scripts/find_equivalent_ext_require_blocks.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+# Copyright 2024 Waffl3x
+# SPDX-License-Identifier: Apache-2.0
+
+import xml.etree.ElementTree as etree
+import itertools
+
+tree = etree.parse('vk.xml')
+doc = tree.getroot()
+
+extensions = doc.find('extensions')
+
+def check_if_children_equal(req1, req2):
+    if len(req1) != len(req2):
+        return False
+    for child1, child2 in zip(req1, req2):
+        if child1.tag != child2.tag:
+            return False
+        if child1.attrib != child2.attrib:
+            return False
+    return True
+# def check_if_children_equal
+
+for ext in extensions:
+    req_with_depends = []
+    # put all candidates into a list
+    for req, count in zip(ext, itertools.count()):
+        if 'depends' in req.attrib:
+            req_with_depends.append((req, count))
+    
+    # compare candidates in a pairwise manner
+    for tup1, it2_start in zip(req_with_depends[:-1], range(1, len(req_with_depends))):
+        for tup2 in req_with_depends[it2_start:]:
+            req1, req_count1 = tup1
+            req2, req_count2 = tup2
+            all_match = check_if_children_equal(req1, req2)
+            if all_match:
+                print('Found matching require block in extension {}:'.format(ext.attrib['name']))
+                print('blocks {} and {} are equal'.format(req_count1, req_count2))
+                print('require block {} attributes: {}'.format(req_count1, req1.attrib))
+                print('require block {} attributes: {}'.format(req_count2, req2.attrib))
+                print('  block children:')
+                for child1, child2 in zip(req1, req2):
+                    print('    ', req_count1, ': ', child1.attrib)
+                    print('    ', req_count2, ': ', child2.attrib)

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -18125,11 +18125,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdPushDescriptorSetKHR"/>
                 <type name="VkPhysicalDevicePushDescriptorPropertiesKHR"/>
             </require>
-            <require depends="VK_VERSION_1_1">
-                <command name="vkCmdPushDescriptorSetWithTemplateKHR"/>
-                <enum value="1" extends="VkDescriptorUpdateTemplateType"    name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR" comment="Create descriptor update template for pushed descriptor updates"/>
-            </require>
-            <require depends="VK_KHR_descriptor_update_template">
+            <require depends="VK_VERSION_1_1,VK_KHR_descriptor_update_template">
                 <command name="vkCmdPushDescriptorSetWithTemplateKHR"/>
                 <enum value="1" extends="VkDescriptorUpdateTemplateType"    name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR" comment="Create descriptor update template for pushed descriptor updates"/>
             </require>
@@ -20515,10 +20511,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT"/>
                 <type name="VkSurfaceFullScreenExclusiveWin32InfoEXT"/>
             </require>
-            <require depends="VK_KHR_device_group">
-                <command name="vkGetDeviceGroupSurfacePresentModes2EXT"/>
-            </require>
-            <require depends="VK_VERSION_1_1">
+            <require depends="VK_KHR_device_group,VK_VERSION_1_1">
                 <command name="vkGetDeviceGroupSurfacePresentModes2EXT"/>
             </require>
         </extension>


### PR DESCRIPTION
Addresses #2404
Merges extension require blocks that have identical children, extending the depends attribute with a logical or.