### PR TITLE
Add explicit return type to funcpointer definitions in Vulkan XML

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -1030,36 +1030,36 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkDefaultVertexAttributeValueKHR" category="enum"/>
 
         <comment>The PFN_vk*Function types are used by VkAllocationCallbacks below</comment>
-        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkInternalAllocationNotification</name>)(
+        <type category="funcpointer" requires="void">typedef void (VKAPI_PTR *<name>PFN_vkInternalAllocationNotification</name>)(
     <type>void</type>*                                       pUserData,
     <type>size_t</type>                                      size,
     <type>VkInternalAllocationType</type>                    allocationType,
     <type>VkSystemAllocationScope</type>                     allocationScope);</type>
-        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkInternalFreeNotification</name>)(
+        <type category="funcpointer" requires="void">typedef void (VKAPI_PTR *<name>PFN_vkInternalFreeNotification</name>)(
     <type>void</type>*                                       pUserData,
     <type>size_t</type>                                      size,
     <type>VkInternalAllocationType</type>                    allocationType,
     <type>VkSystemAllocationScope</type>                     allocationScope);</type>
-        <type category="funcpointer">typedef void* (VKAPI_PTR *<name>PFN_vkReallocationFunction</name>)(
+        <type category="funcpointer" requires="void">typedef void* (VKAPI_PTR *<name>PFN_vkReallocationFunction</name>)(
     <type>void</type>*                                       pUserData,
     <type>void</type>*                                       pOriginal,
     <type>size_t</type>                                      size,
     <type>size_t</type>                                      alignment,
     <type>VkSystemAllocationScope</type>                     allocationScope);</type>
-        <type category="funcpointer">typedef void* (VKAPI_PTR *<name>PFN_vkAllocationFunction</name>)(
+        <type category="funcpointer" requires="void">typedef void* (VKAPI_PTR *<name>PFN_vkAllocationFunction</name>)(
     <type>void</type>*                                       pUserData,
     <type>size_t</type>                                      size,
     <type>size_t</type>                                      alignment,
     <type>VkSystemAllocationScope</type>                     allocationScope);</type>
-        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkFreeFunction</name>)(
+        <type category="funcpointer" requires="void">typedef void (VKAPI_PTR *<name>PFN_vkFreeFunction</name>)(
     <type>void</type>*                                       pUserData,
     <type>void</type>*                                       pMemory);</type>
 
             <comment>The PFN_vkVoidFunction type are used by VkGet*ProcAddr below</comment>
-        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkVoidFunction</name>)(void);</type>
+        <type category="funcpointer" requires="void">typedef void (VKAPI_PTR *<name>PFN_vkVoidFunction</name>)(void);</type>
 
             <comment>The PFN_vkDebugReportCallbackEXT type are used by the DEBUG_REPORT extension</comment>
-        <type category="funcpointer">typedef VkBool32 (VKAPI_PTR *<name>PFN_vkDebugReportCallbackEXT</name>)(
+        <type category="funcpointer" requires="VkBool32">typedef VkBool32 (VKAPI_PTR *<name>PFN_vkDebugReportCallbackEXT</name>)(
     <type>VkDebugReportFlagsEXT</type>                       flags,
     <type>VkDebugReportObjectTypeEXT</type>                  objectType,
     <type>uint64_t</type>                                    object,
@@ -1070,20 +1070,20 @@ typedef void* <name>MTLSharedEvent_id</name>;
     <type>void</type>*                                       pUserData);</type>
 
             <comment>The PFN_vkDebugUtilsMessengerCallbackEXT type are used by the VK_EXT_debug_utils extension</comment>
-        <type category="funcpointer" requires="VkDebugUtilsMessengerCallbackDataEXT">typedef VkBool32 (VKAPI_PTR *<name>PFN_vkDebugUtilsMessengerCallbackEXT</name>)(
+        <type category="funcpointer" requires="VkBool32">typedef VkBool32 (VKAPI_PTR *<name>PFN_vkDebugUtilsMessengerCallbackEXT</name>)(
     <type>VkDebugUtilsMessageSeverityFlagBitsEXT</type>           messageSeverity,
     <type>VkDebugUtilsMessageTypeFlagsEXT</type>                  messageTypes,
     const <type>VkDebugUtilsMessengerCallbackDataEXT</type>*      pCallbackData,
     <type>void</type>*                                            pUserData);</type>
 
             <comment>The PFN_vkFaultCallbackFunction type is used by VKSC_VERSION_1_0</comment>
-        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkFaultCallbackFunction</name>)(
+        <type category="funcpointer" requires="void">typedef void (VKAPI_PTR *<name>PFN_vkFaultCallbackFunction</name>)(
     <type>VkBool32</type>                                    unrecordedFaults,
     <type>uint32_t</type>                                    faultCount,
     const <type>VkFaultData</type>*                          pFaults);</type>
 
             <comment>The PFN_vkDeviceMemoryReportCallbackEXT type is used by the VK_EXT_device_memory_report extension</comment>
-        <type category="funcpointer" requires="VkDeviceMemoryReportCallbackDataEXT">typedef void (VKAPI_PTR *<name>PFN_vkDeviceMemoryReportCallbackEXT</name>)(
+        <type category="funcpointer" requires="void">typedef void (VKAPI_PTR *<name>PFN_vkDeviceMemoryReportCallbackEXT</name>)(
     const <type>VkDeviceMemoryReportCallbackDataEXT</type>*  pCallbackData,
     <type>void</type>*                                       pUserData);</type>
 
@@ -1093,7 +1093,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                      equivalent PFN_vkGetInstanceProcAddr type, even though
                      it is implicitly generated in the C header, because
                      that results in multiple definitions.</comment>
-        <type category="funcpointer" requires="VkInstance">typedef PFN_vkVoidFunction (VKAPI_PTR *<name>PFN_vkGetInstanceProcAddrLUNARG</name>)(
+        <type category="funcpointer" requires="PFN_vkVoidFunction">typedef PFN_vkVoidFunction (VKAPI_PTR *<name>PFN_vkGetInstanceProcAddrLUNARG</name>)(
     <type>VkInstance</type> instance, const <type>char</type>* pName);</type>
 
             <comment>Struct types</comment>


### PR DESCRIPTION
# Proposal: Explicit return types for funcpointers

Currently, it is not possible to fully analyze function pointer signatures in the Vulkan XML in a purely static way.
While the function arguments and the function name are accessible, the return type is not.
This makes it difficult to parse function pointers reliably in generators and analysis tools.
Additionally, the missing return type makes it very hard to construct a proper topological order of type dependencies, since the dependency chain cannot be resolved statically.

## Suggested change
The `requires` attribute of the `<type>` element could be used to store the return type explicitly.
At the moment, the `requires` attribute is only used for redundant information that can already be derived from the function arguments.
Using it consistently for return types instead would remove this redundancy and make the return type available in a static, machine-readable way.

For example:

```xml
<type category="funcpointer" requires="VkBool32">typedef VkBool32 (VKAPI_PTR *<name>PFN_vkDebugUtilsMessengerCallbackEXT</name>)(
    <type>VkDebugUtilsMessageSeverityFlagBitsEXT</type>           messageSeverity,
    <type>VkDebugUtilsMessageTypeFlagsEXT</type>                  messageTypes,
    const <type>VkDebugUtilsMessengerCallbackDataEXT</type>*      pCallbackData,
    <type>void</type>*                                            pUserData);
</type>
```
With this change, the return type, arguments, and function name can all be determined statically and unambiguously.
It would also make it possible to construct a correct topological ordering of all types.

## Alternative option
If using `requires` for return types is considered semantically unclear, a dedicated `returns` attribute could be introduced to make the intent explicit (at the cost of a schema extension).

## Summary
- Problem: Return types of funcpointers cannot currently be determined statically
- Proposal: Use `requires` to specify the return type explicitly
- Alternative: Introduce a new `returns` attribute for stronger semantic clarity
