### PR TITLE
Rework and expand docs site landing page

### DIFF
--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -31,44 +31,44 @@ current page.
 
 === Vulkan specification
 
-xref:spec:introduction.adoc[The Vulkan specification] describes the Vulkan Application Programming Interface (API). Vulkan is a C99 API designed for explicit control of low-level graphics and compute functionality.
+xref:spec::index.adoc[The Vulkan specification] describes the Vulkan Application Programming Interface (API). Vulkan is a C99 API designed for explicit control of low-level graphics and compute functionality.
 
 The specification is aimed at implementors of Vulkan and at developers that already know the basics of Vulkan and want to read up on more advanced topics.
 
 === Vulkan feature descriptions
 
-xref:features:index.adoc[The Vulkan feature descriptions] include extension documents that
+xref:features::index.adoc[The Vulkan feature descriptions] include extension documents that
 are written outlining the proposed API for new extensions. They are the base for the
 final extension specification and contain supplementary documentation. 
 
 It is closely related to the Vulkan specification and can help to understand
-why an extension or a feature have been implemented in a certain way.
+why an extension or a feature has been implemented in a given way.
 
 === Vulkan guide
 
-xref:guide:index.adoc[The Vulkan Guide] is designed to help developers get up and going with the world of Vulkan. It is aimed to be a light read that leads to many other useful links depending on what a developer is looking for. All information is intended to help better fill the gaps about the many nuances of the Vulkan ecosystem including peripheral topics like shading languages.
+xref:guide::index.adoc[The Vulkan Guide] is designed to help developers get up and going with the world of Vulkan. It is aimed to be a light read that leads to many other useful links depending on what a developer is looking for. All information is intended to help better fill the gaps about the many nuances of the Vulkan ecosystem including peripheral topics like shading languages.
 
 The Guide is a good starting point for first time Vulkan developers.
 
 === Vulkan samples
 
-xref:samples:index.adoc[The Vulkan Samples] are a collection of resources to help you develop optimized Vulkan applications. These C++ samples demonstrate a wide range of Vulkan's functionality. From writing a first "Hello triangle" sample to rendering complex scenes, doing GPU based work and using hardware accelerated ray tracing, these samples are trying to help developers learn how to use Vulkan.
+xref:samples::README.adoc[The Vulkan Samples] are a collection of resources to help you develop optimized Vulkan applications. These C++ samples demonstrate a wide range of Vulkan's functionality. From writing a first "Hello triangle" sample to rendering complex scenes, doing GPU based work and using hardware accelerated ray tracing, these samples are trying to help developers learn how to use Vulkan.
 
 === Vulkan tutorial
 
-xref:tutorial:index.adoc[The Vulkan tutorial] will teach you the basics of using Vulkan. It'll help you get started with the API and teaches you how to get your first graphics and compute programs up and running using the C++ programming language.
+xref:tutorial::00_Introduction.adoc[The Vulkan tutorial] will teach you the basics of using Vulkan. It'll help you get started with the API and teaches you how to get your first graphics and compute programs up and running using the C++ programming language.
 
 The Tutorial is aimed at people starting with Vulkan. If you are new to Vulkan, this should be your starting point.
 
 === GLSL documentation
 
-Although Vulkan consumes shaders in SPIR-V, one of the most widely used shading languages is xref:glsl:index.adoc[GLSL]. This part of the documentation site contains the GLSL shading language specification with Vulkan specific extensions.
+Although Vulkan consumes shaders in SPIR-V, one of the most widely used shading languages is xref:glsl::index.adoc[GLSL]. This part of the documentation site contains the GLSL shading language specification with Vulkan specific extensions.
 
 == How to get started with Vulkan
 
 === Requirements
 
-Vulkan is a available on a xref:guide:platforms.adoc[wide range of platforms]. To develop with it, you first need an implementation that supports Vulkan. Most systems nowadays support Vulkan out of the box, as support ships via graphics cards drivers.
+Vulkan is a available on a xref:guide::platforms.adoc[wide range of platforms]. To develop with it, you first need an implementation that supports Vulkan. Most systems nowadays support Vulkan out of the box, as support ships via graphics cards drivers.
 
 For actually writing code that uses Vulkan, you need bindings for your programming language like the https://github.com/KhronosGroup/Vulkan-Headers[C bindings] (that also work with C++) or the https://github.com/KhronosGroup/Vulkan-Hpp[C{pp} bindings] that offers a C{pp} based interface to the API.
 
