### PR TITLE
Remove superfluous underscore in shaders chapter

### DIFF
--- a/chapters/shaders.adoc
+++ b/chapters/shaders.adoc
@@ -2220,7 +2220,7 @@ of fragment shader invocations associated with other fragments.
 [[shaders-compute]]
 == Compute Shaders
 
-Compute shaders are invoked via <<dispatch, _dispatching commands>>.
+Compute shaders are invoked via <<dispatch, dispatching commands>>.
 In general, they have access to similar resources as shader stages executing
 as part of a graphics pipeline.
 


### PR DESCRIPTION
This (totally minor) PR removes a superfluous underscore in the compute shader paragraph in the shaders chapter:

![image](https://github.com/user-attachments/assets/add57706-82e4-4eda-a8c2-68549d9dad4f)
