### PR TITLE
Fix incorrect returnonly=true on VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -10542,7 +10542,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member limittype="max"><type>uint32_t</type>                         <name>maxFragmentDensityMapLayers</name></member>
         </type>
-        <type category="struct" name="VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE" returnedonly="true" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+        <type category="struct" name="VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_LAYERED_FEATURES_VALVE"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>VkBool32</type>                                         <name>fragmentDensityMapLayered</name></member>


### PR DESCRIPTION
`VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE` extends `VkDeviceCreateInfo` via `structextends`, but was incorrectly marked with `returnonly="true"`.
This would imply that the application can only query this feature but cannot enable or disable it, which is not the intended behavior.

This change removes the `returnonly="true"` attribute to allow the feature to be properly configured during device creation.