### PR TITLE
Modify genRef.py to respect the 'type' attribute for 'consts' instead of

### DIFF
--- a/antora/refpages/modules/refpages/nav.adoc
+++ b/antora/refpages/modules/refpages/nav.adoc
@@ -1329,7 +1329,6 @@
 ** O
 *** xref:source/VkOffset2D.adoc[VkOffset2D]
 *** xref:source/VkOffset3D.adoc[VkOffset3D]
-*** xref:source/VkOHSurfaceCreateInfoOHOS.adoc[VkOHSurfaceCreateInfoOHOS]
 *** xref:source/VkOpaqueCaptureDescriptorDataCreateInfoEXT.adoc[VkOpaqueCaptureDescriptorDataCreateInfoEXT]
 *** xref:source/VkOpticalFlowExecuteInfoNV.adoc[VkOpticalFlowExecuteInfoNV]
 *** xref:source/VkOpticalFlowImageFormatInfoNV.adoc[VkOpticalFlowImageFormatInfoNV]
@@ -2050,7 +2049,7 @@
 *** xref:source/VkSurfaceCapabilitiesPresentBarrierNV.adoc[VkSurfaceCapabilitiesPresentBarrierNV]
 *** xref:source/VkSurfaceCapabilitiesPresentId2KHR.adoc[VkSurfaceCapabilitiesPresentId2KHR]
 *** xref:source/VkSurfaceCapabilitiesPresentWait2KHR.adoc[VkSurfaceCapabilitiesPresentWait2KHR]
-*** xref:source/VkOHSurfaceCreateInfoOHOS.adoc[VkSurfaceCreateInfoOHOS]
+*** xref:source/VkSurfaceCreateInfoOHOS.adoc[VkSurfaceCreateInfoOHOS]
 *** xref:source/VkSurfaceFormat2KHR.adoc[VkSurfaceFormat2KHR]
 *** xref:source/VkSurfaceFormatKHR.adoc[VkSurfaceFormatKHR]
 *** xref:source/VkSurfaceFullScreenExclusiveInfoEXT.adoc[VkSurfaceFullScreenExclusiveInfoEXT]
@@ -2258,7 +2257,6 @@
 *** xref:source/VkAttachmentDescriptionFlagBits.adoc[VkAttachmentDescriptionFlagBits]
 *** xref:source/VkAttachmentLoadOp.adoc[VkAttachmentLoadOp]
 *** xref:source/VkAttachmentStoreOp.adoc[VkAttachmentStoreOp]
-*** xref:source/VK_ATTACHMENT_UNUSED.adoc[VK_ATTACHMENT_UNUSED]
 ** B
 *** xref:source/VkBlendFactor.adoc[VkBlendFactor]
 *** xref:source/VkBlendOp.adoc[VkBlendOp]
@@ -2357,7 +2355,6 @@
 *** xref:source/VkExternalSemaphoreFeatureFlagBits.adoc[VkExternalSemaphoreFeatureFlagBits]
 *** xref:source/VkExternalSemaphoreHandleTypeFlagBits.adoc[VkExternalSemaphoreHandleTypeFlagBits]
 ** F
-*** xref:source/VK_FALSE.adoc[VK_FALSE]
 *** xref:source/VkFenceCreateFlagBits.adoc[VkFenceCreateFlagBits]
 *** xref:source/VkFenceImportFlagBits.adoc[VkFenceImportFlagBits]
 *** xref:source/VkFilter.adoc[VkFilter]
@@ -2412,25 +2409,8 @@
 *** xref:source/VkLineRasterizationMode.adoc[VkLineRasterizationMode]
 *** xref:source/VkLineRasterizationMode.adoc[VkLineRasterizationModeEXT]
 *** xref:source/VkLineRasterizationMode.adoc[VkLineRasterizationModeKHR]
-*** xref:source/VK_LOD_CLAMP_NONE.adoc[VK_LOD_CLAMP_NONE]
 *** xref:source/VkLogicOp.adoc[VkLogicOp]
-*** xref:source/VK_LUID_SIZE.adoc[VK_LUID_SIZE]
-*** xref:source/VK_LUID_SIZE.adoc[VK_LUID_SIZE_KHR]
 ** M
