### PR TITLE
Fix asciidoc conditional

### DIFF
--- a/chapters/VK_KHR_present_wait/present_wait.adoc
+++ b/chapters/VK_KHR_present_wait/present_wait.adoc
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: CC-BY-4.0
 
-ifndef::VK_KHR_present_wait2
+ifndef::VK_KHR_present_wait2[]
 
 [[present-wait]]
 == Present Wait
@@ -37,4 +37,4 @@ The pname:presentId passed in that structure may then be passed to a future
 flink:vkWaitForPresentKHR call to cause the application to block until that
 presentation is finished.
 
-endif::VK_KHR_present_wait2
+endif::VK_KHR_present_wait2[]


### PR DESCRIPTION
Added missing brackets on conditional. This is meant to ensure only the present_wait or present_wait2 version of the Present Wait section is output.