### PR TITLE
Remove superfluous semicolon in `VK_NV_optical_flow`

### DIFF
--- a/appendices/VK_NV_optical_flow.adoc
+++ b/appendices/VK_NV_optical_flow.adoc
@@ -75,7 +75,7 @@ imageCreateInfo.extent = { width, height, (uint32_t)1};
 imageCreateInfo.mipLevels = 1;
 imageCreateInfo.arrayLayers = 1;
 imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-imageCreateInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;;
+imageCreateInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
 
 vkCreateImage(device, &imageCreateInfo, NULL, &input);


### PR DESCRIPTION
Remove extra semicolon in example.