### PR TITLE
Elide duplicate API markup macros in `ChangeLog.adoc`

### DIFF
--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -10574,7 +10574,7 @@ Internal Issues:
     <<spirvenv-module-validation, Validation Rules within a Module>>
     sections, and for the <<limits-minTexelGatherOffset>> and
     <<limits-maxTexelGatherOffset>> limits (internal issue 1723).
-  * Require code:code:OpGroupNonUniformBroadcast to take a constant `Id`
+  * Require code:OpGroupNonUniformBroadcast to take a constant `Id`
     operand in the <<spirvenv-module-validation, Validation Rules within a
     Module>> sections (internal issue 1726).
   * Note that the swapchain specified in slink:VkImageSwapchainCreateInfoKHR
@@ -10666,7 +10666,7 @@ Internal Issues:
     slink:VkFramebufferCreateInfo (internal issue 1670).
   * Refactor common valid usage statements for flink:vkCmdBeginQuery and
     flink:vkCmdBeginQueryIndexedEXT (internal issue 1682).
-  * Prohibit the ename:ename:VK_SAMPLER_YCBCR_RANGE_ITU_NARROW range from
+  * Prohibit the ename:VK_SAMPLER_YCBCR_RANGE_ITU_NARROW range from
     being used in slink:VkSamplerYcbcrConversionCreateInfo for formats with
     a bit depth less than 8 (internal issue 1688).
   * Add missing interactions with `<<VK_EXT_host_query_reset_usage>>` in the
@@ -12751,7 +12751,7 @@ Internal Issues:
     <<shaders-fragment-execution, Fragment Shader Execution>> sections; for
     the <<features-features-sampleRateShading, sampleRateShading>> feature;
     for code:FragCoord, code:SampleId, and code:SamplePosition; and for
-    slink:sname:VkPipelineMultisampleStateCreateInfo (internal issue 1134).
+    slink:VkPipelineMultisampleStateCreateInfo (internal issue 1134).
   * Clarify the meaning of the ptext:maxDescriptorSet* limits in footnote 8
     of the <<features-limits-required,Required Limits>> table (internal
     issue 1139).


### PR DESCRIPTION
Missed a few in #2637.