### PR TITLE
Add VK_EXT_disable_wayland_color_management

### DIFF
--- a/appendices/VK_EXT_disable_wayland_color_management.adoc
+++ b/appendices/VK_EXT_disable_wayland_color_management.adoc
@@ -1,0 +1,31 @@
+// Copyright 2016-2024 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_disable_wayland_color_management.adoc[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2024-08-16
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+    Colin Marc
+
+=== Description
+
+This extension expands tlink:VkWaylandSurfaceCreateFlagsKHR to allow
+applications to request that implementations avoid using the
+`wp_color_management` protocol when creating or managing the surface.
+
+include::{generated}/interfaces/VK_EXT_disable_wayland_color_management.adoc[]
+
+=== Issues
+
+None.
+
+=== Version History
+
+  * Revision 1, 2024-08-16 (Colin Marc)
+  ** Initial draft

--- a/appendices/VK_KHR_wayland_surface.adoc
+++ b/appendices/VK_KHR_wayland_surface.adoc
@@ -90,3 +90,6 @@ an onerous restriction on application developers.
      ename:VK_PRESENT_MODE_MAILBOX_KHR.
   ** Added wording about interactions between flink:vkQueuePresentKHR and
      the Wayland requests sent to the compositor.
+
+  * Revision 7, 2024-08-16 (Colin Marc)
+  ** Added VkWaylandSurfaceCreateFlagBits.

--- a/chapters/VK_KHR_swapchain/wsi.adoc
+++ b/chapters/VK_KHR_swapchain/wsi.adoc
@@ -418,6 +418,14 @@ endif::VK_KHR_shared_presentable_image[]
     and pname:colorSpace members, respectively, of one of the
     sname:VkSurfaceFormatKHR structures returned by
     fname:vkGetPhysicalDeviceSurfaceFormatsKHR for the surface
+ifdef::VK_EXT_disable_wayland_color_management[]
+  * [[VUID-VkSwapchainCreateInfoKHR-imageColorSpace-00000]]
+    If pname:surface was created using flink:vkCreateWaylandSurfaceKHR and
+    sname:VkWaylandSurfaceCreateInfoKHR::pname:flags containing
+    ename:VK_WAYLAND_SURFACE_CREATE_DISABLE_COLOR_MANAGEMENT_BIT_EXT, then
+    sname:VkSwapchainCreateInfoKHR:pname:imageColorSpace must: be
+    ename:VK_COLOR_SPACE_PASS_THROUGH_EXT
+endif::VK_EXT_disable_wayland_color_management[]
   * [[VUID-VkSwapchainCreateInfoKHR-pNext-07781]]
 ifdef::VK_EXT_swapchain_maintenance1[]
     If a slink:VkSwapchainPresentScalingCreateInfoEXT structure was not

--- a/chapters/VK_KHR_wayland_surface/platformCreateSurface_wayland.adoc
+++ b/chapters/VK_KHR_wayland_surface/platformCreateSurface_wayland.adoc
@@ -35,7 +35,8 @@ include::{generated}/api/structs/VkWaylandSurfaceCreateInfoKHR.adoc[]
   * pname:sType is a elink:VkStructureType value identifying this structure.
   * pname:pNext is `NULL` or a pointer to a structure extending this
     structure.
-  * pname:flags is reserved for future use.
+  * pname:flags is a bitmask of elink:VkWaylandSurfaceCreateFlagBitsKHR
+    specifying additional surface creation parameters.
   * pname:display and pname:surface are pointers to the Wayland
     code:wl_display and code:wl_surface to associate the surface with.
 
@@ -87,10 +88,25 @@ If the application wishes to synchronize any window changes with a
 particular frame, such requests must: be sent to the Wayland display server
 prior to calling flink:vkQueuePresentKHR.
 
