### PR TITLE
Migrate Antora makefile targets into top-level Makefile

### DIFF
--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -176,7 +176,7 @@ Internal Issues
     palette when VK_NV_shading_rate_image is enabled (internal MR 6872).
   * Merge common draw vertex binding VUs for shader object and pipeline
     patch control and update corresponding language in the shader object
-    <<shaders-objects-state Setting State>> section (internal MR 6876).
+    <<shaders-objects-state, Setting State>> section (internal MR 6876).
   * Fix definition of the built-in variable
     <<interfaces-builtin-variables-viewindex, ViewIndex>> to specify it
     returns bit indexes, not bit values (internal MR 6877).
@@ -519,7 +519,7 @@ Internal Issues
   * Unify markup for corresponding, but differently named subgroup property
     members of VkPhysicalDeviceVulkan11Properties and
     VkPhysicalDeviceSubgroupProperties (internal issue 3886).
-  * Fix <<spirvenv-module-validation-runtime Runtime SPIR-V Validation>> VU
+  * Fix <<spirvenv-module-validation-runtime, Runtime SPIR-V Validation>> VU
     09644 for SubpassData variables declared as arrays (internal issue
     3887).
   * Clarify when VkDescriptorSetLayout objects can be freed in the
@@ -835,7 +835,7 @@ Internal Issues
     transition, VkImageViewCreateInfo, and VkSparseImageMemoryBindInfo
     (internal MR 6522).
   * fix shader object interaction with dynamic blend states in the
-    <<shaders-objects-state]] Setting State>> section and common draw VUs
+    <<shaders-objects-state, Setting State>> section and common draw VUs
     (internal MR 6523).
 
 New Extensions
@@ -1812,10 +1812,11 @@ Internal Issues
     3537).
   * Remove check in reflow.py that did not allow embedded conditionals in VU
     statement markup (internal issue 3545).
-  * Reduce duplication of spec language in the <<Cooperative Matrices>>
-    section, where the apiext:VK_KHR_cooperative_matrix interfaces are
-    similar to, but not promoted from the apiext:VK_NV_cooperative_matrix
-    interfaces (internal issue 3547).
+  * Reduce duplication of spec language in the
+    <<cooperative-matrices,Cooperative Matrices>> section, where the
+    apiext:VK_KHR_cooperative_matrix interfaces are similar to, but not
+    promoted from the apiext:VK_NV_cooperative_matrix interfaces (internal
+    issue 3547).
   * Fix shader tile image access for depth/stencil images in
     elink:VkAccessFlagBits2 and elink:VkAccessFlagsBits (internal merge
     request 5912)
@@ -1973,8 +1974,8 @@ Internal Issues
     will ease keeping the two repositories closely synchronized (internal
     merge request 5930).
   * Update precision for code:degrees() and code:radians() instructions
-    in the <<Precision of GLSL.std.450 Instructions>> table
-    (internal merge request 5922).
+    in the <<precision-of-glsl-std-450-instructions, Precision of
+    GLSL.std.450 Instructions>> table (internal merge request 5922).
   * Fix definition of code:ulp() in the
     <<spirvenv-op-prec, Precision of Individual Operations>>
     section to limit the definition to finite numbers
@@ -2923,7 +2924,7 @@ Internal Issues:
   * Tighten wording around <<descriptor-validity>> and in the
     <<descriptor-set-initial-state>> section (internal issue 3248).
   * Add VU for code:Component decoration on 64 bit types in
-    <<spirvenv-module-validation-standalone Standalone SPIR-V Validation>>
+    <<spirvenv-module-validation-standalone, Standalone SPIR-V Validation>>
     (internal merge request 5495).
   * Clarify the meaning of "`new image`" in flink:vkWaitForPresentKHR
     (internal merge request 5513).
