### PR TITLE
Specify that the stored size of headerVersion in VkPipelineCacheHeaderVersionOne is 4 bytes

### DIFF
--- a/chapters/pipelines.adoc
+++ b/chapters/pipelines.adoc
@@ -7838,10 +7838,10 @@ with identical pipeline identifiers in the same pipeline cache.
 
 Unlike most structures declared by the Vulkan API, all fields of this
 structure are written with the least significant byte first, regardless of
-host byte-order.
+host byte-order, and the headerVersion field is written as exactly 4 bytes.
 
 The C language specification does not define the packing of structure
-members.
+members or the size of enum types.
 This layout assumes tight structure member packing, with members laid out in
 the order listed in the structure, and the intended size of the structure is
 56 bytes.


### PR DESCRIPTION
Pedantic fix.  C/C++ allow enums to be larger than 4 bytes.  This specifies that the stored VkPipelineCacheHeaderVersion in VkPipelineCacheHeaderVersionOne is exactly 4 bytes.