@@ -80,9 +80,9 @@ While not a requirement for developing Vulkan application, the https://www.lunar
 
 The https://vulkan.lunarg.com/doc/sdk/1.4.309.0/windows/getting_started.html[Vulkan SDK] contains C and C{pp} project templates for Microsoft Visual Studio that can be used as a starting point for writing Vulkan programs.
 
-Another option is to follow the xref:tutorial:02_Development_environment.adoc[development environment chapter] of the xref:tutorial:index.adoc[The Vulkan tutorial] which has instructions for different platforms.
+Another option is to follow the xref:tutorial::02_Development_environment.adoc[development environment chapter] of the xref:tutorial::00_Introduction.adoc[The Vulkan tutorial] which has instructions for different platforms.
 
-As a third option, the xref:samples:index.adoc[The Vulkan Samples] come with build system that supports different platforms and C++ based development environments.
+As a third option, the xref:samples::README.adoc[The Vulkan Samples] come with build system that supports different platforms and C++ based development environments.
 
 == Getting help
 

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -68,7 +68,21 @@ Although Vulkan consumes shaders in SPIR-V, one of the most widely used shading 
 
 === Requirements
 
+Vulkan is a available on a xref:guide:platforms.adoc[wide range of platforms]. To develop with it, you first need an implementation that supports Vulkan. Most systems nowadays support Vulkan out of the box, as support ships via graphics cards drivers.
+
+For actually writing code that uses Vulkan, you need bindings for your programming language like the https://github.com/KhronosGroup/Vulkan-Headers[C bindings] (that also work with C++) or the https://github.com/KhronosGroup/Vulkan-Hpp[C{pp} bindings] that offers a C{pp} based interface to the API.
+
 === Vulkan SDK
+
+While not a requirement for developing Vulkan application, the https://www.lunarg.com/vulkan-sdk/[LunarG Vulkan SDK] is a convenient package of components and tools to help with developing Vulkan applications. Using the SDK is recommended.
+
+=== First Vulkan program
+
+The https://vulkan.lunarg.com/doc/sdk/1.4.309.0/windows/getting_started.html[Vulkan SDK] contains C and C{pp} project templates for Microsoft Visual Studio that can be used as a starting point for writing Vulkan programs.
+
+Another option is to follow the xref:tutorial:02_Development_environment.adoc[development environment chapter] of the xref:tutorial:index.adoc[The Vulkan tutorial] which has instructions for different platforms.
+
+As a third option, the xref:samples:index.adoc[The Vulkan Samples] come with build system that supports different platforms and C++ based development environments.
 
 == Getting help
 

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -8,7 +8,7 @@ include::{generated}/specattribs.adoc[]
 
 == About
 
-Welcome the the official Documentation site for the cross-platform Vulkan
+Welcome to the official Documentation site for the cross-platform Vulkan
 graphics and compute API.
 This is your starting point for all things related to
 https://www.vulkan.org[Vulkan].

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -20,7 +20,7 @@ Vulkan-based applications.
 This build of the site includes the Vulkan {SPECREVISION} API specification
 {APITITLE}, generated on {SPECDATE} {SPECREMARK}.
 
-== How to navigate this site
+== How to Navigate This Site
 
 The site is organized into "`components`".
 The left navigation sidebar links to pages in the current component.
@@ -36,9 +36,9 @@ Otherwise, all components of the site are searched.
 On pages with multiple sections, a right navigation sidebar links to
 sections in the current page.
 
-== What's included
+== What's Included
 
-=== Vulkan specification
+=== Vulkan Specification
 
 xref:spec::index.adoc[The Vulkan specification] describes the Vulkan
 Application Programming Interface (API).
@@ -49,7 +49,7 @@ The specification is aimed at implementors of Vulkan and at developers that
 already know the basics of Vulkan and want to read up on more advanced
 topics.
 
-=== Vulkan feature descriptions
+=== Vulkan Feature Descriptions
 
 xref:features::index.adoc[The Vulkan feature descriptions] include extension
 documents that are written outlining the proposed API for new extensions.
@@ -59,7 +59,7 @@ supplementary documentation.
 It is closely related to the Vulkan specification and can help to understand
 why an extension or a feature has been implemented in a given way.
 
-=== Vulkan guide
+=== Vulkan Guide
 
 xref:guide::index.adoc[The Vulkan Guide] is designed to help developers get
 up and going with the world of Vulkan.
@@ -71,7 +71,7 @@ languages.
 
 The Guide is a good starting point for first time Vulkan developers.
 
-=== Vulkan samples
+=== Vulkan Samples
 
 xref:samples::README.adoc[The Vulkan Samples] are a collection of resources
 to help you develop optimized Vulkan applications.
@@ -80,7 +80,7 @@ From writing a first "Hello triangle" sample to rendering complex scenes,
 doing GPU based work and using hardware accelerated ray tracing, these
 samples are trying to help developers learn how to use Vulkan.
 
-=== Vulkan tutorial
+=== Vulkan Tutorial
 
 xref:tutorial::00_Introduction.adoc[The Vulkan tutorial] will teach you the
 basics of using Vulkan.
@@ -91,14 +91,14 @@ language.
 The Tutorial is aimed at people starting with Vulkan.
 If you are new to Vulkan, this should be your starting point.
 
-=== GLSL documentation
+=== GLSL Specification
 
 Although Vulkan consumes shaders in SPIR-V, one of the most widely used
 shading languages is xref:glsl::index.adoc[GLSL].
 This part of the documentation site contains the GLSL shading language
 specification with Vulkan specific extensions.
 
-== How to get started with Vulkan
+== How to get Started With Vulkan
 
 === Requirements
 
@@ -121,7 +121,7 @@ https://www.lunarg.com/vulkan-sdk/[LunarG Vulkan SDK] is a convenient
 package of components and tools to help with developing Vulkan applications.
 Using the SDK is recommended.
 
-=== First Vulkan program
+=== First Vulkan Program
 
 The
 https://vulkan.lunarg.com/doc/sdk/1.4.309.0/windows/getting_started.html[Vulkan
@@ -137,7 +137,7 @@ As a third option, the xref:samples::README.adoc[The Vulkan Samples] come
 with build system that supports different platforms and C++ based
 development environments.
 
-== Getting help
+== Getting Help
 
 The Vulkan communities are there to help with all questions regarding the
 Vulkan ecosystem.

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -14,7 +14,7 @@ It combines multiple ecosystem documentation components into a convenient
 single site, meaning information is linked between these components and can
 easily be discovered using the global search.
 
-== Navigate this site
+== How to navigate this site
 
 The site is organized into "`components`". The left navigation sidebar links to 
 pages in the current component. The bottom-left button switches between components.
@@ -86,6 +86,8 @@ As a third option, the xref:samples:index.adoc[The Vulkan Samples] come with bui
 
 == Getting help
 
+The Vulkan communities are there to help with all questions regarding the Vulkan ecosystem. Official channels include https://discord.gg/vulkan[Discord], https://www.reddit.com/r/vulkan/[Reddit] and a https://community.khronos.org/c/vulkan[Vulkan forum].
+
 == Versioning
 
 This build of the site includes the Vulkan {SPECREVISION} API specification
@@ -96,3 +98,5 @@ This build of the site includes the Vulkan {SPECREVISION} API specification
 If you need to report a problem or want to build the site yourself, start with the
 link:https://github.com/KhronosGroup/Vulkan-Site/[Vulkan-Site] repository on
 GitHub.
+
+This site is generated using the link:https://docs.antora.org/[Antora] static site generator.

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -14,6 +14,9 @@ It combines multiple ecosystem documentation components into a convenient
 single site, meaning information is linked between these components and can
 easily be discovered using the global search.
 
+This build of the site includes the Vulkan {SPECREVISION} API specification
+{APITITLE}, generated on {SPECDATE} {SPECREMARK}.
+
 == How to navigate this site
 
 The site is organized into "`components`". The left navigation sidebar links to 
@@ -87,11 +90,6 @@ As a third option, the xref:samples::README.adoc[The Vulkan Samples] come with b
 == Getting help
 
 The Vulkan communities are there to help with all questions regarding the Vulkan ecosystem. Official channels include https://discord.gg/vulkan[Discord], https://www.reddit.com/r/vulkan/[Reddit] and a https://community.khronos.org/c/vulkan[Vulkan forum].
-
-== Versioning
-
-This build of the site includes the Vulkan {SPECREVISION} API specification
-{APITITLE}, generated on {SPECDATE} {SPECREMARK}.
 
 == Feedback
 

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -8,18 +8,18 @@ include::{generated}/specattribs.adoc[]
 
 == About
 
