### PR TITLE
Extend 'len' attribute for nested pointers

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -8489,9 +8489,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>               <name>blockDimZ</name></member>
             <member><type>uint32_t</type>               <name>sharedMemBytes</name></member>
             <member optional="true"><type>size_t</type>                 <name>paramCount</name></member>
-            <member len="paramCount">const <type>void</type>* const *    <name>pParams</name></member>
+            <member len="paramCount,1">const <type>void</type>* const *    <name>pParams</name></member>
             <member optional="true"><type>size_t</type>                 <name>extraCount</name></member>
-            <member len="extraCount">const <type>void</type>* const *    <name>pExtras</name></member>
+            <member len="extraCount,1">const <type>void</type>* const *    <name>pExtras</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDescriptorBufferFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -8865,9 +8865,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>               <name>blockDimZ</name></member>
             <member><type>uint32_t</type>               <name>sharedMemBytes</name></member>
             <member optional="true"><type>size_t</type>                                     <name>paramCount</name></member>
-            <member noautovalidity="true" len="paramCount">const <type>void</type>* const * <name>pParams</name></member>
+            <member noautovalidity="true" len="paramCount,1">const <type>void</type>* const * <name>pParams</name></member>
             <member optional="true"><type>size_t</type>                                     <name>extraCount</name></member>
-            <member noautovalidity="true" len="extraCount">const <type>void</type>* const * <name>pExtras</name></member>
+            <member noautovalidity="true" len="extraCount,1">const <type>void</type>* const * <name>pExtras</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -16410,7 +16410,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param externsync="true"><type>VkCommandBuffer</type>                                    <name>commandBuffer</name></param>
             <param><type>uint32_t</type> <name>infoCount</name></param>
             <param len="infoCount">const <type>VkAccelerationStructureBuildGeometryInfoKHR</type>* <name>pInfos</name></param>
-            <param len="infoCount">const <type>VkAccelerationStructureBuildRangeInfoKHR</type>* const* <name>ppBuildRangeInfos</name></param>
+            <param len="infoCount,pInfos[].geometryCount">const <type>VkAccelerationStructureBuildRangeInfoKHR</type>* const* <name>ppBuildRangeInfos</name></param>
         </command>
         <command conditionalrendering="false" queues="VK_QUEUE_COMPUTE_BIT" renderpass="outside" cmdbufferlevel="primary,secondary" tasks="action">
             <proto><type>void</type> <name>vkCmdBuildAccelerationStructuresIndirectKHR</name></proto>
@@ -16419,7 +16419,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param len="infoCount">const <type>VkAccelerationStructureBuildGeometryInfoKHR</type>* <name>pInfos</name></param>
             <param len="infoCount">const <type>VkDeviceAddress</type>*             <name>pIndirectDeviceAddresses</name></param>
             <param len="infoCount">const <type>uint32_t</type>*                    <name>pIndirectStrides</name></param>
-            <param len="infoCount">const <type>uint32_t</type>* const*             <name>ppMaxPrimitiveCounts</name></param>
+            <param len="infoCount,pInfos[].geometryCount">const <type>uint32_t</type>* const*             <name>ppMaxPrimitiveCounts</name></param>
         </command>
         <command successcodes="VK_SUCCESS,VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_UNKNOWN,VK_ERROR_VALIDATION_FAILED">
             <proto><type>VkResult</type> <name>vkBuildAccelerationStructuresKHR</name></proto>
@@ -16427,7 +16427,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="true"><type>VkDeferredOperationKHR</type> <name>deferredOperation</name></param>
             <param><type>uint32_t</type> <name>infoCount</name></param>
             <param len="infoCount">const <type>VkAccelerationStructureBuildGeometryInfoKHR</type>* <name>pInfos</name></param>
-            <param len="infoCount">const <type>VkAccelerationStructureBuildRangeInfoKHR</type>* const* <name>ppBuildRangeInfos</name></param>
+            <param len="infoCount,pInfos[].geometryCount">const <type>VkAccelerationStructureBuildRangeInfoKHR</type>* const* <name>ppBuildRangeInfos</name></param>
         </command>
         <command>
             <proto><type>VkDeviceAddress</type> <name>vkGetAccelerationStructureDeviceAddressKHR</name></proto>


### PR DESCRIPTION
This draft PR experiments with an extended len syntax for pointer-to-pointer parameters in the KHR acceleration structure build commands.

The goal is to describe the conceptual 2D shape of these parameters more accurately:
- outer dimension: `infoCount`
- inner dimension: `pInfos[i].geometryCount`

This syntax is new for the Registry and is proposed here only as a draft for discussion.

## Proposed constraints for the new len form
The extended `len="X,Y"` form (with `Y` referencing `SomeArray[].member`) is intended to be valid only under the following conditions:
1. The referenced symbol in `Y` (e.g. `pInfos`) must be another member of the same command/struct/union.
2. That member must be a pointer type (e.g. `const VkAccelerationStructureBuildGeometryInfoKHR* pInfos`).
3. The target pointer must itself have a len attribute whose first component matches the first component of the extended len (here: both use `infoCount` as the outer dimension).
4. The pointed-to type must be a struct that contains the referenced inner member (here: `VkAccelerationStructureBuildGeometryInfoKHR` must contain a `geometryCount` member).

These rules are intended to keep the semantics constrained and mechanically checkable for tools and schema validation.