### PR TITLE
Clean up `VK_QCOM_tile_shading.adoc` proposal

### DIFF
--- a/proposals/VK_QCOM_tile_shading.adoc
+++ b/proposals/VK_QCOM_tile_shading.adoc
@@ -13,7 +13,7 @@ This document proposes a new extension that adds "tile shading" to Vulkan.
 
 ## Problem Statement
 
-Rendering pipelines that interleave compute with graphics, have become
+Rendering pipelines that interleave compute with graphics have become
 increasingly common.
 Tile-based lighting techniques are commonly used in Forward+ and Tile
 Deferred renderers leverage compute shaders to optimize the subsequent
@@ -94,15 +94,15 @@ that can be supported with dynamic render passes.
 Tile shading extends Vulkan render passes with new functionality. When tile shading is
 enabled for a render pass instance, these are the highlights of the new functionality:
 
-  * Fragment shaders can declare link:{docs}chapters/renderpass.html#renderpass-tile-shading-attachment-access.html[tile image attachment]
+  * Fragment shaders can declare link:{docs}chapters/renderpass.html#renderpass-tile-shading-attachment-access[tile image attachment]
     resources allowing fragment shader invocations to load pixel values of other fragments
     within the same tile, or to sample from the pixels in a tile attachment.
   * Fragment shaders can use <<spirv-changes,built-in input variables>> that describe the
     active tile's extent in framebuffer coordinates.
-  * link:{docs}chapters/renderpass.html#renderpass-tile-shading-aprons.html[Tile aprons] can be enabled and pixels in the apron
+  * link:{docs}chapters/renderpass.html#renderpass-tile-shading-aprons[Tile aprons] can be enabled and pixels in the apron
     region can be accessed by the fragment shader.
   * A new state command is added that enables/disables
-    link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model.html[per-tile execution model].
+    link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model[per-tile execution model].
     When this execution model is enabled:
   ** `VkCmdDispatch*` commands can be recorded in a render pass instance.
   ** Recorded draw and dispatch commands will be invoked multiple times; each recorded
@@ -110,11 +110,11 @@ enabled for a render pass instance, these are the highlights of the new function
      extent is exposed in the shader via <<spirv-changes,built-in input variables>>
      and in the API via `VK_QCOM_tile_properties`.
   ** Compute shaders have all the same functionality described above for fragment shaders.
-     This includes load/store/sample of link:{docs}chapters/renderpass.html#renderpass-tile-shading-attachment-access.html[tile image attachments],
-     <<spirv-changes,built-in input variables>>, and link:{docs}chapters/renderpass.html#renderpass-tile-shading-aprons.html[tile aprons].
+     This includes load/store/sample of link:{docs}chapters/renderpass.html#renderpass-tile-shading-attachment-access[tile image attachments],
+     <<spirv-changes,built-in input variables>>, and link:{docs}chapters/renderpass.html#renderpass-tile-shading-aprons[tile aprons].
 
 Vulkan tile shading will empower applications to leverage tile memory by injecting
-per-tile commands into GPU's existing TBDR geometry pipeline, allowing compute to
+per-tile commands into the GPU's existing TBDR geometry pipeline, allowing compute to
 participate fully in render passes, and enabling operations
 that happen while the color and depth values reside in tile memory.
 
@@ -144,19 +144,19 @@ typedef struct VkRenderPassTileShadingCreateInfoQCOM {
 ----
 
 `tileApronSize` specifies the width and height of the
-link:{docs}chapters/renderpass.html#renderpass-tile-shading-aprons.html[ tile apron].
+link:{docs}chapters/renderpass.html#renderpass-tile-shading-aprons[tile apron].
 If tile apron is not used, this should be set to 0.
 
 When tile shading is enabled for a render pass, the following
 features become available to shaders within that render pass:
   * Compute shaders can declare the `TileShadingQCOM` capability.
-  * Fragment shaders shaders can declare the `TileShadingQCOM` capability if the
+  * Fragment shaders can declare the `TileShadingQCOM` capability if the
     `tileShadingFragmentStage` feature is enabled.
 
 ### Per-tile execution mode
 
-Within a render pass that link:{docs}chapters/renderpass.html#renderpass-tile-shading.html[enables tile shading],
-the link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model.html[per-tile execution mode]
+Within a render pass that link:{docs}chapters/renderpass.html#renderpass-tile-shading[enables tile shading],
+the link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model[per-tile execution mode]
 can be enabled or disabled:
 
 [source,c]
@@ -176,7 +176,7 @@ void vkCmdBeginPerTileExecutionQCOM(
     const VkPerTileBeginInfoQCOM* pPerTileBeginInfo);
 
 void vkCmdEndPerTileExecutionQCOM(
-    VkCommandBuffer               commandBuffer);
+    VkCommandBuffer               commandBuffer,
     const VkPerTileEndInfoQCOM*   pPerTileEndInfo);
 ----
 
