### PR TITLE
Fix the CullPrimitiveEXT VUID's

### DIFF
--- a/chapters/interfaces.adoc
+++ b/chapters/interfaces.adoc
@@ -3238,7 +3238,7 @@ endif::VK_VERSION_1_2[]
     The variable decorated with code:Layer within the code:MeshEXT
     {ExecutionModel} must: also be decorated with the code:PerPrimitiveEXT
     decoration
-  * code:Layer within the MeshEXT Execution Model must: decorate a scalar 
+  * code:Layer within the code:MeshEXT {ExecutionModel} must: decorate a scalar 
     32-bit integer member of a structure decorated as code:Block, or decorate a 
     variable of type code:OpTypeArray of scalar 32-bit integer values. 
   * If code:Layer is declared as an array of boolean values, the size of 
@@ -3905,7 +3905,7 @@ SPIR-V has to use code:PrimitiveId.
     The variable decorated with code:PrimitiveId within the code:MeshEXT
     {ExecutionModel} must: also be decorated with the code:PerPrimitiveEXT
     decoration
-  * code:PrimitiveId within the MeshEXT Execution Model must: decorate a 
+  * code:PrimitiveId within the code:MeshEXT {ExecutionModel} must: decorate a 
     scalar 32-bit integer member of a structure decorated as code:Block, 
     or decorate a variable of type code:OpTypeArray of 32-bit integer values. 
   * If code:PrimitiveId is declared as an array of 32-bit integer values, 
@@ -4132,7 +4132,7 @@ value is undefined: for executions of the shader that take that path.
     The variable decorated with code:PrimitiveShadingRateKHR within the
     code:MeshEXT {ExecutionModel} must: also be decorated with the code:PerPrimitiveEXT 
     decoration
-  * code:PrimitiveShadingRateKHR within the MeshEXT Execution Model must: decorate 
+  * code:PrimitiveShadingRateKHR within the code:MeshEXT {ExecutionModel} must: decorate 
     a scalar 32-bit integer member of a structure decorated as code:Block, or decorate 
     a variable of type code:OpTypeArray of 32-bit integer values. 
   * If code:PrimitiveShadingRateKHR is declared as an array of boolean values, 
@@ -5135,7 +5135,7 @@ endif::VK_VERSION_1_2[]
     The variable decorated with code:ViewportIndex within the code:MeshEXT
     {ExecutionModel} must: also be decorated with the code:PerPrimitiveEXT
     decoration
-  * code:ViewportIndex within the MeshEXT Execution Model must: decorate a 
+  * code:ViewportIndex within the code:MeshEXT {ExecutionModel} must: decorate a 
     scalar boolean member of a structure decorated as code:Block, or decorate
     a variable of type code:OpTypeArray of boolean values. 
   * If code:ViewportIndex is declared as an array of boolean values, the size 

--- a/chapters/interfaces.adoc
+++ b/chapters/interfaces.adoc
@@ -2201,11 +2201,10 @@ culled, if it is code:false it will not be culled.
     The variable decorated with code:CullPrimitiveEXT must: be declared
     using the code:Output {StorageClass}
   * [[VUID-{refpage}-CullPrimitiveEXT-07036]]
-    code:CullPrimitiveEXT must: be declared as a boolean value member of a structure or a variable of type code:OpTypeArray of boolean values. 
-  * If code:CullPrimitiveEXT declared as an array of boolean values. The size of the array 
-    decorated with code:CullPrimitiveEXT must: match the value specified by code:OutputPrimitivesEXT
-  * If code:CullPrimitiveEXT is a member of a structure, there must: be a variable declared 
-    which is array of parent strucure that contains code:CullPrimitiveEXT. The size of the array must: match the value specified by code:OutputPrimitivesEXT.
+    code:CullPrimitiveEXT must: decorate a scalar boolean member of a structure decorated as code:Block, or decorate a variable of type code:OpTypeArray of boolean values. 
+  * If code:CullPrimitiveEXT is declared as an array of boolean values, the size of the array 
+    must: match the value specified by code:OutputPrimitivesEXT
+  * If code:CullPrimitiveEXT decorates a member of a structure, the variable declaration of the containing code:Block type must: have an array size that matches the value specified by code:OutputPrimitivesEXT
   * There must be only one declaration of the code:CullPrimitiveEXT associated with a entry
     point's interface.
   * [[VUID-{refpage}-CullPrimitiveEXT-07038]]

--- a/chapters/interfaces.adoc
+++ b/chapters/interfaces.adoc
@@ -3233,11 +3233,19 @@ endif::VK_VERSION_1_2[]
     {ExecutionModel} must: be declared using the code:Input {StorageClass}
   * [[VUID-{refpage}-Layer-04276]]
     The variable decorated with code:Layer must: be declared as a scalar
-    32-bit integer value
+    32-bit integer value for all supported execution models except code:MeshEXT.
   * [[VUID-{refpage}-Layer-07039]]
     The variable decorated with code:Layer within the code:MeshEXT
     {ExecutionModel} must: also be decorated with the code:PerPrimitiveEXT
     decoration
+  * code:Layer within the MeshEXT Execution Model must: decorate a scalar 
+    32-bit integer member of a structure decorated as code:Block, or decorate a 
+    variable of type code:OpTypeArray of scalar 32-bit integer values. 
+  * If code:Layer is declared as an array of boolean values, the size of 
+    the array must: match the value specified by code:OutputPrimitivesEXT
+  * If code:Layer decorates a member of a structure, the variable declaration 
+    of the containing code:Block type must: have an array size that matches 
+    the value specified by code:OutputPrimitivesEXT
 ****
 --
 
@@ -3892,11 +3900,20 @@ SPIR-V has to use code:PrimitiveId.
     {StorageClass}
   * [[VUID-{refpage}-PrimitiveId-04337]]
     The variable decorated with code:PrimitiveId must: be declared as a
-    scalar 32-bit integer value
+    scalar 32-bit integer value for all supported execution models except code:MeshEXT
   * [[VUID-{refpage}-PrimitiveId-07040]]
     The variable decorated with code:PrimitiveId within the code:MeshEXT
     {ExecutionModel} must: also be decorated with the code:PerPrimitiveEXT
     decoration
+  * code:PrimitiveId within the MeshEXT Execution Model must: decorate a 
+    scalar 32-bit integer member of a structure decorated as code:Block, 
+    or decorate a variable of type code:OpTypeArray of 32-bit integer values. 
+  * If code:PrimitiveId is declared as an array of 32-bit integer values, 
+    within the code:MeshEXT {ExecutionModel}, size of the array must: match 
+    the value specified by code:OutputPrimitivesEXT
+  * If code:PrimitiveId decorates a member of a structure, the variable 
+    declaration of the containing code:Block type must: have an array size that
+    matches the value specified by code:OutputPrimitivesEXT
 ****
 --
 
@@ -4099,7 +4116,8 @@ value is undefined: for executions of the shader that take that path.
     declared using the code:Output {StorageClass}
   * [[VUID-{refpage}-PrimitiveShadingRateKHR-04486]]
     The variable decorated with code:PrimitiveShadingRateKHR must: be
-    declared as a scalar 32-bit integer value
+    declared as a scalar 32-bit integer value for all supported execution models
+    except code:MeshEXT
   * [[VUID-{refpage}-PrimitiveShadingRateKHR-04487]]
     The value written to code:PrimitiveShadingRateKHR must: include no more
     than one of code:Vertical2Pixels and code:Vertical4Pixels
@@ -4112,8 +4130,16 @@ value is undefined: for executions of the shader that take that path.
     enumerants in the SPIR-V specification
   * [[VUID-{refpage}-PrimitiveShadingRateKHR-07059]]
     The variable decorated with code:PrimitiveShadingRateKHR within the