@@ -5786,8 +5787,8 @@ Internal Issues:
     `<<VK_KHR_zero_initialize_workgroup_memory>> appendix (internal merge
     request 4553).
   * Add missing `R64ui` and `R64i` entries to the SPIR-V
-    <<spirvenv-format-type-matching tables, image format matching tables>>
-    for `<<VK_EXT_shader_image_atomic_int64>>` (internal
+    <<spirvenv-format-type-matching, image format matching tables>> for
+    `<<VK_EXT_shader_image_atomic_int64>>` (internal
     Tracker/vk-gl-cts#2885).
 
 New Extensions:
@@ -6009,8 +6010,8 @@ GitHub Issues:
     are different (public issue 1357).
   * Fix tagging for slink:VkPhysicalDeviceVulkan11Features in `vk.xml`
     (public issue 1437).
-  * Update the <<WSI Swapchain>> chapter's use of "`release`" and
-    "`present`" terminology (public pull request 1470).
+  * Update the <<wsi-swapchain, WSI Swapchain>> chapter's use of "`release`"
+    and "`present`" terminology (public pull request 1470).
   * Migrate from Azure Pipelines to GitHub Actions for CI, and use updated
     Khronos Docker image to build (public pull request 1473).
 
@@ -6031,7 +6032,7 @@ Internal Issues:
   * Update valid usage ID assignment and extraction scripts to handle IDs
     containing function pointer names (internal issue 2557).
   * Move some runtime restrictions to
-    <<spirvenv-module-validation-standalone Standalone SPIR-V>> valid usage
+    <<spirvenv-module-validation-standalone, Standalone SPIR-V>> valid usage
     statements (internal merge request 4286).
   * Use new version of the HTML asciidoctor-chunker, which runs much faster,
     and a new Docker image which omits the old implementation of the chunker
@@ -6920,8 +6921,9 @@ GitHub Issues:
 
 Internal Issues:
 
-  * Improve the layout of the <<Standard sample locations>> table to avoid
-    overflow in the HTML output (internal issue 1354).
+  * Improve the layout of the <<standard-sample-locations, Standard Sample
+    Locations>> table to avoid overflow in the HTML output (internal issue
+    1354).
   * Also build core-only HTML spec in internal CI, to try and catch
     extension ifdef errors (should probably also do this in Azure CI on
     GitHub) (internal issue 1770).
@@ -8098,7 +8100,7 @@ Internal Issues:
     <<shaders-scope-queue-family>> sections to apply to Vulkan 1.2, as well
     as `VK_KHR_vulkan_memory_model` (internal merge request 3570).
   * Add performance queries to the list in the introduction of the
-    <<supported query types, queries>> chapter (internal merge request
+    <<queries, supported query types>> chapter (internal merge request
     3577).
 
 New Extensions
@@ -8540,8 +8542,8 @@ GitHub Issues:
     in same-parent valid usage statements (public pull request 1030).
   * Make slink:VkDescriptorUpdateTemplateCreateInfo::pname:descriptorSetLayout
     `noautovalidity` in `vk.xml` (public pull request 1031).
-  * Fix footnote markup in the <<vkGetDeviceProcAddr behavior>> table
-    (public pull request 1034).
+  * Fix footnote markup in the <<vkGetDeviceProcAddr-behavior,
+    vkGetDeviceProcAddr behavior>> table (public pull request 1034).
 
 Internal Issues:
 
@@ -8751,7 +8753,8 @@ GitHub Issues:
   * Remove redundant slink:VkSubpassDependency and
     slink:VkSubpassDependency2KHR valid usage statements
     (public pull request 995).
-  * Clarify the <<vkGetInstanceProcAddr behavior>> and <<vkGetDeviceProcAddr
+  * Clarify the <<vkGetInstanceProcAddr-behavior, vkGetInstanceProcAddr
+    behavior>> and <<vkGetDeviceProcAddr-behavior, vkGetDeviceProcAddr
     behavior>> tables (public pull request 1004).
   * Fix use of nonexistent
     slink:VkSamplerYcbcrConversionImageFormatProperties::pname:maxCombinedImageSamplerDescriptorCount
@@ -9979,7 +9982,7 @@ Internal Issues:
     `optimize-pdf` step of PDF generation, due (apparently) to inconsistent
     treatment of unwrapped multicharacter terms by different LaTeX parsers
     (internal issue 1435).
-  * For the <<memory-model-synchronizes-with synchronizes-with>> memory
+  * For the <<memory-model-synchronizes-with, Synchronizes-With>> memory
     model relation cases involving a release barrier plus relaxed atomic
     write, treat the atomic as if it were a release atomic and allow the
     acquire side to read from its hypothetical release sequence. This is
@@ -10279,8 +10282,8 @@ Public Issues:
 
 Internal Issues:
 
-  * Add images to the <<Standard sample locations>> table (internal issue
-    1115).
+  * Add images to the <<standard-sample-locations, Standard Sample
+    Locations>> table (internal issue 1115).
   * Add a definition of "`Inherited from`" precision in the
     <<spirvenv-precision-operation, Precision and Operation of SPIR-V
     Instructions>> section (internal issue 1314).
@@ -10334,11 +10337,11 @@ Internal Issues:
   * Reword and consolidate synchronization valid usage statements for
     flink:vkCmdPipelineBarrier such that they correctly account for multiple
     possible self-dependencies (internal issue 1322).
-  * Change order of <<Standard sample locations>> for 2xMSAA (internal issue
-    1347).
-  * Add definitions of "`<<Correctly Rounded>>`" and "`<<ULP>>`" in the
-    SPIR-V environment appendix, and "`Units in the Last Place (ULP)`" in
-    the glossary.
+  * Change order of <<standard-sample-locations, Standard Sample Locations>>
+    for 2xMSAA (internal issue 1347).
+  * Add definitions of <<spirvenv-correctly-rounded, Correctly Rounded>>
+    <<spirvenv-ulp, ULP>> in the SPIR-V environment appendix, and "`Units in
+    the Last Place (ULP)`" in the glossary.
 
 New Extensions:
 
@@ -13791,9 +13794,9 @@ GitHub Issues:
     source tree (public issue 203).
   * Fix duplicate 'which which' typo in description of
     elink:VkCommandPoolResetFlagBits (public issue 204).
-  * Move the <<Programmable Primitive Shading>> section up one level, out of
-    the <<drawing-primitive-topologies,Primitive Topologies>> section
-    (public issue 209).
+  * Move the <<drawing-primitive-shading, Programmable Primitive Shading>>
+    section up one level, out of the <<drawing-primitive-topologies,
+    Primitive Topologies>> section (public issue 209).
 
 Internal Issues:
 
@@ -13910,8 +13913,8 @@ Internal Issues:
   * Document that the requested patch version number specified as part
     of slink:VkApplicationInfo::pname:apiVersion is ignored when
     creating an instance (internal issue 176).
-  * Clarify handling of extension structs in the
-    <<fundamentals-validusageValid Usage>> section (internal issue 254).
+  * Clarify handling of extension structs in the <<fundamentals-validusage,
+    Valid Usage>> section (internal issue 254).
   * Update required slink:VkImageFormatProperties::pname:maxMipLevels to
     be limited to the maximum allowed mipmap pyramid size corresponding
     to the actual maximum supported size for the format (internal issue

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,9 @@ PROPOSALDIR = $(OUTDIR)/proposals
 JSAPIMAP  = $(GENERATED)/apimap.cjs
 PYAPIMAP  = $(GENERATED)/apimap.py
 RBAPIMAP  = $(GENERATED)/apimap.rb
+PYXREFMAP = $(GENERATED)/xrefMap.py
+JSXREFMAP = $(GENERATED)/xrefMap.cjs
+JSPAGEMAP = $(GENERATED)/pageMap.cjs
 
 # PDF Equations are written to SVGs, this dictates the location to store those files (temporary)
 PDFMATHDIR = $(OUTDIR)/equations_temp
@@ -540,48 +543,6 @@ check-txtfiles:
 check-xrefs: $(HTMLDIR)/vkspec.html
 	$(PYTHON) $(SCRIPTS)/check_html_xrefs.py $(HTMLDIR)/vkspec.html
 
-# Clean generated and output files
-
-clean: clean_html clean_pdf clean_man clean_generated clean_validusage
-
-clean_html:
-	$(QUIET)$(RMRF) $(HTMLDIR) $(OUTDIR)/katex
-	$(QUIET)$(RM) $(OUTDIR)/apispec.html $(OUTDIR)/styleguide.html \
-	    $(OUTDIR)/registry.html
-
-clean_pdf:
-	$(QUIET)$(RMRF) $(PDFDIR) $(OUTDIR)/apispec.pdf
-
-clean_man:
-	$(QUIET)$(RMRF) $(MANHTMLDIR)
-
-# Generated directories and files to remove
-CLEAN_GEN_PATHS = \
-    $(APIPATH) \
-    $(HOSTSYNCPATH) \
-    $(VALIDITYPATH) \
-    $(METAPATH) \
-    $(INTERFACEPATH) \
-    $(SPIRVCAPPATH) \
-    $(FORMATSPATH) \
-    $(SYNCPATH) \
-    $(REFPATH) \
-    $(GENERATED)/include \
-    $(GENERATED)/__pycache__ \
-    $(PDFMATHDIR) \
-    $(JSAPIMAP) \
-    $(PYAPIMAP) \
-    $(RBAPIMAP) \
-    $(REQSDEPEND) \
-    $(ATTRIBFILE)
-
-clean_generated:
-	$(QUIET)$(RMRF) $(CLEAN_GEN_PATHS)
-
-clean_validusage:
-	$(QUIET)$(RM) $(VUDIR)/validusage.json
-
-
 # Generated refpage sources. For now, always build all refpages.
 MANSOURCES   = $(filter-out $(REFPATH)/apispec.adoc, $(wildcard $(REFPATH)/*.adoc))
 
@@ -683,6 +644,8 @@ MAKEMANALIASES = $(SCRIPTS)/makemanaliases.py
 manaliases: $(PYAPIMAP)
 	$(PYTHON) $(MAKEMANALIASES) -genpath $(GENERATED) -refdir $(MANHTMLDIR)
 
+# Antora-related targets
+
 # Targets generated from the XML and registry processing scripts
 #   $(PYAPIMAP) (apimap.py) - Python encoding of the registry
 # The $(...DEPEND) targets are files named 'timeMarker' in generated
@@ -721,6 +684,15 @@ pyapi $(PYAPIMAP): $(VKXML) $(GENVK)
 rubyapi $(RBAPIMAP): $(VKXML) $(GENVK)
 	$(QUIET)$(MKDIR) $(GENERATED)
 	$(QUIET)$(PYTHON) $(GENVK) $(GENVKOPTS) -o $(GENERATED) apimap.rb
+
+# Cross-references of anchors to spec chapters they lie within
+# Used both by Antora and validusage_page targets
+
+xrefmaps: $(PYXREFMAP) $(JSXREFMAP)
+
+$(PYXREFMAP) $(JSXREFMAP): $(HTMLDIR)/vkspec.html
+	$(QUIET)$(PYTHON) $(SCRIPTS)/map_html_anchors.py \
+	    $(HTMLDIR)/vkspec.html -pyfile $(PYXREFMAP) -jsfile $(JSXREFMAP)
 
 apiinc: $(APIDEPEND)
 
@@ -782,6 +754,58 @@ $(SYNCDEPEND): $(VKXML) $(GENVK)
 	$(QUIET)$(MKDIR) $(SYNCPATH)
 	$(QUIET)$(PYTHON) $(GENVK) $(GENVKOPTS) -o $(SYNCPATH) syncinc
 
+# Generate all Antora module content
+# After the targets are built, the $(JSREFMAP) and $(JSPAGEMAP) files
+# used by spec macros in the Antora build must be copied into the Antora
+# project build tree, which is in a different repository.
+setup_antora: xrefmaps setup_spec_antora setup_features_antora
+	$(QUIET)$(CP) $(JSXREFMAP) antora/spec/
+	$(QUIET)$(CP) $(JSPAGEMAP) antora/spec/modules/ROOT/partials/gen/
+
+# Generate Antora spec module content by rewriting spec sources
+# Individual files must be specified last
+# This target must also be used to generate the pagemap, which is
+# combined with the xrefmaps above to map VUID anchors into the Antora
+# pages they are found within.
+setup_spec_antora pagemap $(JSPAGEMAP): $(JSAPIMAP)
+	$(QUIET)$(PYTHON) $(SCRIPTS)/antora-prep.py \
+	    -root . \
+	    -component $(shell realpath antora/spec/modules/ROOT) \
+	    -xrefpath antora/spec \
+	    -pageHeaders antora/pageHeaders-spec.adoc \
+	    -pagemappath $(JSPAGEMAP) \
+	    ./config/attribs.adoc \
+	    ./config/copyright-ccby.adoc \
+	    ./config/copyright-spec.adoc \
+	    ./images/*.svg \
+	    `find ./gen ./chapters ./appendices -name '[A-Za-z]*.adoc' | grep -v /vulkanscdeviations.adoc` \
+	    $(JSAPIMAP)
+
+# Generate Antora fetaures module content by rewriting feature sources
+# No additional pageHeaders required.
+setup_features_antora: features_nav_antora
+	$(QUIET)$(PYTHON) $(SCRIPTS)/antora-prep.py \
+	    -root . \
+	    -component $(shell realpath antora/features/modules/features) \
+	    -xrefpath antora/features \
+	    `find ./images/proposals -type f` \
+	    `find ./proposals -name '[A-Za-z]*.adoc'`
+
+# Construct the features component nav.adoc from the current list of
+# features, so it remains up to date.
+# This could be merged into antora-prep.py but is very specific
+# to the features module, so that is pointless.
+# We no longer include the proposal template.
+# To restore it, add
+#   -templatepath proposals/template.adoc
+# and uncomment that option in the script.
+features_nav_antora:
+	scripts/antora-nav-features.py \
+	    -root . \
+	    -component $(shell realpath antora/features/modules/features) \
+	    -roadmappath proposals/Roadmap.adoc \
+	    `find ./proposals -name 'VK_*.adoc'`
+
 # This generates a single file containing asciidoc attributes for each
 # core version and extension in the spec being built.
 # For use with Antora, it also includes a couple of document attributes
@@ -803,3 +827,65 @@ $(ATTRIBFILE):
 
 # Debugging aid - generate all files from registry XML
 generated: $(PYAPIMAP) $(GENDEPENDS)
+
+# Clean generated and output files
+
+clean: clean_html clean_pdf clean_man clean_generated clean_antora clean_validusage
+
+clean_html:
+	$(QUIET)$(RMRF) $(HTMLDIR) $(OUTDIR)/katex
+	$(QUIET)$(RM) $(OUTDIR)/apispec.html $(OUTDIR)/styleguide.html \
+	    $(OUTDIR)/registry.html
+
+clean_pdf:
+	$(QUIET)$(RMRF) $(PDFDIR) $(OUTDIR)/apispec.pdf
+
+clean_man:
+	$(QUIET)$(RMRF) $(MANHTMLDIR)
+
+# Generated directories and files to remove
+CLEAN_GEN_PATHS = \
+    $(APIPATH) \
+    $(HOSTSYNCPATH) \
+    $(VALIDITYPATH) \
+    $(METAPATH) \
+    $(INTERFACEPATH) \
+    $(SPIRVCAPPATH) \
+    $(FORMATSPATH) \
+    $(SYNCPATH) \
+    $(REFPATH) \
+    $(GENERATED)/include \
+    $(GENERATED)/__pycache__ \
+    $(PDFMATHDIR) \
+    $(JSAPIMAP) \
+    $(PYAPIMAP) \
+    $(RBAPIMAP) \
+    $(REQSDEPEND) \
+    $(ATTRIBFILE)
+
+clean_generated:
+	$(QUIET)$(RMRF) $(CLEAN_GEN_PATHS)
+
+# Files generated by 'setup_antora' target
+CLEAN_ANTORA_PATHS = \
+	antora/spec/modules/ROOT/images \
+	antora/spec/modules/ROOT/pages/appendices \
+	antora/spec/modules/ROOT/pages/chapters \
+	antora/spec/modules/ROOT/pages/partials \
+	antora/spec/modules/ROOT/pages/gen \
+	antora/spec/modules/ROOT/partials \
+	antora/features/modules/features/pages/proposals \
+	antora/features/modules/features/partials \
+	antora/features/modules/features/images \
+	antora/features/modules/features/nav.adoc \
+	$(JSXREFMAP) \
+	$(PYXREFMAP) \
+	$(JSPAGEMAP)
+
+clean_antora:
+	$(QUIET)$(RMRF) $(CLEAN_ANTORA_PATHS)
+
+clean_validusage:
+	$(QUIET)$(RM) $(VUDIR)/validusage.json
+
+

--- a/Makefile
+++ b/Makefile
@@ -759,8 +759,6 @@ $(SYNCDEPEND): $(VKXML) $(GENVK)
 # used by spec macros in the Antora build must be copied into the Antora
 # project build tree, which is in a different repository.
 setup_antora: xrefmaps setup_spec_antora setup_features_antora
-	$(QUIET)$(CP) $(JSXREFMAP) antora/spec/
-	$(QUIET)$(CP) $(JSPAGEMAP) antora/spec/modules/ROOT/partials/gen/
 
 # Generate Antora spec module content by rewriting spec sources
 # Individual files must be specified last
@@ -781,7 +779,7 @@ setup_spec_antora pagemap $(JSPAGEMAP): $(JSAPIMAP)
 	    `find ./gen ./chapters ./appendices -name '[A-Za-z]*.adoc' | grep -v /vulkanscdeviations.adoc` \
 	    $(JSAPIMAP)
 
-# Generate Antora fetaures module content by rewriting feature sources
+# Generate Antora features module content by rewriting feature sources
 # No additional pageHeaders required.
 setup_features_antora: features_nav_antora
 	$(QUIET)$(PYTHON) $(SCRIPTS)/antora-prep.py \

--- a/Makefile
+++ b/Makefile
@@ -771,7 +771,7 @@ setup_spec_antora pagemap $(JSPAGEMAP): $(JSAPIMAP)
 	$(QUIET)$(PYTHON) $(SCRIPTS)/antora-prep.py \
 	    -root . \
 	    -component $(shell realpath antora/spec/modules/ROOT) \
-	    -xrefpath antora/spec \
+	    -xrefpath $(GENERATED) \
 	    -pageHeaders antora/pageHeaders-spec.adoc \
 	    -pagemappath $(JSPAGEMAP) \
 	    ./config/attribs.adoc \
@@ -787,7 +787,7 @@ setup_features_antora: features_nav_antora
 	$(QUIET)$(PYTHON) $(SCRIPTS)/antora-prep.py \
 	    -root . \
 	    -component $(shell realpath antora/features/modules/features) \
-	    -xrefpath antora/features \
+	    -xrefpath $(GENERATED) \
 	    `find ./images/proposals -type f` \
 	    `find ./proposals -name '[A-Za-z]*.adoc'`
 

--- a/antora/features/modules/features/nav.adoc
+++ b/antora/features/modules/features/nav.adoc
@@ -43,6 +43,7 @@
 ** xref:proposals/VK_EXT_opacity_micromap.adoc[]
 ** xref:proposals/VK_EXT_pipeline_library_group_handles.adoc[]
 ** xref:proposals/VK_EXT_pipeline_protected_access.adoc[]
+** xref:proposals/VK_EXT_present_mode_fifo_latest_ready.adoc[]
 ** xref:proposals/VK_EXT_primitives_generated_query.adoc[]
 ** xref:proposals/VK_EXT_rasterization_order_attachment_access.adoc[]
 ** xref:proposals/VK_EXT_shader_module_identifier.adoc[]

--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -2505,6 +2505,7 @@ Otherwise, either the floating-point value closest to and no less than
 [eq]#x# or the value closest to and no greater than [eq]#x# will be
 returned.
 
+[[spirvenv-ulp]]
 .ULP
 Where an error bound of [eq]#n# ULP (units in the last place) is given, for
 an operation with infinitely precise result #x# the value returned must: be
@@ -2630,6 +2631,7 @@ FMod(x,x) computing x rather than 0, and can also cause the result to have a
 different sign than the infinitely precise result.
 ====
 
+[[precision-of-glsl-std-450-instructions]]
 .Precision of GLSL.std.450 Instructions
 [options="header", cols=",,"]
 |====

--- a/chapters/VK_KHR_swapchain/wsi.adoc
+++ b/chapters/VK_KHR_swapchain/wsi.adoc
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: CC-BY-4.0
 
+[[wsi-swapchain]]
 == WSI Swapchain
 
 [open,refpage='VkSwapchainKHR',desc='Opaque handle to a swapchain object',type='handles',xrefs='vkQueuePresentKHR']

--- a/chapters/copies.adoc
+++ b/chapters/copies.adoc
@@ -493,6 +493,7 @@ and extents>> of the image's format.
 
 ifdef::VK_QCOM_rotated_copy_commands[]
 [[copies-buffers-images-rotation-addressing]]
+.Image Rotation Addressing
 If a rotation is specified by slink:VkCopyCommandTransformInfoQCOM, the 2D
 region of the image being addressed is rotated around the offset, and texels
 at each coordinate [eq]#(x',y',z',layer)# are accessed in the image
@@ -801,9 +802,8 @@ ifdef::VK_QCOM_rotated_copy_commands[]
   * [[VUID-VkCopyBufferToImageInfo2KHR-pRegions-04554]]
     If the image region specified by each element of pname:pRegions contains
     slink:VkCopyCommandTransformInfoQCOM in its pname:pNext chain, the
-    rotated destination region as described in
-    <<copies-buffers-images-rotation-addressing>> must: be contained within
-    pname:dstImage
+    <<copies-buffers-images-rotation-addressing, rotated destination
+    region>> must: be contained within pname:dstImage
   * [[VUID-VkCopyBufferToImageInfo2KHR-pRegions-04555]]
     If any element of pname:pRegions contains
     slink:VkCopyCommandTransformInfoQCOM in its pname:pNext chain, then
@@ -926,9 +926,8 @@ ifdef::VK_QCOM_rotated_copy_commands[]
   * [[VUID-VkCopyImageToBufferInfo2KHR-pRegions-04557]]
     If the image region specified by each element of pname:pRegions contains
     slink:VkCopyCommandTransformInfoQCOM in its pname:pNext chain, the
-    rotated source region as described in
-    <<copies-buffers-images-rotation-addressing>> must: be contained within
-    pname:srcImage
+    <<copies-buffers-images-rotation-addressing, rotated source region>>
+    must: be contained within pname:srcImage
   * [[VUID-VkCopyImageToBufferInfo2KHR-pRegions-04558]]
     If any element of pname:pRegions contains
     slink:VkCopyCommandTransformInfoQCOM in its pname:pNext chain, then

--- a/chapters/descriptorsets.adoc
+++ b/chapters/descriptorsets.adoc
@@ -3560,7 +3560,8 @@ If the destination descriptor is a mutable descriptor, the active descriptor
 type for the destination descriptor becomes pname:descriptorType.
 endif::VK_EXT_mutable_descriptor_type,VK_VALVE_mutable_descriptor_type[]
 
-[[descriptorsets-updates-consecutive, consecutive binding updates]]
+[[descriptorsets-updates-consecutive]]
+.Consecutive Binding Updates
 If the pname:dstBinding has fewer than pname:descriptorCount array elements
 remaining starting from pname:dstArrayElement, then the remainder will be
 used to update the subsequent binding - [eq]#pname:dstBinding+1# starting at
@@ -3623,8 +3624,8 @@ endif::VK_VERSION_1_3,VK_EXT_inline_uniform_block[]
   * [[VUID-VkWriteDescriptorSet-dstArrayElement-00321]]
     The sum of pname:dstArrayElement and pname:descriptorCount must: be less
     than or equal to the number of array elements in the descriptor set
-    binding specified by pname:dstBinding, and all applicable consecutive
-    bindings, as described by <<descriptorsets-updates-consecutive>>
+    binding specified by pname:dstBinding, and all applicable
+    <<descriptorsets-updates-consecutive, consecutive bindings>>
 ifdef::VK_VERSION_1_3,VK_EXT_inline_uniform_block[]
   * [[VUID-VkWriteDescriptorSet-descriptorType-02219]]
     If pname:descriptorType is
@@ -4324,23 +4325,23 @@ endif::VK_EXT_mutable_descriptor_type,VK_VALVE_mutable_descriptor_type[]
   * [[VUID-VkCopyDescriptorSet-srcArrayElement-00346]]
     The sum of pname:srcArrayElement and pname:descriptorCount must: be less
     than or equal to the number of array elements in the descriptor set
-    binding specified by pname:srcBinding, and all applicable consecutive
-    bindings, as described by <<descriptorsets-updates-consecutive>>
+    binding specified by pname:srcBinding, and all applicable
+    <<descriptorsets-updates-consecutive, consecutive bindings>>
   * [[VUID-VkCopyDescriptorSet-dstBinding-00347]]
     pname:dstBinding must: be a valid binding within pname:dstSet
   * [[VUID-VkCopyDescriptorSet-dstArrayElement-00348]]
     The sum of pname:dstArrayElement and pname:descriptorCount must: be less
     than or equal to the number of array elements in the descriptor set
-    binding specified by pname:dstBinding, and all applicable consecutive
-    bindings, as described by <<descriptorsets-updates-consecutive>>
+    binding specified by pname:dstBinding, and all applicable
+    <<descriptorsets-updates-consecutive, consecutive bindings>>
   * [[VUID-VkCopyDescriptorSet-dstBinding-02632]]
     The type of pname:dstBinding within pname:dstSet must: be equal to the
     type of pname:srcBinding within pname:srcSet
   * [[VUID-VkCopyDescriptorSet-srcSet-00349]]
     If pname:srcSet is equal to pname:dstSet, then the source and
     destination ranges of descriptors must: not overlap, where the ranges
-    may: include array elements from consecutive bindings as described by
-    <<descriptorsets-updates-consecutive>>
+    may: include array elements from <<descriptorsets-updates-consecutive,
+    consecutive bindings>>
 ifdef::VK_VERSION_1_3,VK_EXT_inline_uniform_block[]
   * [[VUID-VkCopyDescriptorSet-srcBinding-02223]]
     If the descriptor type of the descriptor set binding specified by
@@ -4736,8 +4737,8 @@ endif::VK_VERSION_1_3,VK_EXT_inline_uniform_block[]
     pname:dstArrayElement and pname:descriptorCount must: be less than or
     equal to the number of array elements in the descriptor set binding
     implicitly specified when using a descriptor update template to update
-    descriptors, and all applicable consecutive bindings, as described by
-    <<descriptorsets-updates-consecutive>>
+    descriptors, and all applicable <<descriptorsets-updates-consecutive,
+    consecutive bindings>>
 ifdef::VK_VERSION_1_3,VK_EXT_inline_uniform_block[]
   * [[VUID-VkDescriptorUpdateTemplateEntry-descriptor-02226]]
     If pname:descriptor type is

--- a/chapters/initialization.adoc
+++ b/chapters/initialization.adoc
@@ -51,6 +51,7 @@ A valid returned function pointer ("`fp`") must: not be `NULL`.
 The returned function pointer is of type tlink:PFN_vkVoidFunction, and must:
 be cast to the type of the command being queried before use.
 
+[[vkGetInstanceProcAddr-behavior]]
 .fname:vkGetInstanceProcAddr behavior
 [width="80%",options="header"]
 |====
@@ -121,6 +122,7 @@ be cast to the type of the command being queried before use.
 The function pointer must: only be called with a dispatchable object (the
 first parameter) that is pname:device or a child of pname:device.
 
+[[vkGetDeviceProcAddr-behavior]]
 .fname:vkGetDeviceProcAddr behavior
 [width="80%",options="header"]
 |====

--- a/chapters/limits.adoc
+++ b/chapters/limits.adoc
@@ -110,7 +110,7 @@ flink:vkGetPhysicalDeviceProperties.
     granularity, in bytes, at which buffer or linear image resources, and
     optimal image resources can: be bound to adjacent offsets in the same
     sname:VkDeviceMemory object without aliasing.
-    See <<resources-bufferimagegranularity,Buffer-Image Granularity>> for
+    See <<resources-bufferimagegranularity, Buffer-Image Granularity>> for
     more details.
   * [[limits-sparseAddressSpaceSize]] pname:sparseAddressSpaceSize is the
     total amount of address space available, in bytes, for sparse memory

--- a/chapters/primsrast.adoc
+++ b/chapters/primsrast.adoc
@@ -724,6 +724,7 @@ fragment.
 
 <<<
 
+[[standard-sample-locations]]
 .Standard Sample Locations
 [options="header",align="center"]
 |====

--- a/chapters/resources.adoc
+++ b/chapters/resources.adoc
@@ -9762,7 +9762,7 @@ endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
 endif::VK_VERSION_1_1,VK_KHR_bind_memory2[]
 
 
-[[resources-bufferimagegranularity,Buffer-Image Granularity]]
+[[resources-bufferimagegranularity]]
 .Buffer-Image Granularity
 The implementation-dependent limit <<limits-bufferImageGranularity,
 pname:bufferImageGranularity>> specifies a page-like granularity at which

--- a/chapters/shaders.adoc
+++ b/chapters/shaders.adoc
@@ -3202,6 +3202,7 @@ endif::VK_VERSION_1_1[]
 
 
 ifdef::VK_NV_cooperative_matrix,VK_KHR_cooperative_matrix[]
+[[cooperative-matrices]]
 == Cooperative Matrices
 
 A _cooperative matrix_ type is a SPIR-V type where the storage for and

--- a/proposals/VK_EXT_descriptor_buffer.adoc
+++ b/proposals/VK_EXT_descriptor_buffer.adoc
@@ -245,7 +245,7 @@ As the name suggests, inline uniform buffers are embedded into the descriptor se
 As descriptors are now in regular memory, drivers cannot hide copies of immutable samplers that end up in descriptor sets from the application.
 As such, applications are required to provide these samplers as if they were not provided immutably.
 These samplers must have identical parameters to the immutable samplers in the descriptor set layout.
-Alternatively, applications can use dedicated descriptor sets for immutable samplers that do not require app-managed memory, by <<Embedded Immutable Samplers,embedding them in a special descriptor set>>.
+Alternatively, applications can use dedicated descriptor sets for immutable samplers that do not require app-managed memory, by <<embedded-immutable-samplers, embedding them in a special descriptor set>>.
 
 If the `descriptorBufferImageLayoutIgnored` feature is enabled, the `imageLayout` in link:{refpage}VkDescriptorImageInfo.html[VkDescriptorImageInfo] is ignored, otherwise it specifies the layout that the descriptor will be used with.
 `type` must not be `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC` or `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC`.
@@ -255,10 +255,11 @@ The `combinedImageSamplerDescriptorSingleArray` property indicates that the impl
 On these implementations, variable descriptor counts of combined image samplers may be supported, but it is not useful as the descriptor set size must assume the upper bound.
 
 
+[[embedded-immutable-samplers]]
 ==== Embedded Immutable Samplers
 
 Immutable samplers can be embedded into descriptor layouts, allowing them to be bound without disturbing descriptor buffer bindings or requiring device memory backing.
-Descriptor set layouts must be created with a new flag for this purpose: 
+Descriptor set layouts must be created with a new flag for this purpose:
 
 [source,c]
 ----
@@ -360,7 +361,7 @@ vkCmdSetDescriptorBufferOffsetsEXT(
 Setting offsets should be a cheap operation and can be performed frequently.
 The offsets must be aligned to `descriptorBufferOffsetAlignment`.
 
-<<Embedded Immutable Samplers,Embedded immutable samplers>> can be bound using:
+<<embedded-immutable-samplers, Embedded Immutable Samplers>> can be bound using:
 
 [source,c]
 -----
@@ -455,7 +456,7 @@ typedef struct VkBufferCaptureDescriptorDataInfoEXT {
 
 VkResult vkGetImageOpaqueCaptureDescriptorDataEXT(
     VkDevice                                   device,
-    const VkImageCaptureDescriptorDataInfoEXT* pInfo, 
+    const VkImageCaptureDescriptorDataInfoEXT* pInfo,
     void*                                      pData);
 
 typedef struct VkImageCaptureDescriptorDataInfoEXT {
@@ -466,7 +467,7 @@ typedef struct VkImageCaptureDescriptorDataInfoEXT {
 
 VkResult vkGetImageViewOpaqueCaptureDescriptorDataEXT(
     VkDevice                                       device,
-    const VkImageViewCaptureDescriptorDataInfoEXT* pInfo, 
+    const VkImageViewCaptureDescriptorDataInfoEXT* pInfo,
     void*                                          pData);
 
 typedef struct VkImageViewCaptureDescriptorDataInfoEXT {
@@ -477,7 +478,7 @@ typedef struct VkImageViewCaptureDescriptorDataInfoEXT {
 
 VkResult vkGetSamplerOpaqueCaptureDescriptorDataEXT(
     VkDevice                                     device,
-    const VkSamplerCaptureDescriptorDataInfoEXT* pInfo, 
+    const VkSamplerCaptureDescriptorDataInfoEXT* pInfo,
     void*                                        pData);
 
 typedef struct VkSamplerCaptureDescriptorDataInfoEXT {
@@ -488,7 +489,7 @@ typedef struct VkSamplerCaptureDescriptorDataInfoEXT {
 
 VkResult vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT(
     VkDevice                                                   device,
-    const VkAccelerationStructureCaptureDescriptorDataInfoEXT* pInfo, 
+    const VkAccelerationStructureCaptureDescriptorDataInfoEXT* pInfo,
     void*                                                      pData);
 
 typedef struct VkAccelerationStructureCaptureDescriptorDataInfoEXT {
@@ -525,7 +526,7 @@ typedef struct VkPhysicalDeviceDescriptorBufferFeaturesEXT {
     VkStructureType    sType;
     void*              pNext;
     VkBool32           descriptorBuffer;
-    VkBool32           descriptorBufferCaptureReplay; 
+    VkBool32           descriptorBufferCaptureReplay;
     VkBool32           descriptorBufferImageLayoutIgnored;
     VkBool32           descriptorBufferPushDescriptors;
 } VkPhysicalDeviceDescriptorBufferFeaturesEXT;
@@ -533,7 +534,7 @@ typedef struct VkPhysicalDeviceDescriptorBufferFeaturesEXT {
 
 If the `descriptorBuffer` feature is enabled, link:{refpage}VK_AMD_shader_fragment_mask.html[VK_AMD_shader_fragment_mask] must not be enabled.
 If the `descriptorBufferImageLayoutIgnored` feature is enabled, the image layout provided when getting a descriptor is ignored.
-The `descriptorBufferCaptureReplay` feature is primarily for capture replay tools, and allows opaque data to be captured and replayed, allowing the same descriptor handles to be used on replay. 
+The `descriptorBufferCaptureReplay` feature is primarily for capture replay tools, and allows opaque data to be captured and replayed, allowing the same descriptor handles to be used on replay.
 If the `descriptorBufferPushDescriptors` features is enabled push descriptors can be used with descriptor buffers.
 
 
@@ -1114,5 +1115,5 @@ Having the base address specified with a device address is still useful for cons
 
 === RESOLVED: How does this interact with VK_EXT_pipeline_robustness?
 
-There is no way to request robust and non-robust descriptors separately, or specify robust/non-robust descriptors in the set layout, so if 
+There is no way to request robust and non-robust descriptors separately, or specify robust/non-robust descriptors in the set layout, so if
 the `robustBufferAccess` feature is enabled then robust descriptors are always used.

--- a/proposals/VK_EXT_mesh_shader.adoc
+++ b/proposals/VK_EXT_mesh_shader.adoc
@@ -44,11 +44,13 @@ This extension opts for something close to option 3, by replacing all pre-raster
 
 == Proposal
 
+[[new-shaders]]
 === New Shaders
 
-This proposal adds two new shader stages, which can be used in place of the existing pre-rasterization shader stages; <<Mesh Shaders>> and <<Task Shaders>>.
+This proposal adds two new shader stages, which can be used in place of the existing pre-rasterization shader stages; <<mesh-shaders, Mesh Shaders>> and <<task-shaders, Task Shaders>>.
 
 
+[[mesh-shaders]]
 ==== Mesh Shaders
 
 Mesh shaders are a new compute-like shader stage that has a primary aim of generating a set of primitives to the rasterizer, which are passed via its new output interface.
@@ -67,9 +69,10 @@ Other user data can be emitted at per-vertex or per-primitive rates alongside th
 Mesh shaders must specify the actual number of primitives and vertices being emitted before writing them, via the `OpSetMeshOutputsEXT` instruction.
 Subsequent fragment shaders can retrieve input data at both rates, tied to the vertices and primitive being rasterized.
 
-Mesh shaders can be dispatched from the API like a compute shader would be, or launched via <<Task Shaders>>.
+Mesh shaders can be dispatched from the API like a compute shader would be, or launched via <<task-shaders, Task Shaders>>.
 
 
+[[task-shaders]]
 ==== Task Shaders
 
 Task shaders are an optional shader stage that executes ahead of mesh shaders. A task shader is dispatched like a compute shader, and indirectly dispatches mesh shader workgroups.
@@ -192,6 +195,7 @@ Each element of this array defines a separate draw call's workgroup counts in ea
 The draw count is read from `countBuffer` at an offset of `countBufferOffset`, and must be lower than `maxDrawCount`.
 
 
+[[properties]]
 ==== Properties
 
 Several new properties are added to the API - some dictating hard limits, and others indicating performance considerations:
@@ -306,7 +310,7 @@ One new capability is added gating all of the new functionality:
 MeshShadingEXT
 ```
 
