### PR TITLE
Fix spelling of its in VkSubpassDescription

### DIFF
--- a/chapters/commonvalidity/subpass_description_common.adoc
+++ b/chapters/commonvalidity/subpass_description_common.adoc
@@ -21,7 +21,7 @@
     ename:VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
   * [[VUID-{refpage}-attachment-06915]]
     If the pname:attachment member of pname:pDepthStencilAttachment is not
-    ename:VK_ATTACHMENT_UNUSED, ts pname:layout member must: not be
+    ename:VK_ATTACHMENT_UNUSED, its pname:layout member must: not be
     ename:VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL or
     ename:VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
 ifdef::VK_VERSION_1_1,VK_KHR_maintenance2[]


### PR DESCRIPTION
An 'i' seems to be missing.
I'm not sure if this is the only occurrence of this particular spelling mistake.

> * VUID-VkSubpassDescription-attachment-06915
> If the attachment member of pDepthStencilAttachment is not VK_ATTACHMENT_UNUSED, **ts** layout member must not be VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL or VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL