### PR TITLE
Fix union member name markup

### DIFF
--- a/chapters/VK_INTEL_performance_query/queries.adoc
+++ b/chapters/VK_INTEL_performance_query/queries.adoc
@@ -123,11 +123,11 @@ The sname:VkPerformanceValueDataINTEL union is defined as:
 
 include::{generated}/api/structs/VkPerformanceValueDataINTEL.adoc[]
 
-  * pname:data.value32 represents 32-bit integer data.
-  * pname:data.value64 represents 64-bit integer data.
-  * pname:data.valueFloat represents floating-point data.
-  * pname:data.valueBool represents basetype:VkBool32 data.
-  * pname:data.valueString represents a pointer to a null-terminated UTF-8
+  * pname:value32 represents 32-bit integer data.
+  * pname:value64 represents 64-bit integer data.
+  * pname:valueFloat represents floating-point data.
+  * pname:valueBool represents basetype:VkBool32 data.
+  * pname:valueString represents a pointer to a null-terminated UTF-8
     string.
 
 The correct member of the union is determined by the associated


### PR DESCRIPTION
`data.` is unnecessary, documents for other unions do not contain such prefix either.