### PR TITLE
Align pointer and pointer-to-pointer param/member names

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -2264,7 +2264,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <comment>WSI extensions</comment>
         <type category="struct" name="VkDisplayPropertiesKHR" returnedonly="true">
             <member><type>VkDisplayKHR</type>                     <name>display</name><comment>Handle of the display object</comment></member>
-            <member len="null-terminated">const <type>char</type>*                      <name>displayName</name><comment>Name of the display</comment></member>
+            <member len="null-terminated">const <type>char</type>*                      <name>pDisplayName</name><comment>Name of the display</comment></member>
             <member><type>VkExtent2D</type>                       <name>physicalDimensions</name><comment>In millimeters?</comment></member>
             <member><type>VkExtent2D</type>                       <name>physicalResolution</name><comment>Max resolution for CRT?</comment></member>
             <member optional="true"><type>VkSurfaceTransformFlagsKHR</type>       <name>supportedTransforms</name><comment>one or more bits from VkSurfaceTransformFlagsKHR</comment></member>
@@ -2340,20 +2340,20 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                    <name>pNext</name></member>
             <member optional="true"><type>VkAndroidSurfaceCreateFlagsKHR</type> <name>flags</name></member>
-            <member noautovalidity="true">struct <type>ANativeWindow</type>*    <name>window</name></member>
+            <member noautovalidity="true">struct <type>ANativeWindow</type>*    <name>pWindow</name></member>
         </type>
         <type category="struct" name="VkViSurfaceCreateInfoNN">
             <member values="VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkViSurfaceCreateFlagsNN</type>   <name>flags</name></member>
-            <member noautovalidity="true"><type>void</type>*                            <name>window</name></member>
+            <member noautovalidity="true"><type>void</type>*                            <name>pWindow</name></member>
         </type>
         <type category="struct" name="VkWaylandSurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkWaylandSurfaceCreateFlagsKHR</type>   <name>flags</name></member>
-            <member noautovalidity="true">struct <type>wl_display</type>*               <name>display</name></member>
-            <member noautovalidity="true">struct <type>wl_surface</type>*               <name>surface</name></member>
+            <member noautovalidity="true">struct <type>wl_display</type>*               <name>pDisplay</name></member>
+            <member noautovalidity="true">struct <type>wl_surface</type>*               <name>pSurface</name></member>
         </type>
         <type category="struct" name="VkWin32SurfaceCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -2399,8 +2399,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_SCREEN_SURFACE_CREATE_INFO_QNX"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkScreenSurfaceCreateFlagsQNX</type>    <name>flags</name></member>
-            <member noautovalidity="true">struct <type>_screen_context</type>*    <name>context</name></member>
-            <member noautovalidity="true">struct <type>_screen_window</type>*     <name>window</name></member>
+            <member noautovalidity="true">struct <type>_screen_context</type>*    <name>pContext</name></member>
+            <member noautovalidity="true">struct <type>_screen_window</type>*     <name>pWindow</name></member>
         </type>
         <type category="struct" name="VkSurfaceFormatKHR" returnedonly="true">
             <member><type>VkFormat</type>                         <name>format</name><comment>Supported pair of rendering format</comment></member>
@@ -3119,7 +3119,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_METAL_HANDLE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
-            <member optional="true"><type>void</type>*           <name>handle</name></member>
+            <member optional="true"><type>void</type>*           <name>pHandle</name></member>
         </type>
         <type category="struct" name="VkMemoryMetalHandlePropertiesEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MEMORY_METAL_HANDLE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3276,7 +3276,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member externsync="true"><type>VkFence</type>              <name>fence</name></member>
             <member><type>VkExternalFenceHandleTypeFlagBits</type>      <name>handleType</name></member>
-            <member><type>void</type>*                                  <name>handle</name></member>
+            <member><type>void</type>*                                  <name>pHandle</name></member>
         </type>
         <type category="struct" name="VkFenceGetSciSyncInfoNV">
             <member values="VK_STRUCTURE_TYPE_FENCE_GET_SCI_SYNC_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