@@ -192,14 +192,14 @@ tiles are processed and the ordering of commands across tiles is undefined.
 When _per-tile execution mode_ is enabled, and if the `tileShadingPerTileDispatch`
 feature is enabled, `VkCmdDispatch*` commands can be recorded inside a render pass.
 These per-tile dispatches can use the functionality described in
-<<spirv-changes, SPIRV changes>>.
+<<spirv-changes, SPIR-V changes>>.
 
 When _per-tile execution mode_ is enabled, the
-link:{docs}chapters/renderpass.html#renderpass-tile-shading-command-restrictions.html[Per-Tile Command Restrictions] apply.
+link:{docs}chapters/renderpass.html#renderpass-tile-shading-command-restrictions[Per-Tile Command Restrictions] apply.
 
 ### Secondary Command Buffers
 
-When executing secondary command buffers in a render pass with tile shading enabled a
+When executing secondary command buffers in a render pass with tile shading enabled, a
 VkRenderPassTileShadingInfoQCOM must have been supplied when recording the secondary command
 buffer in VkCommandBufferInheritanceInfo.
 
@@ -221,7 +221,7 @@ Tile attachment variables are further subdivided into "storage tile
 attachment" and "sampled tile attachment" variables. The former supports
 load/store operations and is backed by a descriptor of
 type `VK_DESCRIPTOR_TYPE_STORAGE_IMAGE`, while the latter supports sampling
-and is backed by a descriptor of type `VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE`
+and is backed by a descriptor of type `VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE`.
 
 Existing features and format restrictions for storage images and sampled images
 also apply when accessing a storage tile attachment or sampled tile attachment. For
@@ -247,7 +247,7 @@ operations are described in the <<spirv-changes,SPIR-V Changes>>.
 
 ### Per-Tile Command Restrictions
 
-When link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model.html[per-tile execution mode]
+When link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model[per-tile execution mode]
 is enabled within a render pass instance, the set of commands that can
 be recorded is largely unchanged. This section documents several exceptions.
 Due to the continuously evolving API, this may not be a complete list of exceptions.
@@ -258,14 +258,14 @@ Where _per-tile execution model_ is enabled the following are disallowed:
   * Transform feedback commands are not allowed:  `vkCmdBeginTransformFeedbackEXT`,
    `vkCmdEndTransformFeedbackEXT`.
   * Query commands are not allowed: `vkCmdBeginQueryIndexedEXT`, `vkCmdEndQueryIndexedEXT`,