-*** xref:source/VK_MAX_DESCRIPTION_SIZE.adoc[VK_MAX_DESCRIPTION_SIZE]
-*** xref:source/VK_MAX_DEVICE_GROUP_SIZE.adoc[VK_MAX_DEVICE_GROUP_SIZE]
-*** xref:source/VK_MAX_DEVICE_GROUP_SIZE.adoc[VK_MAX_DEVICE_GROUP_SIZE_KHR]
-*** xref:source/VK_MAX_DRIVER_INFO_SIZE.adoc[VK_MAX_DRIVER_INFO_SIZE]
-*** xref:source/VK_MAX_DRIVER_INFO_SIZE.adoc[VK_MAX_DRIVER_INFO_SIZE_KHR]
-*** xref:source/VK_MAX_DRIVER_NAME_SIZE.adoc[VK_MAX_DRIVER_NAME_SIZE]
-*** xref:source/VK_MAX_DRIVER_NAME_SIZE.adoc[VK_MAX_DRIVER_NAME_SIZE_KHR]
-*** xref:source/VK_MAX_EXTENSION_NAME_SIZE.adoc[VK_MAX_EXTENSION_NAME_SIZE]
-*** xref:source/VK_MAX_GLOBAL_PRIORITY_SIZE.adoc[VK_MAX_GLOBAL_PRIORITY_SIZE]
-*** xref:source/VK_MAX_MEMORY_HEAPS.adoc[VK_MAX_MEMORY_HEAPS]
-*** xref:source/VK_MAX_MEMORY_TYPES.adoc[VK_MAX_MEMORY_TYPES]
-*** xref:source/VK_MAX_PHYSICAL_DEVICE_NAME_SIZE.adoc[VK_MAX_PHYSICAL_DEVICE_NAME_SIZE]
-*** xref:source/VK_MAX_PIPELINE_BINARY_KEY_SIZE_KHR.adoc[VK_MAX_PIPELINE_BINARY_KEY_SIZE_KHR]
-*** xref:source/VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT.adoc[VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT]
 *** xref:source/VkMemoryAllocateFlagBits.adoc[VkMemoryAllocateFlagBits]
 *** xref:source/VkMemoryDecompressionMethodFlagBitsNV.adoc[VkMemoryDecompressionMethodFlagBitsNV]
 *** xref:source/VkMemoryHeapFlagBits.adoc[VkMemoryHeapFlagBits]
@@ -2511,10 +2491,6 @@
 *** xref:source/VkQueueGlobalPriority.adoc[VkQueueGlobalPriority]
 *** xref:source/VkQueueGlobalPriority.adoc[VkQueueGlobalPriorityEXT]
 *** xref:source/VkQueueGlobalPriority.adoc[VkQueueGlobalPriorityKHR]
-*** xref:source/VK_QUEUE_FAMILY_EXTERNAL.adoc[VK_QUEUE_FAMILY_EXTERNAL]
-*** xref:source/VK_QUEUE_FAMILY_EXTERNAL.adoc[VK_QUEUE_FAMILY_EXTERNAL_KHR]
-*** xref:source/VK_QUEUE_FAMILY_FOREIGN_EXT.adoc[VK_QUEUE_FAMILY_FOREIGN_EXT]
-*** xref:source/VK_QUEUE_FAMILY_IGNORED.adoc[VK_QUEUE_FAMILY_IGNORED]
 ** R
 *** xref:source/VkRasterizationOrderAMD.adoc[VkRasterizationOrderAMD]
 *** xref:source/VkRayTracingInvocationReorderModeNV.adoc[VkRayTracingInvocationReorderModeNV]
@@ -2522,9 +2498,6 @@
 *** xref:source/VkRayTracingLssPrimitiveEndCapsModeNV.adoc[VkRayTracingLssPrimitiveEndCapsModeNV]
 *** xref:source/VkRayTracingShaderGroupTypeKHR.adoc[VkRayTracingShaderGroupTypeKHR]
 *** xref:source/VkRayTracingShaderGroupTypeKHR.adoc[VkRayTracingShaderGroupTypeNV]
-*** xref:source/VK_REMAINING_3D_SLICES_EXT.adoc[VK_REMAINING_3D_SLICES_EXT]
-*** xref:source/VK_REMAINING_ARRAY_LAYERS.adoc[VK_REMAINING_ARRAY_LAYERS]
-*** xref:source/VK_REMAINING_MIP_LEVELS.adoc[VK_REMAINING_MIP_LEVELS]
 *** xref:source/VkRenderingFlagBits.adoc[VkRenderingFlagBits]
 *** xref:source/VkRenderingFlagBits.adoc[VkRenderingFlagBitsKHR]
 *** xref:source/VkRenderPassCreateFlagBits.adoc[VkRenderPassCreateFlagBits]
