### PR TITLE
Support the `stride` attribute for array pointers

### DIFF
--- a/registry.adoc
+++ b/registry.adoc
@@ -642,6 +642,9 @@ The tag:member tag defines the type and name of a structure or union member.
     item count in attr:len list.
     This attribute is intended to support consumers of the XML who need to
     generate validation code from the allowed length.
+  * attr:stride - if the member is an array, stride specifies the name of
+    another member containing the byte stride between consecutive elements
+    in the array. The array is assumed to be tightly packed if omitted.
   * attr:deprecated - optional.
     Indicates that this member has been deprecated.
     Possible values are:
@@ -719,9 +722,6 @@ Explicitly specifying `optional="false"` is not supported, but
     Specifies the name of another member which must be a `VkObjectType` or
     `VkDebugReportObjectTypeEXT` value specifying the type of object the
     handle refers to.
-  * attr:stride - if the member is an array, stride specifies the name of
-    another member containing the byte stride between consecutive elements
-    in the array. Is assumed tightly packed if omitted.
 
 
 ==== Contents of tag:member Tags
@@ -1232,6 +1232,9 @@ and union members.
     item count in attr:len list.
     This attribute is intended to support consumers of the XML who need to
     generate validation code from the allowed length.
+  * attr:stride - if the member is an array, stride specifies the name of
+    another member containing the byte stride between consecutive elements
+    in the array. The array is assumed to be tightly packed if omitted.
   * attr:optional - optional.
     A value of `"true"` specifies that this parameter can be omitted by
     providing `NULL` (for pointers), `VK_NULL_HANDLE` (for handles), or 0
@@ -3308,6 +3311,9 @@ Changes to the `.xml` files and Python scripts are logged in GitHub history.
 [[changelog]]
 = Change Log
 
+  * 2024-09-18 - Support the attr:stride attribute for array pointers in
+    both <<tag-command:param:attr, command tag:param>> and <<tag:type,
+    structure tag:member>> tags (public issue 2435).
   * 2024-08-22 - Add <<tag-required-remove, tag:remove>> attribute
     attr:reasonlink and <<tag-required, tag:required and tag:remove>>
     attribute <<tag-required-feature, tag:feature>>, to support adding

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -70,6 +70,8 @@ Types = element types {
 
 # <type> defines a single type. It is usually a C typedef but
 # may contain arbitrary C code.
+# The attributes are more fully described in the registry schema document.
+#
 #   name - name of this type, if not present in the <name> tag
 #   api - matches a <feature> api attribute, if present
 #   alias - name of a type this type aliases
@@ -116,6 +118,10 @@ Types = element types {
 #           or a latex equation (prefixed with 'latexmath:')
 #       altlen - if len has latexmath equations, this contains equivalent C99
 #                expressions separated by commas.
+#       stride - if the member is an array, stride specifies the name of
+#           another member containing the byte stride between consecutive
+#           elements in the array. The array is assumed to be tightly packed
+#           if omitted.
 #       deprecated - denotes that this member is deprecated, and why.
 #           Valid values: 'ignored', 'true'.
 #       externsync - denotes that the member should be externally synchronized
@@ -176,6 +182,7 @@ Type = element type {
                 attribute api { text } ? ,
                 attribute len { text } ? ,
                 attribute altlen { text } ? ,
+                attribute stride { text } ? ,
                 attribute externsync { text } ? ,
                 attribute optional { text } ? ,
                 attribute selector { text } ? ,
@@ -298,6 +305,9 @@ Commands = element commands {
 # <command> defines a single command
 #
 # There are two forms of the tag.
+# The attributes are more fully described in the registry schema document.
+# The "prefix" and "suffix" attributes are currently present only in the
+# OpenCL XML registry, where they are currently unused.
 #
 # Either form may have an 'api' attribute
 #   api - matches a <feature> api attribute, if present
@@ -306,9 +316,6 @@ Commands = element commands {
 # It defines a command alias.
 #
 # The second form fully defines a command, and has the following structure:
-# The possible attributes are not described in this comment block yet, but
-# are in registry.html. The "prefix" and "suffix" attributes are currently
-# present only in the OpenCL XML registry, where they are currently unused.
 #
 #   <proto> is the C function prototype, including the return type
 #   <param> are function parameters, in order
@@ -319,6 +326,10 @@ Commands = element commands {
 #           or a latex equation (prefixed with 'latexmath:')
 #     altlen - if len has latexmath equations, this contains equivalent C99
 #              expressions separated by commas.
+#     stride - if the member is an array, stride specifies the name of
+#         another parameter containing the byte stride between consecutive
+#         elements in the array. The array is assumed to be tightly packed
+#         if omitted.
 #     externsync - denotes that the member should be externally synchronized
 #         when accessed by Vulkan
 #     optional - whether this value can be omitted by providing NULL (for
@@ -336,9 +347,6 @@ Commands = element commands {
 #         placeholders. Specifies a comma-separated list of structures which
 #         may be passed in place of the parameter, or anywhere in the pNext
 #         chain of the parameter.
-#     stride - if the member is an array, stride specifies the name of
-#         another member containing the byte stride between consecutive
-#         elements in the array. Is assumed tightly packed if omitted.
 #     <type> is a <type> name, if present
 #     <name> is the function / parameter name, if present (normally should
 #         be, except for void parameters).
@@ -377,13 +385,13 @@ Command = element command {
             attribute api { text } ? ,
             attribute len { text } ? ,
             attribute altlen { text } ? ,
+            attribute stride { text } ? ,
             attribute externsync { text } ? ,
             attribute optional { text } ? ,
             attribute selector { text } ? ,
             attribute noautovalidity { text } ? ,
             attribute objecttype { text } ? ,
             attribute validstructs { text } ? ,
-            attribute stride { text } ? ,
             mixed {
                 element type { TypeName } ? ,
                 element name { text } ?

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -24267,7 +24267,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="1"                                         name="VK_KHR_COMPUTE_SHADER_DERIVATIVES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_compute_shader_derivatives&quot;" name="VK_KHR_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType" extnumber="202"  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_KHR"/>
-                <enum offset="0" extends="VkStructureType" 		    name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_PROPERTIES_KHR"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_PROPERTIES_KHR"/>
                 <type name="VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR"/>
                 <type name="VkPhysicalDeviceComputeShaderDerivativesPropertiesKHR"/>
             </require>


### PR DESCRIPTION
 in both command `param` and structure `member` tags.

Closes #2435 