### PR TITLE
Add author ID FREDEMMOTT

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -77,6 +77,7 @@ branch of the member gitlab server.
         <tag name="RASTERGRID"  author="RasterGrid Kft."               contact="Daniel Rakos @aqnuep"/>
         <tag name="MSFT"        author="Microsoft Corporation"         contact="Jesse Natalie @jenatali"/>
         <tag name="SHADY"       author="Saarland University"           contact="Hugo Devillers @hugobros3"/>
+        <tag name="FREDEMMOTT"  author="Frederick Emmott"              contact="Fred Emmott @fredemmott" />
     </tags>
 
     <types comment="Vulkan type definitions">


### PR DESCRIPTION
This matches my OpenXR vendor ID, following the steps documented at https://registry.khronos.org/vulkan/specs/1.3/styleguide.html#extensions-naming-author-IDs

My OpenXR API layer XR_APILAYER_FREDEMMOTT_OpenKneeboard requires a matching Vulkan API layer to enable certain Vulkan extensions in `vkCreateDevice` when the OpenXR application uses the `XR_KHR_vulkan_enable` extension instead of the `XR_KHR_vulkan_enable2` - see:

- [KHR:openxr/openxr#1249](https://gitlab.khronos.org/openxr/openxr/-/issues/1249)
- [KHR:openxr/openxr#1363](https://gitlab.khronos.org/openxr/openxr/-/issues/1363) for reasons why I want to support `XR_KHR_vulkan_enable` as well as `XR_KHR_vulkan_enable2`, introducing the need for a Vulkan API layer
- https://github.com/KhronosGroup/OpenXR-SDK-Source/pull/319