### PR TITLE
Fix mention of "C++" in "API Registry"

### DIFF
--- a/registry.adoc
+++ b/registry.adoc
@@ -2786,7 +2786,7 @@ tag:type is:
 --------------------------------------
 
 In this case, the type `VkInstance` is defined by a special compile time
-macro which defines it as a derived class of `VkObject` (for `C```) or a
+macro which defines it as a derived class of `VkObject` (for C++) or a
 less typesafe definition (for C).
 This macro is not part of the type dependency analysis, just the boilerplate
 used in the header.


### PR DESCRIPTION
It renders as such at [`https://registry.khronos.org/vulkan/specs/latest/registry.html`](https://registry.khronos.org/vulkan/specs/latest/registry.html):

<img width="1346" height="124" alt="image" src="https://github.com/user-attachments/assets/0a1a9166-257f-4f08-9452-e617df778b87" />

---

I have traced the change to commit https://github.com/KhronosGroup/Vulkan-Docs/commit/fd0e4c3b67dd07877eae97965e863f2945104d9e. Looking at the [diff](https://github.com/KhronosGroup/Vulkan-Docs/commit/fd0e4c3b67dd07877eae97965e863f2945104d9e.diff), it seems that some "+" characters were mistakenly changed to "`":

<img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/bf923ea1-0599-43c0-9b23-ad02ecde6336" />
