### PR TITLE
vkGetInstanceProcAddr get device extension dispathcable command that extension must been enabled

### DIFF
--- a/chapters/initialization.adoc
+++ b/chapters/initialization.adoc
@@ -64,7 +64,7 @@ endif::VK_VERSION_1_2[]
 | instance         | flink:vkGetInstanceProcAddr                  | fp
 | instance         | core _dispatchable command_                  | fp^3^
 | instance         | enabled instance extension dispatchable command for pname:instance    | fp^3^
-| instance         | available device extension^4^ dispatchable command for pname:instance | fp^3^
+| instance         | enabled and available device extension^4^ dispatchable command for pname:instance | fp^3^
 2+|  any other case, not covered above                            | `NULL`
 |====
 


### PR DESCRIPTION
In my system case, if I didn't enabled device extension, but fetch function pointer directly, it will return `NULL` .

I think we had better add the limilt about `enabled device extension` .

✧(≖ ◡ ≖) 