### PR TITLE
Add flexible definition of 64 bit bitfield constants

### DIFF
--- a/appendices/boilerplate.adoc
+++ b/appendices/boilerplate.adoc
@@ -310,6 +310,119 @@ current Vulkan headers with their project in this case.
 endif::VKSC_VERSION_1_0[]
 --
 
+[open,refpage='VK_USE_64_BIT_FLAGS_ENUMS',desc='Define whether 64 bit constants should be declared using enumerations or static constants',type='defines']
+--
+dname:VK_USE_64_BIT_FLAGS_ENUMS defines whether the default definition 64 bit constants are declared using enumeration with the appropriate underlying type, or as static constants.
+
+dname:VK_USE_64_BIT_FLAGS_ENUMS default definition is set to '1' if the language allows enumerations with explicit underlying type, otherwise '0'.
+
+include::{generated}/api/defines/VK_USE_64_BIT_FLAGS_ENUMS.adoc[]
+
+[NOTE]
+====
+The `{core_header}` header allows the dname:VK_USE_64_BIT_FLAGS_ENUMS
+definition to be overridden by the application.
+====
+
+ifndef::VKSC_VERSION_1_0[]
+[NOTE]
+====
+This macro was introduced starting with the Vulkan 1.4.338 headers, and its
+availability can be checked at compile time by requiring
+`dname:VK_HEADER_VERSION >= 338`.
+
+It is not available if you are using older headers, such as may be shipped
+with an older Vulkan SDK.
+Developers requiring this functionality may wish to include a copy of the
+current Vulkan headers with their project in this case.
+====
+endif::VKSC_VERSION_1_0[]
+--
+
+[open,refpage='VK_BEGIN_ENUMERATION',desc='Begin the definition of an enumeration of constants with a specific underlying type.',type='defines', xrefs='VK_DEFINE_ENUM_VALUE VK_END_ENUMERATION']
+--
+dname:VK_BEGIN_ENUMERATION begins the definition of an enumeration of constants with a specific underlying type.
+
+include::{generated}/api/defines/VK_BEGIN_ENUMERATION.adoc[]
+
+[NOTE]
+====
+The `{core_header}` header allows the dname:VK_BEGIN_ENUMERATION
+definition to be overridden by the application.
+Care must be taken to also override definitions of dname:VK_DEFINE_ENUM_VALUE and dname:VK_END_ENUMERATION accordingly.
+====
+
+ifndef::VKSC_VERSION_1_0[]
+[NOTE]
+====
+This macro was introduced starting with the Vulkan 1.4.338 headers, and its
+availability can be checked at compile time by requiring
+`dname:VK_HEADER_VERSION >= 338`.
+
+It is not available if you are using older headers, such as may be shipped
+with an older Vulkan SDK.
+Developers requiring this functionality may wish to include a copy of the
+current Vulkan headers with their project in this case.
+====
+endif::VKSC_VERSION_1_0[]
+--
+
+[open,refpage='VK_DEFINE_ENUM_VALUE',desc='Define a enumeration value.',type='defines', xrefs='VK_BEGIN_ENUMERATION VK_END_ENUMERATION']
+--
+dname:VK_DEFINE_ENUM_VALUE defines a enumeration value.
+
+include::{generated}/api/defines/VK_DEFINE_ENUM_VALUE.adoc[]
+
+[NOTE]
+====
+The `{core_header}` header allows the dname:VK_DEFINE_ENUM_VALUE
+definition to be overridden by the application.
+Care must be taken to also override definitions of dname:VK_BEGIN_ENUMERATION and dname:VK_END_ENUMERATION accordingly.
+====
+
+ifndef::VKSC_VERSION_1_0[]
+[NOTE]
+====
+This macro was introduced starting with the Vulkan 1.4.338 headers, and its
+availability can be checked at compile time by requiring
+`dname:VK_HEADER_VERSION >= 338`.
+
+It is not available if you are using older headers, such as may be shipped
+with an older Vulkan SDK.
+Developers requiring this functionality may wish to include a copy of the
+current Vulkan headers with their project in this case.
+====
+endif::VKSC_VERSION_1_0[]
+--
+
+[open,refpage='VK_END_ENUMERATION',desc='Close the definition of an enumeration of constants.',type='defines', xrefs='VK_BEGIN_ENUMERATION VK_DEFINE_ENUM_VALUE']
+--
+dname:VK_END_ENUMERATION closes the definition of an enumeration of constants.
+
+include::{generated}/api/defines/VK_END_ENUMERATION.adoc[]
+
+[NOTE]
+====
+The `{core_header}` header allows the dname:VK_END_ENUMERATION
+definition to be overridden by the application.
+Care must be taken to also override definitions of dname:VK_BEGIN_ENUMERATION and dname:VK_DEFINE_ENUM_VALUE accordingly.
+====
+
+ifndef::VKSC_VERSION_1_0[]
+[NOTE]
+====
+This macro was introduced starting with the Vulkan 1.4.338 headers, and its
+availability can be checked at compile time by requiring
+`dname:VK_HEADER_VERSION >= 338`.
+
+It is not available if you are using older headers, such as may be shipped
+with an older Vulkan SDK.
+Developers requiring this functionality may wish to include a copy of the
+current Vulkan headers with their project in this case.
+====
+endif::VKSC_VERSION_1_0[]
+--
+
 
 [[boilerplate-wsi-header]]
 == Window System-Specific Header Control (Informative)

