### PR TITLE
All _identically defined_ link to glossary-identically-defined

### DIFF
--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -13001,7 +13001,7 @@ GitHub Issues:
     discussion of <<synchronization-submission-order, submission order>>;
     and references elsewhere to these sections (public issue 133).
   * Clarify <<descriptorsets-compatibility,Pipeline Layout Compatibility>>
-    language and introduce the term ``identically defined'' (public issue
+    language and introduce the term <<glossary-identically-defined,identically defined>> (public issue
     164).
   * Add a dependency to the +VK_EXT_debug_marker+ extension that is needed to
     reuse the object type enum from +VK_EXT_debug_report+, and moves the

--- a/chapters/cmdbuffers.adoc
+++ b/chapters/cmdbuffers.adoc
@@ -316,7 +316,7 @@ Two command buffers will consume the same amount of pool memory if:
 
 [NOTE]
 ====
-The rules for identically defined objects apply recursively, implying for
+The rules for <<glossary-identically-defined,identically defined>> objects apply recursively, implying for
 example that if the command buffers are created in different devices that
 those devices must have been created with the same features enabled.
 ====

--- a/chapters/commonvalidity/draw_common.adoc
+++ b/chapters/commonvalidity/draw_common.adoc
@@ -2439,10 +2439,10 @@ endif::VK_EXT_mesh_shader[]
     flink:vkCreateShadersEXT call must: not have any sname:VkShaderEXT bound
   * [[VUID-{refpage}-None-08878]]
     All bound graphics shader objects must: have been created with identical
-    or identically defined push constant ranges
+    or <<glossary-identically-defined,identically defined>> push constant ranges
   * [[VUID-{refpage}-None-08879]]
     All bound graphics shader objects must: have been created with identical
-    or identically defined arrays of descriptor set layouts
+    or <<glossary-identically-defined,identically defined>> arrays of descriptor set layouts
 ifdef::VK_ANDROID_external_format_resolve[]
   * [[VUID-{refpage}-colorAttachmentCount-09372]]
     If the current render pass instance was begun with

--- a/chapters/descriptorsets.adoc
+++ b/chapters/descriptorsets.adoc
@@ -1726,7 +1726,7 @@ include::{generated}/api/structs/VkPipelineLayoutCreateInfo.adoc[]
   * pname:pushConstantRangeCount is the number of push constant ranges
     included in the pipeline layout.
   * pname:pPushConstantRanges is a pointer to an array of
-    sname:VkPushConstantRange structures defining a set of push constant
+    slink:VkPushConstantRange structures defining a set of push constant
     ranges for use in a single pipeline layout.
     In addition to descriptor set layouts, a pipeline layout also describes
     how many push constants can: be accessed by each stage of the pipeline.

--- a/chapters/descriptorsets.adoc
+++ b/chapters/descriptorsets.adoc
@@ -2440,7 +2440,7 @@ Two pipeline layouts are defined to be "`compatible for
 <<descriptorsets-push-constants, push constants>>`" if they were created
 with identical push constant ranges.
 Two pipeline layouts are defined to be "`compatible for set N`" if they were
-created with _identically defined_ descriptor set layouts for sets zero
+created with <<glossary-identically-defined,identically defined>> descriptor set layouts for sets zero
 through N,
 ifdef::VK_EXT_graphics_pipeline_library[]
 if both of them either were or were not created with
@@ -3732,7 +3732,7 @@ ifdef::VK_VULKAN_1_1,VK_KHR_sampler_ycbcr_conversion[]
     sname:VkSamplerYcbcrConversionInfo structure in its pname:pNext chain,
     then pname:dstSet must: have been allocated with a layout that included
     immutable samplers for pname:dstBinding, and the corresponding immutable
-    sampler must: have been created with an _identically defined_
+    sampler must: have been created with an <<glossary-identically-defined,identically defined>>
     sname:VkSamplerYcbcrConversionInfo object
   * [[VUID-VkWriteDescriptorSet-descriptorType-01948]]
     If pname:descriptorType is
@@ -3742,7 +3742,7 @@ ifdef::VK_VULKAN_1_1,VK_KHR_sampler_ycbcr_conversion[]
     pname:pImageInfo which corresponds to an immutable sampler that enables
     <<samplers-YCbCr-conversion,sampler {YCbCr} conversion>> must: have been
     created with a sname:VkSamplerYcbcrConversionInfo structure in its
-    pname:pNext chain with an _identically defined_
+    pname:pNext chain with an <<glossary-identically-defined,identically defined>>
     sname:VkSamplerYcbcrConversionInfo to the corresponding immutable
     sampler
   * [[VUID-VkWriteDescriptorSet-descriptorType-09506]]

--- a/chapters/device_generated_commands/generation.adoc
+++ b/chapters/device_generated_commands/generation.adoc
@@ -745,7 +745,7 @@ include::{generated}/api/protos/vkUpdateIndirectExecutionSetShaderEXT.adoc[]
     info used to create the Indirect Execution Set
   * [[VUID-vkUpdateIndirectExecutionSetShaderEXT-None-11148]]
     Each fragment shader element in the Indirect Execution Set must: have
-    identically defined <<interfaces-fragmentoutput,fragment outputs
+    <<glossary-identically-defined,identically defined>> <<interfaces-fragmentoutput,fragment outputs
     interface>> to the initial shader state used to create the Indirect
     Execution Set
   * [[VUID-vkUpdateIndirectExecutionSetShaderEXT-FragDepth-11054]]

--- a/chapters/pipelines.adoc
+++ b/chapters/pipelines.adoc
@@ -3618,7 +3618,7 @@ ifndef::VK_AMDX_shader_enqueue[If]
     ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT, and the
     pname:layout specified by either library was not created with
     ename:VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT, then the
-    pname:layout used by each library must: be _identically defined_
+    pname:layout used by each library must: be <<glossary-identically-defined,identically defined>>
   * [[VUID-VkGraphicsPipelineCreateInfo-flags-06614]]
     If slink:VkGraphicsPipelineLibraryCreateInfoEXT::pname:flags includes
     only one of
@@ -3648,7 +3648,7 @@ ifndef::VK_AMDX_shader_enqueue[If]
     other subset, and pname:layout was created with
     ename:VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT, elements of
     the pname:pSetLayouts array which pname:layout was created with that are
-    not dlink:VK_NULL_HANDLE must: be _identically defined_ to the element
+    not dlink:VK_NULL_HANDLE must: be <<glossary-identically-defined,identically defined>> to the element
     at the same index of pname:pSetLayouts used to create the library's
     pname:layout
   * [[VUID-VkGraphicsPipelineCreateInfo-pLibraries-06617]]
@@ -3660,7 +3660,7 @@ ifndef::VK_AMDX_shader_enqueue[If]
     pname:layout specified by either library was created with
     ename:VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT, elements of
     the pname:pSetLayouts array which either pname:layout was created with
-    that are not dlink:VK_NULL_HANDLE must: be _identically defined_ to the
+    that are not dlink:VK_NULL_HANDLE must: be <<glossary-identically-defined,identically defined>> to the
     element at the same index of pname:pSetLayouts used to create the other
     library's pname:layout
   * [[VUID-VkGraphicsPipelineCreateInfo-flags-06618]]
@@ -3681,7 +3681,7 @@ ifndef::VK_AMDX_shader_enqueue[If]
     ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT, any
     descriptor set layout _N_ specified by pname:layout in both libraries
     which include bindings accessed by shader stages in each must: be
-    _identically defined_
+    <<glossary-identically-defined,identically defined>>
   * [[VUID-VkGraphicsPipelineCreateInfo-flags-06620]]
     If slink:VkGraphicsPipelineLibraryCreateInfoEXT::pname:flags includes
     only one of
@@ -3690,7 +3690,7 @@ ifndef::VK_AMDX_shader_enqueue[If]
     element of slink:VkPipelineLibraryCreateInfoKHR::pname:pLibraries
     includes the other flag, push constants specified in pname:layout in
     both this pipeline and the library which are available to shader stages
-    in each must: be _identically defined_
+    in each must: be <<glossary-identically-defined,identically defined>>
   * [[VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621]]
     If one element of slink:VkPipelineLibraryCreateInfoKHR::pname:pLibraries
     includes
@@ -3699,7 +3699,7 @@ ifndef::VK_AMDX_shader_enqueue[If]
     ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT, push
     constants specified in pname:layout in both this pipeline and the
     library which are available to shader stages in each must: be
-    _identically defined_
+    <<glossary-identically-defined,identically defined>>
   * [[VUID-VkGraphicsPipelineCreateInfo-flags-06679]]
     If slink:VkGraphicsPipelineLibraryCreateInfoEXT::pname:flags includes
     only one of
@@ -3874,7 +3874,7 @@ endif::VK_VERSION_1_3,VK_KHR_dynamic_rendering[]
     pname:pMultisampleState that was not `NULL`, and an element of
     slink:VkPipelineLibraryCreateInfoKHR::pname:pLibraries was created with
     ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT,
-    pname:pMultisampleState must: be _identically defined_ to that used to
+    pname:pMultisampleState must: be <<glossary-identically-defined,identically defined>> to that used to
     create the library
   * [[VUID-VkGraphicsPipelineCreateInfo-pLibraries-06634]]
     If an element of slink:VkPipelineLibraryCreateInfoKHR::pname:pLibraries
@@ -3883,7 +3883,7 @@ endif::VK_VERSION_1_3,VK_KHR_dynamic_rendering[]
     pname:pMultisampleState that was not `NULL`, and if
     slink:VkGraphicsPipelineLibraryCreateInfoEXT::pname:flags includes
     ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT,
-    pname:pMultisampleState must: be _identically defined_ to that used to
+    pname:pMultisampleState must: be <<glossary-identically-defined,identically defined>> to that used to
     create the library
   * [[VUID-VkGraphicsPipelineCreateInfo-pLibraries-06635]]
     If one element of slink:VkPipelineLibraryCreateInfoKHR::pname:pLibraries
@@ -3894,7 +3894,7 @@ endif::VK_VERSION_1_3,VK_KHR_dynamic_rendering[]
     with
     ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT,
     the pname:pMultisampleState used to create each library must: be
-    _identically defined_
+    <<glossary-identically-defined,identically defined>>
   * [[VUID-VkGraphicsPipelineCreateInfo-pLibraries-06636]]
     If one element of slink:VkPipelineLibraryCreateInfoKHR::pname:pLibraries
     was created with
@@ -3904,14 +3904,14 @@ endif::VK_VERSION_1_3,VK_KHR_dynamic_rendering[]
     slink:VkPipelineLibraryCreateInfoKHR::pname:pLibraries was created with
     ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT, the
     pname:pMultisampleState used to create each library must: be
-    _identically defined_
+    <<glossary-identically-defined,identically defined>>
   * [[VUID-VkGraphicsPipelineCreateInfo-flags-06637]]
     If slink:VkGraphicsPipelineLibraryCreateInfoEXT::pname:flags includes
     ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT,
     pname:pMultisampleState->sampleShadingEnable is ename:VK_TRUE, and an
     element of slink:VkPipelineLibraryCreateInfoKHR::pname:pLibraries was
     created with ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT,
-    pname:pMultisampleState must: be _identically defined_ to that used to
+    pname:pMultisampleState must: be <<glossary-identically-defined,identically defined>> to that used to
     create the library
   * [[VUID-VkGraphicsPipelineCreateInfo-pLibraries-09567]]
     If one element of slink:VkPipelineLibraryCreateInfoKHR::pname:pLibraries
@@ -3921,7 +3921,7 @@ endif::VK_VERSION_1_3,VK_KHR_dynamic_rendering[]
     ename:VK_TRUE, and if
     slink:VkGraphicsPipelineLibraryCreateInfoEXT::pname:flags includes
     ename:VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT,
-    pname:pMultisampleState must: be _identically defined_ to that used to
+    pname:pMultisampleState must: be <<glossary-identically-defined,identically defined>> to that used to
     create the library
 ifdef::VK_KHR_fragment_shading_rate[]
   * [[VUID-VkGraphicsPipelineCreateInfo-flags-06638]]

--- a/chapters/resources.adoc
+++ b/chapters/resources.adoc
@@ -5106,7 +5106,7 @@ create the sampler must: be passed to flink:vkCreateImageView in a
 slink:VkSamplerYcbcrConversionInfo included in the pname:pNext chain of
 slink:VkImageViewCreateInfo.
 Conversely, if a slink:VkSamplerYcbcrConversion object is passed to
-flink:vkCreateImageView, an identically defined
+flink:vkCreateImageView, an <<glossary-identically-defined,identically defined>>
 slink:VkSamplerYcbcrConversion object must: be used when sampling the image.
 
 [[image-views-requiring-sampler-ycbcr-conversion]]


### PR DESCRIPTION
And a question about `identically defined` in [issue : pipeline layout compatibility question](https://github.com/KhronosGroup/Vulkan-Docs/issues/1853#issuecomment-2717067439)