-   `vkCmdBeginQuery`, `vkCmdWriteTimestamp',
+   `vkCmdBeginQuery`, `vkCmdWriteTimestamp`,
    `vkCmdEndQuery`, `vkCmdDebugMarkerBeginEXT`, `vkCmdDebugMarkerEndEXT`,
     `vkCmdDebugMarkerInsertEXT`.
   * Some synchronization commands are not allowed:   `vkCmdWaitEvents2`, `vkCmdWaitEvents`.
   * The following action command is not allowed: `vkCmdClearAttachments`
   * Access of an attachment with layout `VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL`
     as provided by link:{extensions}VK_EXT_attachment_feedback_loop_layout[VK_EXT_attachment_feedback_loop_layout].
-  * Any commands that would cause a invocations of the tessellation, geometry, ray tracing,
+  * Any commands that would cause an invocation of the tessellation, geometry, ray tracing,
     or mesh shading shader stages.
 
 Other tile shading restrictions:
@@ -281,7 +281,7 @@ Other tile shading restrictions:
 
 ### Tile Apron
 
-In a render pass that enables tile shading, a _tile apron_ be enabled by setting
+In a render pass that enables tile shading, a _tile apron_ can be enabled by setting
 `tileApronSize` to a value other than (0,0). Subpass must be specified with flags
 that include `VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM` or the apron
 size will be (0,0) for that subpass, and apps must not access values outside the tile.
@@ -289,11 +289,11 @@ The tile apron enables shader invocations to load from tile attachment variables
 location that is outside the current tile. The (width,height) value of `tileApronSize`
 specifies the number of pixels in the horizontal and vertical directions that are
 included in the apron region. For example, (1,1) means that the apron region extends
-the top, bottom, left and right margins of the tile by 1 pixel. The `tileApronSize`
+the top, bottom, left, and right margins of the tile by 1 pixel. The `tileApronSize`
 must not exceed `VkPhysicalDeviceTileShadingPropertiesQCOM::maxApronSize`.
 
 The tile apron feature is expected to be important for image-based algorithms that require
-access to a single pixel and the neighborhood of pixels around it. These included image
+access to a single pixel and the neighborhood of pixels around it. These include image
 processing use cases such as convolution image processing and gaming use cases such as
 screen-space ambient occlusion (SSAO).
 A good mental model for the tile apron is to think of it as enabling "overlapping
@@ -335,7 +335,7 @@ void vkCmdDispatchTileQCOM(
 ----
 
 This command operates in the
-link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model.html[per-tile execution model],
+link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model[per-tile execution model],
 invoking a separate dispatch for each _covered tile_.
 The global workgroup count and local workgroup size of each dispatch are defined by the
 implementation to efficiently iterate over a uniform grid of pixel blocks within
@@ -379,7 +379,7 @@ NonCoherentTileAttachmentReadQCOM   Disables raster order guarantee. Fragment on
 
 ----
 
-link:{docs}chapters/renderpass.html#renderpass-tile-shading-attachment-access.html[Tile attachment] variables are declared
+link:{docs}chapters/renderpass.html#renderpass-tile-shading-attachment-access[Tile attachment] variables are declared
 as  `OpTypeImage` variables with storage class `TileAttachmentQCOM`.
 Such variables can be used to perform tile read/write operations, tile sampling
 operations, or tile atomic operations.
@@ -403,7 +403,7 @@ type `VK_DESCRIPTOR_TYPE_STORAGE_IMAGE`, `VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE`,
 that is equivalent to the `VkImageView` specified as an attachment in the current
 render pass instance.
 
-Other restrictions, such the valid shader stages, formats, and image coordinates
+Other restrictions, such as the valid shader stages, formats, and image coordinates
 for access to these tile image variables are specified by Vulkan SPIR-V environment.
 
 The extension adds the optional execution mode `NonCoherentTileAttachmentReadQCOM`.
@@ -436,7 +436,7 @@ The Vulkan SPIR-V environment will specify that:
   * A fragment shader must not use stores for tile color, tile input, or tile depth/stencil attachments.
   * A fragment or compute shader can use loads (`OpImageRead`, `OpImageSparseRead`) for tile color, tile depth/stencil,
     or tile input attachments.
-  * If the link:{docs}chapters/renderpass.html#renderpass-tile-shading-aprons.html[tile apron] has width or height greater than zero, then loads
+  * If the link:{docs}chapters/renderpass.html#renderpass-tile-shading-aprons[tile apron] has width or height greater than zero, then loads
     and sampling of apron pixels (outside the tile, but within
     the apron) are allowed. Stores to apron pixels are disallowed. If not executing in a dynamic render pass,
     the subpass flags must include `VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM`.
@@ -446,7 +446,7 @@ The Vulkan SPIR-V environment will specify that:
 
 ### High Level Language Exposure
 
-The GLSL extension GL_QCOM_tile_shading will adds the following types, storage qualifiers,
+The GLSL extension GL_QCOM_tile_shading will add the following types, storage qualifiers,
 layout qualifiers, and built-in variables.
 [source,c]
 ----
@@ -582,7 +582,7 @@ made to pipeline barriers:
 [source,c]
 ----
    VK_ACCESS_INDIRECT_COMMAND_READ_BIT
-   VK_ACCESS_SHADER_SAMPLED_READ_BIT,
+   VK_ACCESS_SHADER_SAMPLED_READ_BIT
    VK_ACCESS_SHADER_STORAGE_READ_BIT
    VK_ACCESS_SHADER_STORAGE_WRITE_BIT
    VK_ACCESS_SHADER_TILE_ATTACHMENT_READ_BIT
@@ -635,7 +635,7 @@ A few notable features are documented below.
   * `tileShadingColorAttachments` indicates the implementation supports
     use of `OpImageRead` and `OpImageSparseRead` in the supported stages
     to access a color attachment.
-    In addition, this feature indicates support for  and `OpImageStore` and
+    In addition, this feature indicates support for `OpImageStore` and
     `OpImageSparseRead` to access a color attachment in the compute stage.
   * `tileShadingDepthAttachments` indicates the implementation supports
     use of `OpImageRead` and `OpImageSparseRead` in the supported
@@ -656,7 +656,7 @@ A few notable features are documented below.
   * `tileShadingPerTileDispatch` indicates the implementation supports
     the recording of dispatch commands inside a render pass. Note that
     dispatches inside a render pass are allowed only where
-    link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model.html[per-tile execution] is enabled.
+    link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model[per-tile execution] is enabled.
   * `tileShadingDispatchTile` indicates the implementation supports
     the `vkCmdDispatchTileQCOM` command. Note this feature requires
     `tileShadingPerTileDispatch`.
@@ -694,7 +694,7 @@ typedef struct VkPhysicalDeviceTileShadingPropertiesQCOM {
 
 ## Issues
 
-### Are all attachment types(color, depth/stencil, input, resolve) accessible via tile attachment load/store operations.
+### Are all attachment types (color, depth/stencil, input, resolve) accessible via tile attachment load/store operations?
 
 PROPOSED:  No, we propose the following restrictions for specific attachment types and shader stages:
 
@@ -706,7 +706,7 @@ There are no known use cases for tile stores to input attachments, and it seemed
 unexpected that an "input attachment" would be modified. Shader writes to
 depth/stencil attachments is unexpected and may require disablement of
 implementation-specific depth acceleration features. Resolve attachments are
-unlikely to be backed by tile memory  Within a fragment shader, stores to the
+unlikely to be backed by tile memory. Within a fragment shader, stores to the
 color attachment do not seem useful and could be difficult to synchronize with
 fragment output writes. For those reasons, the above cases are disallowed
 in this extension.
@@ -721,7 +721,7 @@ cover the current tile, then the implementation may "skip" such primitives for
 that tile.
 If a draw command contains no primitives that cover the current tile, the
 draw call may be entirely skipped for that tile.
-This is important feature for maximizing TBDR rendering efficiency.
+This is an important feature for maximizing TBDR rendering efficiency.
 
 With this extension, per-tile draws are introduced. A per-tile draw guarantees
 the draw will be executed for each tile, effectively bypassing the above
@@ -749,7 +749,7 @@ guarded by feature bit `tileShadingSampledAttachments`.
 * The resulting `OpSampledImage` variable can be used with all the texture
   `OpImageSample*`, `OpImageSparseSample*`, `OpImage*Gather`, and `OpImageSparse*Gather`
   instructions.
-* Texture coordinates for are relative to the attachment dimensions, rather than
+* Texture coordinates are relative to the attachment dimensions, rather than
 relative to the tile dimensions.
 * When sampling from a sampled tile attachment, if the texture coordinates
 are near a tile edge, or fully outside the tile, the texels participating in
@@ -790,7 +790,7 @@ implementation style.
 
 ### Does this extension support attachments with a layer count greater than 1?
 
-PROPOSED: Yes, this is supported. The the existing `VK_QCOM_tile_properties`
+PROPOSED: Yes, this is supported. The existing `VK_QCOM_tile_properties`
 extension exposes support for multi-layered tiles.
 
 ### Are store operations allowed for apron pixels?
@@ -818,7 +818,7 @@ RESOLVED: No, there is no change to the behavior.
 ### Can tile attachment load/store operations be used without enabling per-tile execution?
 
 RESOLVED: Yes, if a render pass enables tile shading but not the
-link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model.html[ per-tile execution model], then
+link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model[per-tile execution model], then
 fragment shader invocations can load pixel values from tile attachment
 variables.
 
@@ -828,7 +828,7 @@ of other fragments within the tile and/or the apron region.
 
 ### Should this extension include the ability for fragment or compute shader to reinterpret the format of tile attachment pixels?
 
-RESOLVED: No, while such a feature is desirable for many TBDR GPUs and is related to
+RESOLVED: No, while such a feature is desirable for many TBDR GPUs and is related
 to this extension, but was considered beyond the scope of this extension.
 
 Use-cases such as deferred shading and deferred lighting are often implemented with multiple
@@ -842,7 +842,7 @@ used. Therefore, it may be best handled as a completely separate extension.
 
 ### Should this extension include an area-based dispatch?
 
-RESOLVED: Yes, one some Adreno (TM) GPUs and for some use cases, the tile-sized
+RESOLVED: Yes, on some Adreno (TM) GPUs and for some use cases, the tile-sized
 dispatch can improve GPU efficiency and has been incorporated into this extension.
 
 `vkCmdDispatchTileQCOM` provides a "tile-sized dispatch" where
@@ -855,7 +855,7 @@ most optimally perform load/store operations for the micro tile's pixels.
 
 RESOLVED: No. In this proposal, a created graphics pipeline can be used in a render
 pass regardless whether the render pass enables tile shading, and regardless whether
-link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model.html[per-tile execution mode] is enabled. Similarly,
+link:{docs}chapters/renderpass.html#renderpass-per-tile-execution-model[per-tile execution mode] is enabled. Similarly,
 a created compute pipelines can now be used inside or outside a render pass. We decided
 not to require these usage flags during pipeline creation because we think it would be a burden
 to developers and because we do not anticipate implementations will require this information.


### PR DESCRIPTION
- Fix a bunch of typos
- Fix broken links with erroneous `.html` in the anchor