### PR TITLE
Fix small typo in proposal for VK_KHR_compute_shader_derivatives

### DIFF
--- a/proposals/VK_KHR_compute_shader_derivatives.adoc
+++ b/proposals/VK_KHR_compute_shader_derivatives.adoc
@@ -17,7 +17,7 @@ As that extension already shipped before proposal documents existed, this docume
 retroactively during promotion to KHR.
 
 The changes relative to `VK_NV_compute_shader_derivatives` are the inclusion of optional
-mesh and tash shader support.
+mesh and task shader support.
 
 
 == Problem Statement


### PR DESCRIPTION
This PR fixes a small typo in the proposal for the  `VK_KHR_compute_shader_derivatives` extension.