### PR TITLE
Primary node clarification for VK_EXT_physical_device_drm

### DIFF
--- a/appendices/VK_EXT_physical_device_drm.adoc
+++ b/appendices/VK_EXT_physical_device_drm.adoc
@@ -7,7 +7,7 @@ include::{generated}/meta/{refprefix}VK_EXT_physical_device_drm.adoc[]
 === Other Extension Metadata
 
 *Last Modified Date*::
-    2021-06-09
+    2024-11-07
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -25,15 +25,21 @@ Unlike the EGL extension, this extension does not expose a string containing
 the name of the device file and instead exposes device minor numbers.
 
 DRM defines multiple device node types.
-Each physical device may have one primary node and one render node
-associated.
-Physical devices may have no primary node (e.g. if the device does not have
-a display subsystem), may have no render node (e.g. if it is a software
-rendering engine), or may have neither (e.g. if it is a software rendering
-engine without a display subsystem).
+Each physical device can only be associated with a single underlying DRM
+device, which has one primary node and may have one render node.
+
+A physical device always has the primary node if it is associated with a DRM
+device. It may have no render node if e.g. it uses a software rendering engine.
 
 To query DRM properties for a physical device, chain
 slink:VkPhysicalDeviceDrmPropertiesEXT to slink:VkPhysicalDeviceProperties2.
+
+[NOTE]
+====
+This extension only returns the primary node and render node from the same
+DRM device for a Vulkan physical device. Implementations should not return the
+primary node and render node from different DRM devices.
+====
 
 include::{generated}/interfaces/VK_EXT_physical_device_drm.adoc[]
 
@@ -43,6 +49,10 @@ include::{generated}/interfaces/VK_EXT_physical_device_drm.adoc[]
     https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_device_drm.txt[`EGL_EXT_device_drm`]
 
 === Version History
+
+  * Revision 2, 2024-11-07
+  ** Clarification about the meaning of the primary node
+  ** Clarification to not advertise more than one DRM device
 
   * Revision 1, 2021-06-09
   ** First stable revision

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -22497,7 +22497,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </extension>
         <extension name="VK_EXT_physical_device_drm" number="354" author="EXT" type="device" contact="Simon Ser @emersion" supported="vulkan" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1">
             <require>
-                <enum value="1"                                             name="VK_EXT_PHYSICAL_DEVICE_DRM_SPEC_VERSION"/>
+                <enum value="2"                                             name="VK_EXT_PHYSICAL_DEVICE_DRM_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_physical_device_drm&quot;"        name="VK_EXT_PHYSICAL_DEVICE_DRM_EXTENSION_NAME"/>
 
                 <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT"/>


### PR DESCRIPTION
The extension already hinted that the primary node represents display capabilities as its intended purpose, but the current text let it ambiguous enough that there has been confusion and divergence in proposed implementations.

Add clarification notes to further define the scope of primary node in the context of this extension.

There has been a long discussion about this issue mainly at https://gitlab.freedesktop.org/mesa/mesa/-/issues/9920 .
That discussion has evolved into solving many problems of split display/render systems, but here I would like to avoid doing that again and focusing only on defining the scope of this extension.

I also discussed with the involved people again recently about proposing this note to the extension.

cc @emersion @cubanismo @fooishbar

Other references:
https://people.freedesktop.org/~cbrill/dri-log/?channel=dri-devel&highlight_names=&date=2023-07-25&show_html=true
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/25431
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31635