### PR TITLE
Do not run CI when pushing tags

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,8 @@ on:
   # This is so there are not duplicate CI runs when the periodic
   # specification updates are tagged.
   push:
+    branches:
+      - '*'
     tags-ignore:
       - '*'
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
In this repo the effect is to duplicate CI runs every time the spec is published.