-    code:MeshEXT {ExecutionModel} must: also be decorated with the
-    code:PerPrimitiveEXT decoration
+    code:MeshEXT {ExecutionModel} must: also be decorated with the code:PerPrimitiveEXT 
+    decoration
+  * code:PrimitiveShadingRateKHR within the MeshEXT Execution Model must: decorate 
+    a scalar 32-bit integer member of a structure decorated as code:Block, or decorate 
+    a variable of type code:OpTypeArray of 32-bit integer values. 
+  * If code:PrimitiveShadingRateKHR is declared as an array of boolean values, 
+    the size of the array must: match the value specified by code:OutputPrimitivesEXT
+  * If code:PrimitiveShadingRateKHR decorates a member of a structure, the variable 
+    declaration of the containing code:Block type must: have an array size that matches
+    the value specified by code:OutputPrimitivesEXT
 ****
 --
 endif::VK_KHR_fragment_shading_rate[]
@@ -5103,11 +5129,20 @@ endif::VK_VERSION_1_2[]
     {ExecutionModel} must: be declared using the code:Input {StorageClass}
   * [[VUID-{refpage}-ViewportIndex-04408]]
     The variable decorated with code:ViewportIndex must: be declared as a
-    scalar 32-bit integer value
+    scalar 32-bit integer value for all supported execution models except 
+    code:MeshEXT
   * [[VUID-{refpage}-ViewportIndex-07060]]
     The variable decorated with code:ViewportIndex within the code:MeshEXT
     {ExecutionModel} must: also be decorated with the code:PerPrimitiveEXT
     decoration
+  * code:ViewportIndex within the MeshEXT Execution Model must: decorate a 
+    scalar boolean member of a structure decorated as code:Block, or decorate
+    a variable of type code:OpTypeArray of boolean values. 
+  * If code:ViewportIndex is declared as an array of boolean values, the size 
+    of the array must: match the value specified by code:OutputPrimitivesEXT
+  * If code:ViewportIndex decorates a member of a structure, the variable 
+    declaration of the containing code:Block type must: have an array size that 
+    matches the value specified by code:OutputPrimitivesEXT
 ****
 --
 

--- a/chapters/interfaces.adoc
+++ b/chapters/interfaces.adoc
@@ -2201,11 +2201,13 @@ culled, if it is code:false it will not be culled.
     The variable decorated with code:CullPrimitiveEXT must: be declared
     using the code:Output {StorageClass}
   * [[VUID-{refpage}-CullPrimitiveEXT-07036]]
-    The variable decorated with code:CullPrimitiveEXT must: be declared as
-    an array of boolean values
-  * [[VUID-{refpage}-CullPrimitiveEXT-07037]]
-    The size of the array decorated with code:CullPrimitiveEXT must: match
-    the value specified by code:OutputPrimitivesEXT
+    code:CullPrimitiveEXT must: be declared as a boolean value member of a structure or a variable of type code:OpTypeArray of boolean values. 
+  * If code:CullPrimitiveEXT declared as an array of boolean values. The size of the array 
+    decorated with code:CullPrimitiveEXT must: match the value specified by code:OutputPrimitivesEXT
+  * If code:CullPrimitiveEXT is a member of a structure, there must: be a variable declared 
+    which is array of parent strucure that contains code:CullPrimitiveEXT. The size of the array must: match the value specified by code:OutputPrimitivesEXT.
+  * There must be only one declaration of the code:CullPrimitiveEXT associated with a entry
+    point's interface.
   * [[VUID-{refpage}-CullPrimitiveEXT-07038]]
     The variable decorated with code:CullPrimitiveEXT within the
     code:MeshEXT {ExecutionModel} must: also be decorated with the


### PR DESCRIPTION
- Remove VUID 07037 that wrongly was needing the builtin to be of type array
- Updated the VUID 7036 to make the type a boolean value

Fixes bug https://gitlab.khronos.org/vulkan/vulkan/-/issues/3296