### PR TITLE
vkGetPipelinePropertiesEXT - remove validstructs attribute, use concrete struct type

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -17233,7 +17233,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <proto><type>VkResult</type> <name>vkGetPipelinePropertiesEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkPipelineInfoEXT</type>* <name>pPipelineInfo</name></param>
-            <param noautovalidity="true" validstructs="VkPipelinePropertiesIdentifierEXT"><type>VkBaseOutStructure</type>* <name>pPipelineProperties</name></param>
+            <param noautovalidity="true"><type>VkPipelinePropertiesIdentifierEXT</type>* <name>pPipelineProperties</name></param>
         </command>
         <command>
             <proto><type>void</type> <name>vkExportMetalObjectsEXT</name></proto>


### PR DESCRIPTION
Use `VkPipelinePropertiesIdentifierEXT*` instead of `VkBaseOutStructure*` for `pPipelineProperties` and drop the obsolete validstructs attribute.

VkPipelinePropertiesIdentifierEXT is always the required type, so this change improves clarity and makes the C API type-safe.

The `validstructs` attribute is no longer used in the current Vulkan registry.