### PR TITLE
Add power 2.2 colorspace enum to VK_EXT_swapchain_colorspace

### DIFF
--- a/appendices/VK_EXT_swapchain_colorspace.adoc
+++ b/appendices/VK_EXT_swapchain_colorspace.adoc
@@ -64,3 +64,6 @@ described by separate extension.
   * Revision 5, 2024-03-16 (Zehui Lin)
   ** Fix interchanged concepts of EOTF and OETF.
   ** Clarify that the presentation engine can accept the color spaces.
+
+  * Revision 6, 2026-01-03 (llyyr)
+  ** Add power2.2 nonlinear color space.

--- a/chapters/VK_KHR_surface/wsi.adoc
+++ b/chapters/VK_KHR_surface/wsi.adoc
@@ -3989,6 +3989,9 @@ ifdef::VK_EXT_swapchain_colorspace[]
   * ename:VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT specifies support for the
     images in Adobe RGB color space, encoded according to the Adobe RGB
     specification (approximately Gamma 2.2).
+  * ename:VK_COLOR_SPACE_POWER22_NONLINEAR_EXT specifies support for images
+    in a pure power 2.2 color space, encoded using a power-law (γ = 2.2)
+    transfer function.
   * ename:VK_COLOR_SPACE_PASS_THROUGH_EXT specifies that color components
     are used "`as is`".
     This is intended to allow applications to supply data for color spaces

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -21581,7 +21581,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </extension>
         <extension name="VK_EXT_swapchain_colorspace" number="105" type="instance" depends="VK_KHR_surface" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney-g" supported="vulkan,vulkansc" ratified="vulkan,vulkansc" nofeatures="true">
             <require>
-                <enum value="5"                                             name="VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION"/>
+                <enum value="6"                                             name="VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_swapchain_colorspace&quot;"       name="VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME"/>
                 <enum offset="1" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT"/>
                 <enum offset="2" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT"/>
@@ -21597,6 +21597,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="12" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT"/>
                 <enum offset="13" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_PASS_THROUGH_EXT"/>
                 <enum offset="14" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT"/>
+                <enum offset="15" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_POWER22_NONLINEAR_EXT"/>
                 <enum api="vulkan" extends="VkColorSpaceKHR"                name="VK_COLOR_SPACE_DCI_P3_LINEAR_EXT" alias="VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT" deprecated="aliased"/>
             </require>
         </extension>


### PR DESCRIPTION
Primary motivation for this is Wayland platform, which recommends to use gamma22 for video and computer graphics for applications but there's no gamma2.2 colorspace to set via the Vulkan API.