@@ -3294,7 +3294,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member externsync="true"><type>VkSemaphore</type>          <name>semaphore</name></member>
             <member><type>VkExternalSemaphoreHandleTypeFlagBits</type>  <name>handleType</name></member>
-            <member><type>void</type>*                                  <name>handle</name></member>
+            <member><type>void</type>*                                  <name>pHandle</name></member>
         </type>
         <type category="struct" name="VkSemaphoreGetSciSyncInfoNV">
             <member values="VK_STRUCTURE_TYPE_SEMAPHORE_GET_SCI_SYNC_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
@@ -4282,7 +4282,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkNativeBufferANDROID" structextends="VkImageCreateInfo,VkBindImageMemoryInfo">
             <member values="VK_STRUCTURE_TYPE_NATIVE_BUFFER_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>* <name>pNext</name></member>
-            <member>const <type>void</type>* <name>handle</name></member>
+            <member>const <type>void</type>* <name>pHandle</name></member>
             <member><type>int</type> <name>stride</name></member>
             <member><type>int</type> <name>format</name></member>
             <member><type>int</type> <name>usage</name></member>
@@ -4700,7 +4700,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkImportAndroidHardwareBufferInfoANDROID" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
-            <member>struct <type>AHardwareBuffer</type>*            <name>buffer</name></member>
+            <member>struct <type>AHardwareBuffer</type>*            <name>pBuffer</name></member>
         </type>
         <type category="struct" name="VkAndroidHardwareBufferUsageANDROID" structextends="VkImageFormatProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
@@ -5699,7 +5699,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member selection="VK_PERFORMANCE_VALUE_TYPE_UINT64_INTEL"><type>uint64_t</type>                           <name>value64</name></member>
             <member selection="VK_PERFORMANCE_VALUE_TYPE_FLOAT_INTEL"><type>float</type>                               <name>valueFloat</name></member>
             <member selection="VK_PERFORMANCE_VALUE_TYPE_BOOL_INTEL"><type>VkBool32</type>                             <name>valueBool</name></member>
-            <member selection="VK_PERFORMANCE_VALUE_TYPE_STRING_INTEL" len="null-terminated">const <type>char</type>*  <name>valueString</name></member>
+            <member selection="VK_PERFORMANCE_VALUE_TYPE_STRING_INTEL" len="null-terminated">const <type>char</type>*  <name>pValueString</name></member>
         </type>
         <type category="struct" name="VkPerformanceValueINTEL" returnedonly="true">
             <member><type>VkPerformanceValueTypeINTEL</type>        <name>type</name></member>
@@ -6279,15 +6279,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="union" name="VkDeviceOrHostAddressKHR">
             <member noautovalidity="true"><type>VkDeviceAddress</type>            <name>deviceAddress</name></member>
-            <member noautovalidity="true"><type>void</type>*                      <name>hostAddress</name></member>
+            <member noautovalidity="true"><type>void</type>*                      <name>pHostAddress</name></member>
         </type>
         <type category="union" name="VkDeviceOrHostAddressConstKHR">
             <member noautovalidity="true"><type>VkDeviceAddress</type>            <name>deviceAddress</name></member>
-            <member noautovalidity="true">const <type>void</type>*                <name>hostAddress</name></member>
+            <member noautovalidity="true">const <type>void</type>*                <name>pHostAddress</name></member>
         </type>
         <type category="union" name="VkDeviceOrHostAddressConstAMDX">
             <member noautovalidity="true"><type>VkDeviceAddress</type>            <name>deviceAddress</name></member>