-Welcome the the official Vulkan Documentation site. This is your starting point 
-for all things related to the https://www.vulkan.org[Vulkan] low-level graphics
-api. It combines different ecosystem documentation components into a convenient
+Welcome the the official Documentation site for the cross-platform Vulkan graphics
+api. This is your starting point for all things related to https://www.vulkan.org[Vulkan].
+It combines multiple ecosystem documentation components into a convenient
 single site, meaning information is linked between these components and can
 easily be discovered using the global search.
 
 == Navigate this site
 
-The site is organized in "`components`". The left navigation sidebar links to 
+The site is organized into "`components`". The left navigation sidebar links to 
 pages in the current component. The bottom-left button switches between components.
 
-The top navigation has links to all "`components`" and related external docmentation.
+The top navigation has links to all "`components`" and related external documentation.
 It also allows for searching within this site. If the "`In this component`" box is
 checked, search will be restricted to the current component. Otherwise, all components 
 of the site are searched.
@@ -31,13 +31,38 @@ current page.
 
 === Vulkan specification
 
+xref:spec:introduction.adoc[The Vulkan specification] describes the Vulkan Application Programming Interface (API). Vulkan is a C99 API designed for explicit control of low-level graphics and compute functionality.
+
+The specification is aimed at implementors of Vulkan and at developers that already know the basics of Vulkan and want to read up on more advanced topics.
+
 === Vulkan feature descriptions
+
+xref:features:index.adoc[The Vulkan feature descriptions] include extension documents that
+are written outlining the proposed API for new extensions. They are the base for the
+final extension specification and contain supplementary documentation. 
+
+It is closely related to the Vulkan specification and can help to understand
+why an extension or a feature have been implemented in a certain way.
 
 === Vulkan guide
 
+xref:guide:index.adoc[The Vulkan Guide] is designed to help developers get up and going with the world of Vulkan. It is aimed to be a light read that leads to many other useful links depending on what a developer is looking for. All information is intended to help better fill the gaps about the many nuances of the Vulkan ecosystem including peripheral topics like shading languages.
+
+The Guide is a good starting point for first time Vulkan developers.
+
 === Vulkan samples
 
+xref:samples:index.adoc[The Vulkan Samples] are a collection of resources to help you develop optimized Vulkan applications. These C++ samples demonstrate a wide range of Vulkan's functionality. From writing a first "Hello triangle" sample to rendering complex scenes, doing GPU based work and using hardware accelerated ray tracing, these samples are trying to help developers learn how to use Vulkan.
+
 === Vulkan tutorial
+
+xref:tutorial:index.adoc[The Vulkan tutorial] will teach you the basics of using Vulkan. It'll help you get started with the API and teaches you how to get your first graphics and compute programs up and running using the C++ programming language.
+
+The Tutorial is aimed at people starting with Vulkan. If you are new to Vulkan, this should be your starting point.
+
+=== GLSL documentation
+
+Although Vulkan consumes shaders in SPIR-V, one of the most widely used shading languages is xref:glsl:index.adoc[GLSL]. This part of the documentation site contains the GLSL shading language specification with Vulkan specific extensions.
 
 == How to get started with Vulkan
 
@@ -54,6 +79,6 @@ This build of the site includes the Vulkan {SPECREVISION} API specification
 
 == Feedback
 
-If you need to report a problem or want tobuild the site yourself, start with the
+If you need to report a problem or want to build the site yourself, start with the
 link:https://github.com/KhronosGroup/Vulkan-Site/[Vulkan-Site] repository on
 GitHub.

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -9,7 +9,7 @@ include::{generated}/specattribs.adoc[]
 == About
 
 Welcome the the official Documentation site for the cross-platform Vulkan
-graphic api.
+graphics and compute API.
 This is your starting point for all things related to
 https://www.vulkan.org[Vulkan].
 This site gathers together several key Vulkan documents into a convenient

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -26,7 +26,7 @@ The site is organized into "`components`".
 The left navigation sidebar links to pages in the current component.
 The bottom-left button switches between components.
 
-The top navigation has links to all "`components`" and related external
+The top navigation also has links to all components and related external
 documentation.
 It also allows for searching within this site.
 If the "`In this component`" box is checked, search will be restricted to

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -6,47 +6,54 @@
 include::{config}/attribs.adoc[]
 include::{generated}/specattribs.adoc[]
 