-Two new execution models are added, corresponding to the two <<New Shaders>> added by this extension:
+Two new execution models are added, corresponding to the two <<new-shaders, New Shaders>> added by this extension:
 
 ```
 TaskEXT
@@ -534,7 +538,7 @@ The following changes have been made to the API:
   * There are new device queries for the number of mesh primitives generated, and the number of shader invocations for the new shader stages.
   * A new command token is added when interacting with VK_NV_device_generated_commands, as mesh shaders from each extension are incompatible.
   * New optional features have been added for interactions with multiview, primitive fragment shading rate specification, and the new queries.
-  * Several more device properties are expressed to enable application developers to use mesh shaders optimally across vendors (see <<Properties>> for details of how these are expressed and used).
+  * Several more device properties are expressed to enable application developers to use mesh shaders optimally across vendors (see <<properties, Properties>> for details of how these are expressed and used).
 
 Note that the SPIR-V and GLSL expression of these extensions have changed, details of which are outlined in those extensions.
 These changes aim to make the extension more portable across multiple vendors, and increase compatibility with the similar feature in Microsoft® DirectX®.
@@ -548,7 +552,7 @@ This makes it so that the shader can be compiled without modifying the input int
 Some amount of massaging by the HLSL compiler will be required to the shader interfaces as DirectX does linking by name rather than location between mesh and pixel shaders, but the requirement to use `\[[vk::perprimitive]]` allows the different attributes to continue using locations in Vulkan.
 
 The only notable difference on the API side is that Vulkan provides additional device properties that allow developers to tune their shaders to different vendors' fast paths, should they wish to.
-Details of how these are expressed are detailed <<Properties, here>>.
+Details of how these are expressed are detailed <<properties, here>>.
 
 === Can there be more than one output payload in a task shader?
 

--- a/proposals/VK_KHR_pipeline_binary.adoc
+++ b/proposals/VK_KHR_pipeline_binary.adoc
@@ -175,7 +175,7 @@ such as extensions and features being enabled on the device, or even enabled lay
 
 Only one of `pipeline`, `pKeysAndDataInfo`, and `pPipelineCreateInfo` can be used at once.
 
-A new link:{refpage}VkResult.html[VkResult] value is added so that `vkCreatePipelineBinariesKHR` can indicate that an implementation supporting `pipelineBinaryInternalCache` <<Properties>> does not have a binary in its internal cache:
+A new link:{refpage}VkResult.html[VkResult] value is added so that `vkCreatePipelineBinariesKHR` can indicate that an implementation supporting `pipelineBinaryInternalCache` <<properties, Properties>> does not have a binary in its internal cache:
 
 [source,c]
 ----
@@ -230,6 +230,7 @@ typedef struct VkPhysicalDevicePipelineBinaryFeaturesKHR {
 * `pipelineBinaries` is the main feature enabling this extension’s functionality and
 must be supported if this extension is supported.
 
+[[properties]]
 #### Properties
 
 On some platforms, the internal pipeline cache is still very important and may be maintained outside the scope of the application.
@@ -253,6 +254,7 @@ typedef struct VkPhysicalDevicePipelineBinaryPropertiesKHR {
 } VkPhysicalDevicePipelineBinaryPropertiesKHR;
 ----
 
+[[pipelineBinaryInternalCache]]
 ##### `pipelineBinaryInternalCache`
 
 When `pipelineBinaryInternalCache` is supported it is possible to create pipeline binaries using just the pipeline create info, without providing either SPIR-V or binary data, by
@@ -275,7 +277,7 @@ createInfo.pPipelineCreateInfo = &pipelineCreateInfo;
 
 VkPipelineBinaryHandlesInfoKHR handlesInfo;
 handlesInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR;
-handlesInfo.pNext = NULL; 
+handlesInfo.pNext = NULL;
 handlesInfo.pipelineBinaryCount = 0;
 handlesInfo.pPipelineBinaries = NULL;
 
@@ -421,7 +423,7 @@ createInfo.pPipelineCreateInfo = NULL;
 
 VkPipelineBinaryHandlesInfoKHR handlesInfo;
 handlesInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR;
-handlesInfo.pNext = NULL; 
+handlesInfo.pNext = NULL;
 handlesInfo.pipelineBinaryCount = 0;
 handlesInfo.pPipelineBinaries = NULL;
 
@@ -443,7 +445,7 @@ for (int i = 0; i < handlesInfo.pipelineBinaryCount; ++i) {
     binaryInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_BINARY_DATA_INFO_KHR;
     binaryInfo.pNext = NULL;
     binaryInfo.pipelineBinary = pipelineBinaries[i];
-    
+
     size_t binaryDataSize = 0;
     vkGetPipelineBinaryDataKHR(device, &binaryInfo, &binaryKeys[i], &binaryDataSize, NULL);
     vector<uint_8> data;
@@ -510,7 +512,7 @@ pipelineBinaries.resize(binaryKeysAndData.binaryCount);
 
 VkPipelineBinaryHandlesInfoKHR handlesInfo;
 handlesInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR;
-handlesInfo.pNext = NULL; 
+handlesInfo.pNext = NULL;
 handlesInfo.pipelineBinaryCount = binaryKeysAndData.binaryCount;
 handlesInfo.pPipelineBinaries = pipelineBinaries.data();
 
@@ -556,7 +558,7 @@ createInfo.pPipelineCreateInfo = &pipelineCreateInfo;
 
 VkPipelineBinaryHandlesInfoKHR handlesInfo;
 handlesInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR;
-handlesInfo.pNext = NULL; 
+handlesInfo.pNext = NULL;
 handlesInfo.pipelineBinaryCount = 0;
 handlesInfo.pPipelineBinaries = NULL;
 


### PR DESCRIPTION
Will allow validusage.json to contain mappings from VUIDs to the docs.vulkan.org page containing them.

Also adds some missing explicit anchors, and titles on deeply nested anchors.

Pairs with https://github.com/KhronosGroup/Vulkan-Site/pull/93 . Both PRs must be merged to allow building of the site to continue working - merging just one will cause problems.