### PR TITLE
Fix const pNext in returnedonly="true" structs

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -3723,7 +3723,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkDisplayModeStereoPropertiesNV" structextends="VkDisplayModeProperties2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_MODE_STEREO_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type>                    <name>hdmi3DSupported</name><comment>Whether this mode supports HDMI 3D stereo rendering.</comment></member>
         </type>
         <type category="struct" name="VkDisplayPlaneInfo2KHR">
@@ -4261,7 +4261,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkPhysicalDevicePresentationPropertiesANDROID" returnedonly="true" structextends="VkPhysicalDeviceProperties2" requiredlimittype="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENTATION_PROPERTIES_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member limittype="max"><type>VkBool32</type> <name>sharedImage</name></member>
         </type>
         <type category="struct" name="VkShaderResourceUsageAMD" returnedonly="true">
@@ -5358,7 +5358,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"            alias="VkPhysicalDeviceScalarBlockLayoutFeatures"/>
         <type category="struct" name="VkSurfaceProtectedCapabilitiesKHR" structextends="VkSurfaceCapabilities2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type> <name>supportsProtected</name><comment>Represents if surface can be protected</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceUniformBufferStandardLayoutFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
@@ -6863,7 +6863,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkAccelerationStructureBuildSizesInfoKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*        <name>pNext</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                       <name>accelerationStructureSize</name></member>
             <member><type>VkDeviceSize</type>                       <name>updateScratchSize</name></member>
             <member><type>VkDeviceSize</type>                       <name>buildScratchSize</name></member>
@@ -9458,7 +9458,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkOpticalFlowImageFormatPropertiesNV" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*  <name>pNext</name></member>
+            <member optional="true"><type>void</type>*  <name>pNext</name></member>
             <member><type>VkFormat</type> <name>format</name></member>
         </type>
         <type category="struct" name="VkOpticalFlowSessionCreateInfoNV">
@@ -10120,7 +10120,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkLatencyTimingsFrameReportNV" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_LATENCY_TIMINGS_FRAME_REPORT_NV"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true" noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>* <name>pNext</name></member>
             <member><type>uint64_t</type>               <name>presentID</name></member>
             <member><type>uint64_t</type>               <name>inputSampleTimeUs</name></member>
             <member><type>uint64_t</type>               <name>simStartTimeUs</name></member>
@@ -10587,7 +10587,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkTensorFormatPropertiesARM" returnedonly="true" structextends="VkFormatProperties2" requiredlimittype="true">
             <member values="VK_STRUCTURE_TYPE_TENSOR_FORMAT_PROPERTIES_ARM"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                <name>pNext</name></member>
+            <member optional="true"><type>void</type>*                <name>pNext</name></member>
             <member limittype="bitmask"><type>VkFormatFeatureFlags2</type>  <name>optimalTilingTensorFeatures</name></member>
             <member limittype="bitmask"><type>VkFormatFeatureFlags2</type>  <name>linearTilingTensorFeatures</name></member>
         </type>


### PR DESCRIPTION
Some structs marked `returnedonly="true"` declare `pNext` as `const void*`.
This is inconsistent - returned-only structs are output structs, and their `pNext` must be writable by the implementation.

This change updates these structs to use `void* pNext` for consistency with `VkBaseOutStructure`.