-            <member noautovalidity="true">const <type>void</type>*                <name>hostAddress</name></member>
+            <member noautovalidity="true">const <type>void</type>*                <name>pHostAddress</name></member>
         </type>
         <type category="struct" name="VkAccelerationStructureGeometryTrianglesDataKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -8489,9 +8489,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>               <name>blockDimZ</name></member>
             <member><type>uint32_t</type>               <name>sharedMemBytes</name></member>
             <member optional="true"><type>size_t</type>                 <name>paramCount</name></member>
-            <member len="paramCount">const <type>void</type>* const *    <name>pParams</name></member>
+            <member len="paramCount">const <type>void</type>* const *    <name>ppParams</name></member>
             <member optional="true"><type>size_t</type>                 <name>extraCount</name></member>
-            <member len="extraCount">const <type>void</type>* const *    <name>pExtras</name></member>
+            <member len="extraCount">const <type>void</type>* const *    <name>ppExtras</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDescriptorBufferFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -8608,7 +8608,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkOpaqueCaptureDescriptorDataCreateInfoEXT" structextends="VkBufferCreateInfo,VkImageCreateInfo,VkImageViewCreateInfo,VkSamplerCreateInfo,VkAccelerationStructureCreateInfoKHR,VkAccelerationStructureCreateInfoNV,VkTensorCreateInfoARM,VkTensorViewCreateInfoARM">
             <member values="VK_STRUCTURE_TYPE_OPAQUE_CAPTURE_DESCRIPTOR_DATA_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
-            <member>const <type>void</type>*            <name>opaqueCaptureDescriptorData</name></member>
+            <member>const <type>void</type>*            <name>pOpaqueCaptureDescriptorData</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderIntegerDotProductFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
@@ -8865,9 +8865,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>               <name>blockDimZ</name></member>
             <member><type>uint32_t</type>               <name>sharedMemBytes</name></member>
             <member optional="true"><type>size_t</type>                                     <name>paramCount</name></member>
-            <member noautovalidity="true" len="paramCount">const <type>void</type>* const * <name>pParams</name></member>
+            <member noautovalidity="true" len="paramCount">const <type>void</type>* const * <name>ppParams</name></member>
             <member optional="true"><type>size_t</type>                                     <name>extraCount</name></member>
-            <member noautovalidity="true" len="extraCount">const <type>void</type>* const * <name>pExtras</name></member>
+            <member noautovalidity="true" len="extraCount">const <type>void</type>* const * <name>ppExtras</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -9889,7 +9889,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkImportScreenBufferInfoQNX" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_SCREEN_BUFFER_INFO_QNX"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
-            <member noautovalidity="true">struct <type>_screen_buffer</type>*       <name>buffer</name></member>
+            <member noautovalidity="true">struct <type>_screen_buffer</type>*       <name>pBuffer</name></member>
         </type>
         <type category="struct" name="VkScreenBufferPropertiesQNX" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_SCREEN_BUFFER_PROPERTIES_QNX"><type>VkStructureType</type> <name>sType</name></member>
@@ -10813,7 +10813,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_SURFACE_CREATE_INFO_OHOS"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                    <name>pNext</name></member>
             <member optional="true"><type>VkSurfaceCreateFlagsOHOS</type> <name>flags</name></member>
-            <member noautovalidity="true"><type>OHNativeWindow</type>*    <name>window</name></member>
+            <member noautovalidity="true"><type>OHNativeWindow</type>*    <name>pWindow</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDataGraphFeaturesARM" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_FEATURES_ARM"><type>VkStructureType</type> <name>sType</name></member>
@@ -10980,7 +10980,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkNativeBufferOHOS" structextends="VkImageCreateInfo,VkBindImageMemoryInfo">
             <member values="VK_STRUCTURE_TYPE_NATIVE_BUFFER_OHOS"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>* <name>pNext</name></member>
-            <member>struct <type>OHBufferHandle</type>* <name>handle</name></member>
+            <member>struct <type>OHBufferHandle</type>* <name>pHandle</name></member>
         </type>
         <type category="struct" name="VkSwapchainImageCreateInfoOHOS" structextends="VkImageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_IMAGE_CREATE_INFO_OHOS"><type>VkStructureType</type> <name>sType</name></member>