--- a/registry.adoc
+++ b/registry.adoc
@@ -3162,11 +3162,11 @@ For this example, assume we want to define bit flags that can handle up to
 [source,c]
 --------------------------------------
 // Flag bits for VkExampleFlagBits
-typedef VkFlags64 VkExampleFlagBits;
-static const VkExampleFlagBits VK_EXAMPLE_NONE = 0;
-static const VkExampleFlagBits VK_EXAMPLE_FIRST_BIT = 0x00000001;
-static const VkExampleFlagBits VK_EXAMPLE_SECOND_BIT = 0x00000002;
-
+VK_BEGIN_ENUMERATION(VkExampleFlagBits, VkFlags64)
+VK_DEFINE_ENUM_VALUE(VkExampleFlagBits, VK_EXAMPLE_NONE, 0);
+VK_DEFINE_ENUM_VALUE(VkExampleFlagBits, VK_EXAMPLE_FIRST_BIT, 0x00000001);
+VK_DEFINE_ENUM_VALUE(VkExampleFlagBits, VK_EXAMPLE_SECOND_BIT, 0x00000002);
+VK_END_ENUMERATION(VkExampleFlagBits, VkFlags64)
 typedef VkFlags64 VkExampleFlags;
 --------------------------------------
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -645,12 +645,9 @@ class OutputGenerator:
         flagTypeName = groupElem.get('name')
 
         # Prefix
-        body = f"// Flag bits for {flagTypeName}\n"
-
-        if bitwidth == 64:
-            body += f"typedef VkFlags64 {flagTypeName};\n";
-        else:
-            body += f"typedef VkFlags {flagTypeName};\n";
+        body = "// Flag bits for " + flagTypeName + "\n"
+        underlying_type = "VkFlags64" if bitwidth == 64 else "VkFlags"
+        body += f'VK_BEGIN_ENUMERATION({flagTypeName}, {underlying_type})\n'
 
         # Maximum allowable value for a flag (unsigned 64-bit integer)
         maxValidValue = 2**(64) - 1
@@ -705,7 +702,7 @@ class OutputGenerator:
                             (numVal, strVal) = self.enumToValue(alias, True, bitwidth, True)
                         else:
                             self.logMsg('error', f'No such alias {strVal} for enum {name}')
-                    decl += f"static const {flagTypeName} {name} = {strVal};\n"
+                    decl += f'VK_DEFINE_ENUM_VALUE({flagTypeName}, {name}, {strVal})\n'
 
                 if numVal is not None:
                     body += decl
@@ -719,6 +716,7 @@ class OutputGenerator:
         body += aliasText
 
         # Postfix
+        body += f'VK_END_ENUMERATION({flagTypeName}, {underlying_type})\n'
 
         return ("bitmask", body)
 

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -236,6 +236,39 @@ branch of the member gitlab server.
     #endif
 #endif</type>
 
+        <type category="define" name="VK_USE_64_BIT_FLAGS_ENUMS">
+#ifndef VK_USE_64_BIT_FLAGS_ENUMS
+    #if (defined(__cplusplus) &amp;&amp; (__cplusplus >= 201103L)) || (defined(_MSVC_LANG) &amp;&amp; (_MSVC_LANG >= 201103L)) || (defined(__STDC_VERSION__) &amp;&amp; (__STDC_VERSION__ >= 202311L))
+        #define VK_USE_64_BIT_FLAGS_ENUMS 1
+    #else
+        #define VK_USE_64_BIT_FLAGS_ENUMS 0
+    #endif
+#endif</type>
+        <type category="define" requires="VK_USE_64_BIT_FLAGS_ENUMS" name="VK_BEGIN_ENUMERATION">
+#ifndef VK_BEGIN_ENUMERATION
+    #if VK_USE_64_BIT_FLAGS_ENUMS
+        #define VK_BEGIN_ENUMERATION(enum_name, underlying_type) typedef enum enum_name : underlying_type {
+    #else
+        #define VK_BEGIN_ENUMERATION(enum_name, underlying_type) typedef underlying_type enum_name;
+    #endif
+#endif</type>
+        <type category="define" requires="VK_USE_64_BIT_FLAGS_ENUMS" name="VK_DEFINE_ENUM_VALUE">
+#ifndef VK_DEFINE_ENUM_VALUE
+    #if VK_USE_64_BIT_FLAGS_ENUMS
+        #define VK_DEFINE_ENUM_VALUE(enum_name, value_name, value) value_name = value,
+    #else
+        #define VK_DEFINE_ENUM_VALUE(enum_name, value_name, value) static const enum_name value_name = value;
+    #endif
+#endif</type>
+        <type category="define" requires="VK_USE_64_BIT_FLAGS_ENUMS" name="VK_END_ENUMERATION">
+#ifndef VK_END_ENUMERATION
+    #if VK_USE_64_BIT_FLAGS_ENUMS
+        #define VK_END_ENUMERATION(enum_name, underlying_type) } enum_name;
+    #else
+        #define VK_END_ENUMERATION(enum_name, underlying_type)
+    #endif
+#endif</type>
+
         <type category="basetype">struct <name>ANativeWindow</name>;</type>
         <type category="basetype">struct <name>AHardwareBuffer</name>;</type>
         <type category="basetype">#ifdef __OBJC__
