### PR TITLE
Add SHADY author id

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -76,6 +76,7 @@ branch of the member gitlab server.
         <tag name="FB"          author="Facebook, Inc"                 contact="Artem Bolgar @artyom17"/>
         <tag name="RASTERGRID"  author="RasterGrid Kft."               contact="Daniel Rakos @aqnuep"/>
         <tag name="MSFT"        author="Microsoft Corporation"         contact="Jesse Natalie @jenatali"/>
+        <tag name="SHADY"       author="Saarland University"           contact="Hugo Devillers @hugobros3"/>
     </tags>
 
     <types comment="Vulkan type definitions">


### PR DESCRIPTION
We'd like to reserve the `SHADY` author ID, for supporting in-development experimental SPIR-V extensions related to the https://github.com/shady-gang/shady compiler tool chain.

I didn't find any changes in the generated headers.