@@ -11049,7 +11049,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkImportNativeBufferInfoOHOS" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_IMPORT_NATIVE_BUFFER_INFO_OHOS"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
-            <member>struct <type>OH_NativeBuffer</type>*            <name>buffer</name></member>
+            <member>struct <type>OH_NativeBuffer</type>*            <name>pBuffer</name></member>
         </type>
         <type category="struct" name="VkMemoryGetNativeBufferInfoOHOS">
             <member values="VK_STRUCTURE_TYPE_MEMORY_GET_NATIVE_BUFFER_INFO_OHOS"><type>VkStructureType</type> <name>sType</name></member>
@@ -15773,7 +15773,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <proto><type>VkResult</type> <name>vkGetMemoryAndroidHardwareBufferANDROID</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkMemoryGetAndroidHardwareBufferInfoANDROID</type>* <name>pInfo</name></param>
-            <param>struct <type>AHardwareBuffer</type>** <name>pBuffer</name></param>
+            <param>struct <type>AHardwareBuffer</type>** <name>ppBuffer</name></param>
         </command>
         <command conditionalrendering="true" export="vulkan,vulkansc" queues="VK_QUEUE_GRAPHICS_BIT" renderpass="inside" cmdbufferlevel="primary,secondary" tasks="action">
             <proto><type>void</type> <name>vkCmdDrawIndirectCount</name></proto>
@@ -17737,7 +17737,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <proto><type>VkResult</type> <name>vkGetMemoryMetalHandleEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkMemoryGetMetalHandleInfoEXT</type>* <name>pGetMetalHandleInfo</name></param>
-            <param><type>void</type>** <name>pHandle</name></param>
+            <param><type>void</type>** <name>ppHandle</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_UNKNOWN,VK_ERROR_VALIDATION_FAILED">
             <proto><type>VkResult</type> <name>vkGetMemoryMetalHandlePropertiesEXT</name></proto>
@@ -17942,21 +17942,21 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR,VK_ERROR_UNKNOWN,VK_ERROR_VALIDATION_FAILED">
             <proto><type>VkResult</type> <name>vkGetNativeBufferPropertiesOHOS</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param>const struct <type>OH_NativeBuffer</type>* <name>buffer</name></param>
+            <param>const struct <type>OH_NativeBuffer</type>* <name>pBuffer</name></param>
             <param><type>VkNativeBufferPropertiesOHOS</type>* <name>pProperties</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_UNKNOWN,VK_ERROR_VALIDATION_FAILED">
             <proto><type>VkResult</type> <name>vkGetMemoryNativeBufferOHOS</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkMemoryGetNativeBufferInfoOHOS</type>* <name>pInfo</name></param>
-            <param>struct <type>OH_NativeBuffer</type>** <name>pBuffer</name></param>
+            <param>struct <type>OH_NativeBuffer</type>** <name>ppBuffer</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_UNKNOWN,VK_ERROR_VALIDATION_FAILED">
             <proto><type>VkResult</type> <name>vkGetSwapchainGrallocUsageOHOS</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkFormat</type> <name>format</name></param>
             <param><type>VkImageUsageFlags</type> <name>imageUsage</name></param>
-            <param><type>uint64_t</type>* <name>grallocUsage</name></param>
+            <param><type>uint64_t</type>* <name>pGrallocUsage</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_UNKNOWN,VK_ERROR_VALIDATION_FAILED">
             <proto><type>VkResult</type> <name>vkAcquireImageOHOS</name></proto>


### PR DESCRIPTION
This PR updates the naming of pointer and pointer-to-pointer parameters and members to improve consistency with Vulkans naming conventions and existing API patterns. Only parameter names are changed; no metadata, types, or semantics are modified.