### PR TITLE
Add VUID for relaxed control barrier with storage class semantics

### DIFF
--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -246,6 +246,10 @@ or knowledge of runtime information, such as enabled features.
     code:AcquireRelease, or code:SequentiallyConsistent memory semantics
   * [[VUID-{refpage}-OpMemoryBarrier-04733]]
     code:OpMemoryBarrier must: include at least one {StorageClass}
+  * [[VUID-{refpage}-OpControlBarrier-04649]]
+    If the semantics for code:OpControlBarrier includes at least one {StorageClass},
+    then it must: include one of code:Acquire, code:Release, code:AcquireRelease,
+    or code:SequentiallyConsistent memory semantics
   * [[VUID-{refpage}-OpControlBarrier-04650]]
     If the semantics for code:OpControlBarrier includes one of code:Acquire,
     code:Release, code:AcquireRelease, or code:SequentiallyConsistent memory

--- a/appendices/spirvenv.adoc
+++ b/appendices/spirvenv.adoc
@@ -246,8 +246,7 @@ or knowledge of runtime information, such as enabled features.
     code:AcquireRelease, or code:SequentiallyConsistent memory semantics
   * [[VUID-{refpage}-OpMemoryBarrier-04733]]
     code:OpMemoryBarrier must: include at least one {StorageClass}
-  * [[VUID-{refpage}-OpControlBarrier-04649]]
-    If the semantics for code:OpControlBarrier includes at least one {StorageClass},
+  * If the semantics for code:OpControlBarrier includes at least one {StorageClass},
     then it must: include one of code:Acquire, code:Release, code:AcquireRelease,
     or code:SequentiallyConsistent memory semantics
   * [[VUID-{refpage}-OpControlBarrier-04650]]


### PR DESCRIPTION
Add a new VUID for a relaxed control barrier with non-zero storage class semantics. PR in SPIRV-Tools:
https://github.com/KhronosGroup/SPIRV-Tools/pull/5984