-[open,refpage='VkWaylandSurfaceCreateFlagsKHR',desc='Reserved for future use',type='flags']
+[open,refpage='VkWaylandSurfaceCreateFlagBitsKHR',desc='Bitmask specifying additional parameters for the Wayland surface.',type='enums',xrefs='VkWaylandSurfaceCreateInfoKHR']
+--
+include::{generated}/api/enums/VkWaylandSurfaceCreateFlagBitsKHR.adoc[]
+--
+
+ifdef::VK_EXT_disable_wayland_color_management[]
+Possible values of the pname:flags member of
+slink:VkWaylandSurfaceCreateInfoKHR are:
+
+  * ename:VK_WAYLAND_SURFACE_CREATE_DISABLE_COLOR_MANAGEMENT_BIT_EXT specifies
+    that the implementation should avoid using the `wp_color_management` protocol
+    manage the surface.
+endif::VK_EXT_disable_wayland_color_management[]
+
+
+[open,refpage='VkWaylandSurfaceCreateFlagsKHR',desc='Bitmask of VkWaylandSurfaceCreateFlagBitsKHR',type='flags']
 --
 include::{generated}/api/flags/VkWaylandSurfaceCreateFlagsKHR.adoc[]
 
-tname:VkWaylandSurfaceCreateFlagsKHR is a bitmask type for setting a mask,
-but is currently reserved for future use.
+tname:VkWaylandSurfaceCreateFlagsKHR is a bitmask type for setting a mask of
+zero or more elink:VkWaylandSurfaceCreateFlagBitsKHR.
 --

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -402,7 +402,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDisplaySurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkAndroidSurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkViSurfaceCreateFlagsNN</name>;</type>
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkWaylandSurfaceCreateFlagsKHR</name>;</type>
+        <type requires= "VkWaylandSurfaceCreateFlagBitsKHR" category="bitmask">typedef <type>VkFlags</type> <name>VkWaylandSurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkWin32SurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXlibSurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXcbSurfaceCreateFlagsKHR</name>;</type>
@@ -877,6 +877,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkOutOfBandQueueTypeNV" category="enum"/>
         <type name="VkPhysicalDeviceSchedulingControlsFlagBitsARM" category="enum"/>
         <type name="VkMemoryUnmapFlagBitsKHR" category="enum"/>
+        <type name="VkWaylandSurfaceCreateFlagBitsKHR" category="enum"/>
 
             <comment>Enumerated types in the header, but not used by the API</comment>
         <type name="VkVendorId" category="enum"/>
@@ -11322,6 +11323,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
     </enums>
     <enums name="VkMemoryUnmapFlagBitsKHR" type="bitmask">
     </enums>
+    <enums name="VkWaylandSurfaceCreateFlagBitsKHR" type="bitmask">
+    </enums>
 
     <commands comment="Vulkan command definitions">
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_LAYER_NOT_PRESENT,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_INCOMPATIBLE_DRIVER">
@@ -17026,10 +17029,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </extension>
         <extension name="VK_KHR_wayland_surface" number="7" type="instance" depends="VK_KHR_surface" platform="wayland" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="6"                                                 name="VK_KHR_WAYLAND_SURFACE_SPEC_VERSION"/>
+                <enum value="7"                                                 name="VK_KHR_WAYLAND_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_wayland_surface&quot;"                name="VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR"/>
                 <type name="VkWaylandSurfaceCreateFlagsKHR"/>
+                <type name="VkWaylandSurfaceCreateFlagBitsKHR"/>
                 <type name="VkWaylandSurfaceCreateInfoKHR"/>
                 <command name="vkCreateWaylandSurfaceKHR"/>
                 <command name="vkGetPhysicalDeviceWaylandPresentationSupportKHR"/>
@@ -24648,11 +24652,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="17" extends="VkExternalMemoryHandleTypeFlagBits" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_603_BIT_2_EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_604" number="604" author="EXT" contact="Colin Marc @colinmarc" supported="disabled">
+        <extension name="VK_EXT_disable_wayland_color_management" number="604" type="instance" depends="VK_KHR_wayland_surface+VK_EXT_swapchain_colorspace" author="EXT" contact="Colin Marc @colinmarc" supported="vulkan">
             <require>