@@ -18153,6 +18186,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <type name="VK_USE_64_BIT_PTR_DEFINES"/>
             <type name="VK_DEFINE_NON_DISPATCHABLE_HANDLE"/>
             <type name="VK_NULL_HANDLE"/>
+            <type name="VK_USE_64_BIT_FLAGS_ENUMS"/>
+            <type name="VK_BEGIN_ENUMERATION"/>
+            <type name="VK_DEFINE_ENUM_VALUE"/>
+            <type name="VK_END_ENUMERATION"/>
         </require>
         <require comment="Fundamental types used by many commands and structures">
             <type name="VkBool32"/>


### PR DESCRIPTION
Currently, due to limitations of C99, 64-bit flags (such as `VkAccessFlagBits2`) are defined as alias of `VkFlags64`, and global  `static const` variables. More recent standards (such as C++11 and C23) allow enumerations with an explicit underlying type.

This PR proposes to add macros to define 64-bit flags in `vulkan_core.h` in a flexible way, depending on the langage capabilities, and the application preferences:
```c
#ifndef VK_USE_64_BIT_FLAGS_ENUMS
    #if (defined(__cplusplus) && (__cplusplus >= 201103L)) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L)) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L))
        #define VK_USE_64_BIT_FLAGS_ENUMS 1
    #else
        #define VK_USE_64_BIT_FLAGS_ENUMS 0
    #endif
#endif

#ifndef VK_BEGIN_ENUMERATION
    #if VK_USE_64_BIT_FLAGS_ENUMS
        #define VK_BEGIN_ENUMERATION(enum_name, underlying_type) typedef enum enum_name : underlying_type {
    #else
        #define VK_BEGIN_ENUMERATION(enum_name, underlying_type) typedef underlying_type enum_name;
    #endif
#endif

#ifndef VK_DEFINE_ENUM_VALUE
    #if VK_USE_64_BIT_FLAGS_ENUMS
        #define VK_DEFINE_ENUM_VALUE(enum_name, value_name, value) value_name = value,
    #else
        #define VK_DEFINE_ENUM_VALUE(enum_name, value_name, value) static const enum_name value_name = value;
    #endif
#endif

#ifndef VK_END_ENUMERATION
    #if VK_USE_64_BIT_FLAGS_ENUMS
        #define VK_END_ENUMERATION(enum_name, underlying_type) } enum_name;
    #else
        #define VK_END_ENUMERATION(enum_name, underlying_type)
    #endif
#endif
```

Declaration of 64-bit flags would become:
```c
// Flag bits for VkPipelineStageFlagBits2
VK_BEGIN_ENUMERATION(VkPipelineStageFlagBits2, VkFlags64)
VK_DEFINE_ENUM_VALUE(VkPipelineStageFlagBits2, VK_PIPELINE_STAGE_2_NONE, 0ULL)
VK_DEFINE_ENUM_VALUE(VkPipelineStageFlagBits2, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT, 0x00000001ULL)
VK_DEFINE_ENUM_VALUE(VkPipelineStageFlagBits2, VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT, 0x00000002ULL)
VK_DEFINE_ENUM_VALUE(VkPipelineStageFlagBits2, VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT, 0x00000004ULL)
/// ....
VK_END_ENUMERATION(VkPipelineStageFlagBits2, VkFlags64)
```
The above definition in C is still quite readable, but unfortunately a bit less than directly using enums or static constants.
Each individual macro of `VK_BEGIN_ENUMERATION`, `VK_DEFINE_ENUM_VALUE` and `VK_END_ENUMERATION` can be defined by the application to suit its needs.
An additional macro `VK_USE_64_BIT_FLAGS_ENUMS` is defined as a shorcut to decide how the above macros are defined by default (similar to how `VK_USE_64_BIT_PTR_DEFINES` decides the default definition of `VK_DEFINE_NON_DISPATCHABLE_HANDLE`)

This PR should not bring any API breaking change.
The only issue I would see is if a script parses `vulkan_core.h` to extract bitfields values, it would probably break.


I am open to feedback and suggestions.

---------
Note:
In `appendices/boilerplate.adoc`, I used version 338 for when the macros were added to the specification. This will need to be changed if this PR is accepted for a later version.