@@ -2554,9 +2527,6 @@
 *** xref:source/VkShaderGroupShaderKHR.adoc[VkShaderGroupShaderKHR]
 *** xref:source/VkShaderInfoTypeAMD.adoc[VkShaderInfoTypeAMD]
 *** xref:source/VkShaderStageFlagBits.adoc[VkShaderStageFlagBits]
-*** xref:source/VK_SHADER_INDEX_UNUSED_AMDX.adoc[VK_SHADER_INDEX_UNUSED_AMDX]
-*** xref:source/VK_SHADER_UNUSED_KHR.adoc[VK_SHADER_UNUSED_KHR]
-*** xref:source/VK_SHADER_UNUSED_KHR.adoc[VK_SHADER_UNUSED_NV]
 *** xref:source/VkShadingRatePaletteEntryNV.adoc[VkShadingRatePaletteEntryNV]
 *** xref:source/VkSharingMode.adoc[VkSharingMode]
 *** xref:source/VkSparseImageFormatFlagBits.adoc[VkSparseImageFormatFlagBits]
@@ -2570,7 +2540,6 @@
 *** xref:source/VkSubpassContents.adoc[VkSubpassContents]
 *** xref:source/VkSubpassDescriptionFlagBits.adoc[VkSubpassDescriptionFlagBits]
 *** xref:source/VkSubpassMergeStatusEXT.adoc[VkSubpassMergeStatusEXT]
-*** xref:source/VK_SUBPASS_EXTERNAL.adoc[VK_SUBPASS_EXTERNAL]
 *** xref:source/VkSurfaceCounterFlagBitsEXT.adoc[VkSurfaceCounterFlagBitsEXT]
 *** xref:source/VkSurfaceTransformFlagBitsKHR.adoc[VkSurfaceTransformFlagBitsKHR]
 *** xref:source/VkSwapchainCreateFlagBitsKHR.adoc[VkSwapchainCreateFlagBitsKHR]
@@ -2586,9 +2555,6 @@
 *** xref:source/VkTimeDomainKHR.adoc[VkTimeDomainKHR]
 *** xref:source/VkToolPurposeFlagBits.adoc[VkToolPurposeFlagBits]
 *** xref:source/VkToolPurposeFlagBits.adoc[VkToolPurposeFlagBitsEXT]
-*** xref:source/VK_TRUE.adoc[VK_TRUE]
-** U
-*** xref:source/VK_UUID_SIZE.adoc[VK_UUID_SIZE]
 ** V
 *** xref:source/VkValidationCacheHeaderVersionEXT.adoc[VkValidationCacheHeaderVersionEXT]
 *** xref:source/VkValidationCheckEXT.adoc[VkValidationCheckEXT]
@@ -2629,8 +2595,6 @@
 *** xref:source/VkVideoSessionCreateFlagBitsKHR.adoc[VkVideoSessionCreateFlagBitsKHR]
 *** xref:source/VkVideoSessionParametersCreateFlagBitsKHR.adoc[VkVideoSessionParametersCreateFlagBitsKHR]
 *** xref:source/VkViewportCoordinateSwizzleNV.adoc[VkViewportCoordinateSwizzleNV]
-** W
-*** xref:source/VK_WHOLE_SIZE.adoc[VK_WHOLE_SIZE]
 
 [[flags]]
 * Flags
@@ -3003,6 +2967,49 @@
 
 [[consts]]
 * Constants