-                <enum value="0"                                              name="VK_EXT_EXTENSION_604_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_604&quot;"               name="VK_EXT_EXTENSION_604_EXTENSION_NAME"/>
-                <enum bitpos="0" extends="VkWaylandSurfaceCreateFlagBitsKHR" name="VK_WAYLAND_SURFACE_CREATE_DISABLE_COLOR_MANAGEMENT"/>
+                <enum value="1"                                                   name="VK_EXT_DISABLE_WAYLAND_COLOR_MANAGEMENT_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_disable_wayland_color_management&quot;" name="VK_EXT_DISABLE_WAYLAND_COLOR_MANAGEMENT_EXTENSION_NAME"/>
+                <enum bitpos="0" extends="VkWaylandSurfaceCreateFlagBitsKHR"      name="VK_WAYLAND_SURFACE_CREATE_DISABLE_COLOR_MANAGEMENT_BIT_EXT"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
### VK_EXT_disable_wayland_color_management

This adds a small extension, allowing applications to request that WSI implementations avoid using wayland color management, so that they can do it themselves. This addresses #2307.

## Background

Wayland is growing color management and HDR support, in the soon-to-be-finalized `wp_color_management` protocol[^1]. The protocol has support for tagging surfaces with colorspace information and HDR metadata, generally in ways matching up to Vulkan's [`VK_KHR_swapchain_colorspace`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_swapchain_colorspace.html) and [`VK_EXT_hdr_metadata`](https://registry.khronos.org/VulkanSC/specs/1.0-extensions/man/html/VK_EXT_hdr_metadata.html), but also with facilities that are not currently expressible via Vulkan or other graphics APIs, such as using an ICC profile to describe a surface's content.

As such, applications wanting to do color management or output HDR content on Wayland will roughly fall into three buckets:

 1. Image viewers and other utility apps that use Wayland directly, but not Vulkan or other graphics APIs
 2. Games, video players, and the like, which will use Vulkan or other graphics APIs, but not the Wayland protocol directly
 3. Content creation apps, which are picky about color management and wish to use the Wayland protocol directly, but also want to use Vulkan/etc to submit GPU buffers

The protocol's design is such that only one Wayland client may do color management for a particular surface at once. Specifically, only one `color_management_surface` may exist for a given Wayland surface at a time. Applications in the first group will create this object themselves, while applications in the second group will use `VK_KHR_swapchain_colorspace` and other related extensions, and rely on WSI implementations to do the tagging for them. The third group wants to create the object themselves, but needs to prevent the WSI implementation from also creating the object, since that would be a protocol violation. Hence this extension.

## Alternatives considered

### 1. Check whether `VK_KHR_swapchain_colorspace` is enabled

WSI implementations could check whether the application has enabled the extension, and only create `color_management_surface` objects if it is. This has a few problems:

 - It uses an instance extension to signal an option that really should be per-surface, changing the behavior of all surfaces created from the same instance.
 - Because the extension is disabled, the application has no access to `VK_COLOR_SPACE_PASS_THROUGH_EXT`, which matches the behavior they want, and must use `VK_COLOR_SPACE_SRGB_NONLINEAR_KHR`, which may be completely unrelated to the content of their surface, to mean that the surface should remain untagged.

### 2. Switch on `VK_COLOR_SPACE_PASS_THROUGH_EXT`

This is more intuitively correct. Applications that set `PASS_THROUGH` would seem to be indicating that they want the surface to be untagged. However, this is difficult to implement. By the time the swapchain is create, the wayland surface has already been created, which means the driver must delay deciding whether to create the `color_management_surface` object. Furthermore, if another swapchain is created with a different colorspace, the `color_management_surface` must be created at that point, and then destroyed if the colorspace is again set to `PASS_THROUGH`. All of those operations could potentially race with the application's creation or destruction of the `color_management_surface` object, and such shenanigans would be pretty error-prone in general.

## Note

I would like to create a validation check to ensure that surfaces created with `VK_WAYLAND_SURFACE_CREATE_DISABLE_COLOR_MANAGEMENT` must only be used to create swapchains with `VK_COLOR_SPACE_PASS_THROUGH_EXT`. Should that go in this PR, or somewhere else? Should the validation be on `vkCreateSwapchainKHR` or on `VkWaylandCreateSurafceKHR`?

[^1]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14