### PR TITLE
Add VK_EXT_swapchain_colorspace2

### DIFF
--- a/appendices/VK_EXT_swapchain_colorspace2.adoc
+++ b/appendices/VK_EXT_swapchain_colorspace2.adoc
@@ -1,0 +1,31 @@
+// Copyright 2016-2026 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_swapchain_colorspace2.adoc[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2026-01-04
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - llyyr
+
+=== Description
+
+`VK_EXT_swapchain_colorspace2` extends the list of swapchain color spaces
+defined by `VK_EXT_swapchain_colorspace` to include pure power-law (gamma =
+2.2) nonlinear.
+
+include::{generated}/interfaces/VK_EXT_swapchain_colorspace2.adoc[]
+
+=== Issues
+
+None.
+
+=== Version History
+
+  * Revision 1, 2026-01-04 (llyyr)
+  ** Initial draft

--- a/chapters/VK_KHR_surface/wsi.adoc
+++ b/chapters/VK_KHR_surface/wsi.adoc
@@ -3993,6 +3993,11 @@ ifdef::VK_EXT_swapchain_colorspace[]
     are used "`as is`".
     This is intended to allow applications to supply data for color spaces
     not described here.
+ifdef::VK_EXT_swapchain_colorspace2[]
+  * ename:VK_COLOR_SPACE_POWER22_NONLINEAR_EXT specifies support for images in
+    a sRGB color space, encoded using a pure power-law (gamma = 2.2) transfer
+    function.
+endif::VK_EXT_swapchain_colorspace2[]
 ifdef::VK_AMD_display_native_hdr[]
   * ename:VK_COLOR_SPACE_DISPLAY_NATIVE_AMD specifies support for the
     display's native color space.

--- a/scripts/xml_consistency.py
+++ b/scripts/xml_consistency.py
@@ -50,6 +50,7 @@ ALLOWED_QUEUE_NAMES = set((
 # specifying the alternate convention they follow
 EXTENSION_ENUM_NAME_SPELLING_CHANGE = {
     'VK_EXT_swapchain_colorspace': 'VK_EXT_SWAPCHAIN_COLOR_SPACE',
+    'VK_EXT_swapchain_colorspace2': 'VK_EXT_SWAPCHAIN_COLOR_SPACE2',
 }
 
 # These are extensions whose names *look* like they end in version numbers,

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -29731,6 +29731,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_669&quot;"             name="VK_KHR_EXTENSION_669_EXTENSION_NAME"/>
             </require>
         </extension>
+        <extension name="VK_EXT_swapchain_colorspace2" number="670" type="instance" depends="VK_KHR_surface" author="EXT" contact="llyyr @llyyr" supported="vulkan" nofeatures="true">
+            <require>
+                <enum value="1"                                             name="VK_EXT_SWAPCHAIN_COLOR_SPACE2_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_swapchain_colorspace2&quot;"      name="VK_EXT_SWAPCHAIN_COLOR_SPACE2_EXTENSION_NAME"/>
+                <enum offset="1" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_POWER22_NONLINEAR_EXT"/>
+            </require>
+        </extension>
     </extensions>
     <formats>
         <format name="VK_FORMAT_R4G4_UNORM_PACK8" class="8-bit" blockSize="1" texelsPerBlock="1" packed="8">


### PR DESCRIPTION
Follow-up from https://github.com/KhronosGroup/Vulkan-Docs/pull/2648

Primary motivation for this is Wayland platform, which recommends to use gamma2.2 for video and computer graphics for applications but there's no gamma2.2 colorspace to set via the Vulkan API.

Driver implementation: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/39152
Client implementation: https://code.videolan.org/videolan/libplacebo/-/merge_requests/775