+** A
+*** xref:source/VK_ATTACHMENT_UNUSED.adoc[VK_ATTACHMENT_UNUSED]
+** F
+*** xref:source/VK_FALSE.adoc[VK_FALSE]
+** L
+*** xref:source/VK_LOD_CLAMP_NONE.adoc[VK_LOD_CLAMP_NONE]
+*** xref:source/VK_LUID_SIZE.adoc[VK_LUID_SIZE]
+*** xref:source/VK_LUID_SIZE.adoc[VK_LUID_SIZE_KHR]
+** M
+*** xref:source/VK_MAX_DESCRIPTION_SIZE.adoc[VK_MAX_DESCRIPTION_SIZE]
+*** xref:source/VK_MAX_DEVICE_GROUP_SIZE.adoc[VK_MAX_DEVICE_GROUP_SIZE]
+*** xref:source/VK_MAX_DEVICE_GROUP_SIZE.adoc[VK_MAX_DEVICE_GROUP_SIZE_KHR]
+*** xref:source/VK_MAX_DRIVER_INFO_SIZE.adoc[VK_MAX_DRIVER_INFO_SIZE]
+*** xref:source/VK_MAX_DRIVER_INFO_SIZE.adoc[VK_MAX_DRIVER_INFO_SIZE_KHR]
+*** xref:source/VK_MAX_DRIVER_NAME_SIZE.adoc[VK_MAX_DRIVER_NAME_SIZE]
+*** xref:source/VK_MAX_DRIVER_NAME_SIZE.adoc[VK_MAX_DRIVER_NAME_SIZE_KHR]
+*** xref:source/VK_MAX_EXTENSION_NAME_SIZE.adoc[VK_MAX_EXTENSION_NAME_SIZE]
+*** xref:source/VK_MAX_GLOBAL_PRIORITY_SIZE.adoc[VK_MAX_GLOBAL_PRIORITY_SIZE]
+*** xref:source/VK_MAX_MEMORY_HEAPS.adoc[VK_MAX_MEMORY_HEAPS]
+*** xref:source/VK_MAX_MEMORY_TYPES.adoc[VK_MAX_MEMORY_TYPES]
+*** xref:source/VK_MAX_PHYSICAL_DEVICE_NAME_SIZE.adoc[VK_MAX_PHYSICAL_DEVICE_NAME_SIZE]
+*** xref:source/VK_MAX_PIPELINE_BINARY_KEY_SIZE_KHR.adoc[VK_MAX_PIPELINE_BINARY_KEY_SIZE_KHR]
+*** xref:source/VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT.adoc[VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT]
+** Q
+*** xref:source/VK_QUEUE_FAMILY_EXTERNAL.adoc[VK_QUEUE_FAMILY_EXTERNAL]
+*** xref:source/VK_QUEUE_FAMILY_EXTERNAL.adoc[VK_QUEUE_FAMILY_EXTERNAL_KHR]
+*** xref:source/VK_QUEUE_FAMILY_FOREIGN_EXT.adoc[VK_QUEUE_FAMILY_FOREIGN_EXT]
+*** xref:source/VK_QUEUE_FAMILY_IGNORED.adoc[VK_QUEUE_FAMILY_IGNORED]
+** R
+*** xref:source/VK_REMAINING_3D_SLICES_EXT.adoc[VK_REMAINING_3D_SLICES_EXT]
+*** xref:source/VK_REMAINING_ARRAY_LAYERS.adoc[VK_REMAINING_ARRAY_LAYERS]
+*** xref:source/VK_REMAINING_MIP_LEVELS.adoc[VK_REMAINING_MIP_LEVELS]
+** S
+*** xref:source/VK_SHADER_INDEX_UNUSED_AMDX.adoc[VK_SHADER_INDEX_UNUSED_AMDX]
+*** xref:source/VK_SHADER_UNUSED_KHR.adoc[VK_SHADER_UNUSED_KHR]
+*** xref:source/VK_SHADER_UNUSED_KHR.adoc[VK_SHADER_UNUSED_NV]
+*** xref:source/VK_SUBPASS_EXTERNAL.adoc[VK_SUBPASS_EXTERNAL]
+** T
+*** xref:source/VK_TRUE.adoc[VK_TRUE]
+** U
+*** xref:source/VK_UUID_SIZE.adoc[VK_UUID_SIZE]
+** W
+*** xref:source/VK_WHOLE_SIZE.adoc[VK_WHOLE_SIZE]
 
 [[defines]]
 * C Macro Definitions

--- a/scripts/reflib.py
+++ b/scripts/reflib.py
@@ -571,7 +571,6 @@ def findRefs(file, filename):
                     if pi.type and not compatiblePageTypes(refpage_type, pi.type):
                         logWarn(f'ERROR: refpageMap[{name}] type:',
                                 pi.type, 'does not match type:', refpage_type)
-                    pi.type = refpage_type
                     pi.validity = line
                     logDiag(f'added TYPE = {pi.type} VALIDITY = {pi.validity}')
                 else:
@@ -588,7 +587,6 @@ def findRefs(file, filename):
                     if pi.type and not compatiblePageTypes(refpage_type, pi.type):
                         logWarn(f'ERROR: refpageMap[{name}] type:',
                                 pi.type, 'does not match type:', refpage_type)
-                    pi.type = refpage_type
                     pi.include = line
                     logDiag(f'added TYPE = {pi.type} INCLUDE = {pi.include}')
                 else:


### PR DESCRIPTION
rewriting it to 'enums' so it matches the API / validity includes.

This has the sole effect of altering the nav.adoc generated for Antora to populate the 'Consts' section of navigation with compile-time constants, which were previously in the 'Enumerants' section.

Fixes https://github.com/KhronosGroup/Vulkan-Site/issues/133