-
 == About
 
-link:https://docs.vulkan.org/[This site] gathers together several key Vulkan
-documents including specifications, extension proposals, guides, tutorials
-and samples into a single site.
-This allows searching and cross-linking across documents, to help navigate
-quickly to the information you need for developing Vulkan-based
-applications.
+Welcome the the official Vulkan Documentation site. This is your starting point 
+for all things related to the https://www.vulkan.org[Vulkan] low-level graphics
+api. It combines different ecosystem documentation components into a convenient
+single site, meaning information is linked between these components and can
+easily be discovered using the global search.
 
-For more information about and resources for using the Vulkan graphics API,
-see the Vulkan developer website at https://vulkan.org .
+== Navigate this site
+
+The site is organized in "`components`". The left navigation sidebar links to 
+pages in the current component. The bottom-left button switches between components.
+
+The top navigation has links to all "`components`" and related external docmentation.
+It also allows for searching within this site. If the "`In this component`" box is
+checked, search will be restricted to the current component. Otherwise, all components 
+of the site are searched.
+
+On pages with multiple sections, a right navigation sidebar links to sections in the 
+current page.
+
+== What's included
+
+=== Vulkan specification
+
+=== Vulkan feature descriptions
+
+=== Vulkan guide
+
+=== Vulkan samples
+
+=== Vulkan tutorial
+
+== How to get started with Vulkan
+
+=== Requirements
+
+=== Vulkan SDK
+
+== Getting help
+
+== Versioning
 
 This build of the site includes the Vulkan {SPECREVISION} API specification
 {APITITLE}, generated on {SPECDATE} {SPECREMARK}.
 
+== Feedback
 
-== Navigation
-
-The site is organized in "`components`" (Antora terminology for
-specifications and other documents), each containing many "`pages`" (Antora
-terminology for a chapter of a specification, or other distinct piece of
-content for other components).
-
-The left navigation sidebar links to pages in the current component.
-
-The right navigation sidebar links to sections in the current page.
-
-The bottom-left button switches between components.
-
-The top navigation bar contains a text searchbox.
-If the "`In this component`" box is checked, search will be restricted to
-the current component.
-Otherwise, all components of the site are searched.
-
-
-== Site Information
-
-link:https://docs.vulkan.org/[This site] is generated using the
-link:https://docs.antora.org/[Antora] static site generator.
-
-If you need to report a problem or build the site yourself, start with the
+If you need to report a problem or want tobuild the site yourself, start with the
 link:https://github.com/KhronosGroup/Vulkan-Site/[Vulkan-Site] repository on
 GitHub.

--- a/antora/spec/modules/ROOT/pages/index.adoc
+++ b/antora/spec/modules/ROOT/pages/index.adoc
@@ -8,93 +8,148 @@ include::{generated}/specattribs.adoc[]
 
 == About
 
-Welcome the the official Documentation site for the cross-platform Vulkan graphics
-api. This is your starting point for all things related to https://www.vulkan.org[Vulkan].
-It combines multiple ecosystem documentation components into a convenient
-single site, meaning information is linked between these components and can
-easily be discovered using the global search.
+Welcome the the official Documentation site for the cross-platform Vulkan
+graphic api.
+This is your starting point for all things related to
+https://www.vulkan.org[Vulkan].
+This site gathers together several key Vulkan documents into a convenient
+single site.This allows searching and cross-linking across documents, to
+help navigate quickly to the information you need for developing
+Vulkan-based applications.
 
 This build of the site includes the Vulkan {SPECREVISION} API specification
 {APITITLE}, generated on {SPECDATE} {SPECREMARK}.
 
 == How to navigate this site
 
-The site is organized into "`components`". The left navigation sidebar links to 
-pages in the current component. The bottom-left button switches between components.
+The site is organized into "`components`".
+The left navigation sidebar links to pages in the current component.
+The bottom-left button switches between components.
 
-The top navigation has links to all "`components`" and related external documentation.
-It also allows for searching within this site. If the "`In this component`" box is
-checked, search will be restricted to the current component. Otherwise, all components 
-of the site are searched.
+The top navigation has links to all "`components`" and related external
+documentation.
+It also allows for searching within this site.
+If the "`In this component`" box is checked, search will be restricted to
+the current component.
+Otherwise, all components of the site are searched.
 
