### PR TITLE
Fix "If If" in Texel Replacement section

### DIFF
--- a/chapters/textures.adoc
+++ b/chapters/textures.adoc
@@ -892,7 +892,6 @@ the <<features-robustImageAccess, pname:robustImageAccess>> feature is
 enabled, then zero must: be returned for the R, G, and B components, if
 present.
 Either zero or one must: be returned for the A component, if present.
-ifdef::VK_EXT_robustness2[If]
 endif::VK_VERSION_1_3,VK_EXT_image_robustness[]
 ifdef::VK_EXT_robustness2[]
 If the <<features-robustImageAccess2, pname:robustImageAccess2>> feature is


### PR DESCRIPTION
https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#textures-texel-replacement

> <del>If </del>If the robustImageAccess2 feature is enabled, zero values must be returned. If only the sample index was invalid, the values returned are undefined.

I think this is the correct fix.