### PR TITLE
Clarify VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI structextends relation

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -6691,7 +6691,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkBool32</type> <name>clustercullingShader</name></member>
             <member><type>VkBool32</type> <name>multiviewClusterCullingShader</name></member>
         </type>
-        <type category="struct" name="VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI" structextends="VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI">
+        <type category="struct" name="VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_VRS_FEATURES_HUAWEI"><type>VkStructureType</type>  <name>sType</name></member>
             <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type> <name>clusterShadingRate</name></member>


### PR DESCRIPTION
This change updates the Vulkan XML registry to clarify the `structextends` relationship of `VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI`.

Currently, this structure extends only `VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI`. This is the only known case in the registry where a feature struct extends another feature struct, rather than `VkPhysicalDeviceFeatures2` and `VkDeviceCreateInfo` directly.

This raises several questions for clarification:

1. Intentional dependency?
Is `VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI` intended to be activatable only when `VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI` is also enabled?

2. Possible correction to `structextends`:
Should the `structextends` attribute be changed to `VkPhysicalDeviceFeatures2,VkDeviceCreateInfo`
(and remove `VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI` from `structextends`),
following the pattern used by other feature definitions?

3. Specification clarity:
The current Vulkan specification section on feature enablement (excerpt below) does not explicitly mention dependent feature relationships:
    ```
    "Features advertise additional functionality which can be enabled in the API. [...]
    Features are reported via the extensible structure VkPhysicalDeviceFeatures2, [...]
    Each extension should introduce one new feature structure, if needed.
    This structure can be added to the pNext chain of the VkPhysicalDeviceFeatures2 structure."
    ```
    Would it be helpful to add an explicit note or clarification to the specification describing whether a feature struct can depend on another feature struct being enabled, or whether such nested feature relationships are allowed at all?