-On pages with multiple sections, a right navigation sidebar links to sections in the 
-current page.
+On pages with multiple sections, a right navigation sidebar links to
+sections in the current page.
 
 == What's included
 
 === Vulkan specification
 
-xref:spec::index.adoc[The Vulkan specification] describes the Vulkan Application Programming Interface (API). Vulkan is a C99 API designed for explicit control of low-level graphics and compute functionality.
+xref:spec::index.adoc[The Vulkan specification] describes the Vulkan
+Application Programming Interface (API).
+Vulkan is a C99 API designed for explicit control of low-level graphics and
+compute functionality.
 
-The specification is aimed at implementors of Vulkan and at developers that already know the basics of Vulkan and want to read up on more advanced topics.
+The specification is aimed at implementors of Vulkan and at developers that
+already know the basics of Vulkan and want to read up on more advanced
+topics.
 
 === Vulkan feature descriptions
 
-xref:features::index.adoc[The Vulkan feature descriptions] include extension documents that
-are written outlining the proposed API for new extensions. They are the base for the
-final extension specification and contain supplementary documentation. 
+xref:features::index.adoc[The Vulkan feature descriptions] include extension
+documents that are written outlining the proposed API for new extensions.
+They are the base for the final extension specification and contain
+supplementary documentation.
 
 It is closely related to the Vulkan specification and can help to understand
 why an extension or a feature has been implemented in a given way.
 
 === Vulkan guide
 
-xref:guide::index.adoc[The Vulkan Guide] is designed to help developers get up and going with the world of Vulkan. It is aimed to be a light read that leads to many other useful links depending on what a developer is looking for. All information is intended to help better fill the gaps about the many nuances of the Vulkan ecosystem including peripheral topics like shading languages.
+xref:guide::index.adoc[The Vulkan Guide] is designed to help developers get
+up and going with the world of Vulkan.
+It is aimed to be a light read that leads to many other useful links
+depending on what a developer is looking for.
+All information is intended to help better fill the gaps about the many
+nuances of the Vulkan ecosystem including peripheral topics like shading
+languages.
 
 The Guide is a good starting point for first time Vulkan developers.
 
 === Vulkan samples
 
-xref:samples::README.adoc[The Vulkan Samples] are a collection of resources to help you develop optimized Vulkan applications. These C++ samples demonstrate a wide range of Vulkan's functionality. From writing a first "Hello triangle" sample to rendering complex scenes, doing GPU based work and using hardware accelerated ray tracing, these samples are trying to help developers learn how to use Vulkan.
+xref:samples::README.adoc[The Vulkan Samples] are a collection of resources
+to help you develop optimized Vulkan applications.
+These C++ samples demonstrate a wide range of Vulkan's functionality.
+From writing a first "Hello triangle" sample to rendering complex scenes,
+doing GPU based work and using hardware accelerated ray tracing, these
+samples are trying to help developers learn how to use Vulkan.
 
 === Vulkan tutorial
 
-xref:tutorial::00_Introduction.adoc[The Vulkan tutorial] will teach you the basics of using Vulkan. It'll help you get started with the API and teaches you how to get your first graphics and compute programs up and running using the C++ programming language.
+xref:tutorial::00_Introduction.adoc[The Vulkan tutorial] will teach you the
+basics of using Vulkan.
+It'll help you get started with the API and teaches you how to get your
+first graphics and compute programs up and running using the C++ programming
+language.
 
-The Tutorial is aimed at people starting with Vulkan. If you are new to Vulkan, this should be your starting point.
+The Tutorial is aimed at people starting with Vulkan.
+If you are new to Vulkan, this should be your starting point.
 
 === GLSL documentation
 
-Although Vulkan consumes shaders in SPIR-V, one of the most widely used shading languages is xref:glsl::index.adoc[GLSL]. This part of the documentation site contains the GLSL shading language specification with Vulkan specific extensions.
+Although Vulkan consumes shaders in SPIR-V, one of the most widely used
+shading languages is xref:glsl::index.adoc[GLSL].
+This part of the documentation site contains the GLSL shading language
+specification with Vulkan specific extensions.
 
 == How to get started with Vulkan
 
 === Requirements
 
