### PR TITLE
Fixed VkPresent* bitmasks and enums link

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -522,9 +522,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkTileShadingRenderPassFlagBitsQCOM"   category="bitmask">typedef <type>VkFlags</type> <name>VkTileShadingRenderPassFlagsQCOM</name>;</type>
         <type bitvalues="VkPhysicalDeviceSchedulingControlsFlagBitsARM" category="bitmask">typedef <type>VkFlags64</type> <name>VkPhysicalDeviceSchedulingControlsFlagsARM</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkSurfaceCreateFlagsOHOS</name>;</type>
-        <type bitvalues="VkPresentStageFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkPresentStageFlagsEXT</name>;</type>
-        <type bitvalues="VkPastPresentationTimingFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkPastPresentationTimingFlagsEXT</name>;</type>
-        <type bitvalues="VkPresentTimingInfoFlagBitsEXT"      category="bitmask">typedef <type>VkFlags</type> <name>VkPresentTimingInfoFlagsEXT</name>;</type>
+        <type requires="VkPresentStageFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkPresentStageFlagsEXT</name>;</type>
+        <type requires="VkPastPresentationTimingFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkPastPresentationTimingFlagsEXT</name>;</type>
+        <type requires="VkPresentTimingInfoFlagBitsEXT"      category="bitmask">typedef <type>VkFlags</type> <name>VkPresentTimingInfoFlagsEXT</name>;</type>
         <type requires="VkSwapchainImageUsageFlagBitsOHOS" category="bitmask">typedef <type>VkFlags</type> <name>VkSwapchainImageUsageFlagsOHOS</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPerformanceCounterDescriptionFlagsARM</name>;</type>
 


### PR DESCRIPTION
VkFlags bitmasks are always linked to the respective flag bits enum using `requires`. 