### PR TITLE
Clarify WorkgroupId definition

### DIFF
--- a/chapters/interfaces.adoc
+++ b/chapters/interfaces.adoc
@@ -5587,10 +5587,11 @@ endif::VK_NV_shader_sm_builtins[]
 code:WorkgroupId::
 
 Decorating a variable with the code:WorkgroupId built-in decoration will
-make that variable contain the global workgroup that the current invocation
-is a member of.
-Each component ranges from a base value to a [eq]#base {plus} count# value,
-based on the parameters passed into the dispatching commands.
+make that variable contain the global coordinate of the local workgroup that
+the current invocation is a member of.
+Each component is in the range [eq]#[base,base {plus} count)#, where
+[eq]#base# and [eq]#count# are based on the parameters passed into the
+dispatching commands for each dimension of the dispatch.
 
 .Valid Usage
 ****

--- a/chapters/interfaces.adoc
+++ b/chapters/interfaces.adoc
@@ -5591,7 +5591,11 @@ make that variable contain the global coordinate of the local workgroup that
 the current invocation is a member of.
 Each component is in the range [eq]#[base,base {plus} count)#, where
 [eq]#base# and [eq]#count# are based on the parameters passed into the
-dispatching commands for each dimension of the dispatch.
+dispatching
+ifdef::VK_NV_mesh_shader,VK_EXT_mesh_shader[]
+or drawing
+endif::VK_NV_mesh_shader,VK_EXT_mesh_shader[]
+commands in each dimension.
 
 .Valid Usage
 ****


### PR DESCRIPTION
Make clear that the variable contains coordinates of a local workgrroup, not "the global workgroup", and tighten up the definition of the range.

Fixes #2538