### PR TITLE
Replace fetches with fetch

### DIFF
--- a/appendices/VK_HUAWEI_cluster_culling_shader.adoc
+++ b/appendices/VK_HUAWEI_cluster_culling_shader.adoc
@@ -40,7 +40,7 @@ A set of new built-in output variables are used to express a visible
 cluster, including per-cluster shading rate.
 In addition, a new built-in function is used to emit these variables from
 CCS to the IA stage.
-The IA stage can use these variables to fetches vertices of a visible
+The IA stage can use these variables to fetch vertices of a visible
 cluster and drive vertex shaders to shading these vertices.
 
 Note that CCS do not work with geometry or tessellation shaders, but both IA

--- a/chapters/pipelines.adoc
+++ b/chapters/pipelines.adoc
@@ -44,7 +44,7 @@ When using the Cluster Culling Shader, a compute-like shader will perform
 cluster-based culling, a set of new built-in output variables are used to
 express visible cluster, in addition, a new built-in function is used to
 emit these variables from the cluster culling shader to the Input
-Assembler(IA) stage, then IA can use these variables to fetches vertices of
+Assembler(IA) stage, then IA can use these variables to fetch vertices of
 visible cluster and drive vertex shader to work.
 
 endif::VK_HUAWEI_cluster_culling_shader[]


### PR DESCRIPTION
A tiny typo fix to Pipelines article.
When I was trying to find the string I also found that same typo was present in appendices/VK_HUAWEI_cluster_culling_shader.adoc.