-Vulkan is a available on a xref:guide::platforms.adoc[wide range of platforms]. To develop with it, you first need an implementation that supports Vulkan. Most systems nowadays support Vulkan out of the box, as support ships via graphics cards drivers.
+Vulkan is a available on a xref:guide::platforms.adoc[wide range of
+platforms].
+To develop with it, you first need an implementation that supports Vulkan.
+Most systems nowadays support Vulkan out of the box, as support ships via
+graphics cards drivers.
 
-For actually writing code that uses Vulkan, you need bindings for your programming language like the https://github.com/KhronosGroup/Vulkan-Headers[C bindings] (that also work with C++) or the https://github.com/KhronosGroup/Vulkan-Hpp[C{pp} bindings] that offers a C{pp} based interface to the API.
+For actually writing code that uses Vulkan, you need bindings for your
+programming language like the
+https://github.com/KhronosGroup/Vulkan-Headers[C bindings] (that also work
+with C++) or the https://github.com/KhronosGroup/Vulkan-Hpp[C{pp} bindings]
+that offers a C{pp} based interface to the API.
 
 === Vulkan SDK
 
-While not a requirement for developing Vulkan application, the https://www.lunarg.com/vulkan-sdk/[LunarG Vulkan SDK] is a convenient package of components and tools to help with developing Vulkan applications. Using the SDK is recommended.
+While not a requirement for developing Vulkan application, the
+https://www.lunarg.com/vulkan-sdk/[LunarG Vulkan SDK] is a convenient
+package of components and tools to help with developing Vulkan applications.
+Using the SDK is recommended.
 
 === First Vulkan program
 
-The https://vulkan.lunarg.com/doc/sdk/1.4.309.0/windows/getting_started.html[Vulkan SDK] contains C and C{pp} project templates for Microsoft Visual Studio that can be used as a starting point for writing Vulkan programs.
+The
+https://vulkan.lunarg.com/doc/sdk/1.4.309.0/windows/getting_started.html[Vulkan
+SDK] contains C and C{pp} project templates for Microsoft Visual Studio that
+can be used as a starting point for writing Vulkan programs.
 
-Another option is to follow the xref:tutorial::02_Development_environment.adoc[development environment chapter] of the xref:tutorial::00_Introduction.adoc[The Vulkan tutorial] which has instructions for different platforms.
+Another option is to follow the
+xref:tutorial::02_Development_environment.adoc[development environment
+chapter] of the xref:tutorial::00_Introduction.adoc[The Vulkan tutorial]
+which has instructions for different platforms.
 
-As a third option, the xref:samples::README.adoc[The Vulkan Samples] come with build system that supports different platforms and C++ based development environments.
+As a third option, the xref:samples::README.adoc[The Vulkan Samples] come
+with build system that supports different platforms and C++ based
+development environments.
 
 == Getting help
 
-The Vulkan communities are there to help with all questions regarding the Vulkan ecosystem. Official channels include https://discord.gg/vulkan[Discord], https://www.reddit.com/r/vulkan/[Reddit] and a https://community.khronos.org/c/vulkan[Vulkan forum].
+The Vulkan communities are there to help with all questions regarding the
+Vulkan ecosystem.
+Official channels include https://discord.gg/vulkan[Discord],
+https://www.reddit.com/r/vulkan/[Reddit] and a
+https://community.khronos.org/c/vulkan[Vulkan forum].
 
 == Feedback
 
-If you need to report a problem or want to build the site yourself, start with the
-link:https://github.com/KhronosGroup/Vulkan-Site/[Vulkan-Site] repository on
-GitHub.
+If you need to report a problem or want to build the site yourself, start
+with the link:https://github.com/KhronosGroup/Vulkan-Site/[Vulkan-Site]
+repository on GitHub.
 
-This site is generated using the link:https://docs.antora.org/[Antora] static site generator.
+This site is generated using the link:https://docs.antora.org/[Antora]
+static site generator.


### PR DESCRIPTION
This PR is a first attempt to rework and expand the landing page for the Antora based Vulkan docs site.

The goal behind this is to give people some guidance on what the docs site contains, how to navigate it and how to get started with Vulkan.

In short: Make the docs site a bit more welcoming and help people find their way around ;)

This was something we discussded during multiple internal calls.

A rendered preview can be found at https://gpuinfo.org/misc/docsite/site/spec/latest/index.html (Please ignore missing links and meta data, this is not a full build of the site).

Current landing page for comparison: https://docs.vulkan.org/spec/latest/index.html