### PR TITLE
Remove rogue link in VK_EXT_external_memory_metal chapter

### DIFF
--- a/proposals/VK_EXT_external_memory_metal.adoc
+++ b/proposals/VK_EXT_external_memory_metal.adoc
@@ -16,8 +16,6 @@ An application may wish to reference device memory in multiple Vulkan device ins
 This extension enables an application to export non-Vulkan handles from Vulkan memory objects such that the underlying resources can
 be referenced outside the scope of the Vulkan device instance that created them.
 
-@@link:{extensions}VK_KHR_external_memory[VK_KHR_external_memory].
-
 While link:{extensions}VK_EXT_metal_objects.html[VK_EXT_metal_objects] provides a way to expose underlying Metal resources,
 when importing an image from an `id<MTLTexture>` handle, said images and their backing memory will be imported at
 link:{docs}chapters/resources.html#VkImage[VkImage] creation.


### PR DESCRIPTION
This PR removes a seemingly random link to `VK_KHR_external_memory` in the proposal for `VK_EXT_external_memory_metal`.

![image](https://github.com/user-attachments/assets/3497c8e0-c7cf-441e-bf65-772110a0f465)
