### PR TITLE
Remove extra double-quote at the end of a comment

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -13360,7 +13360,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="10"   name="VK_FORMAT_FEATURE_2_BLIT_SRC_BIT"/>
         <enum bitpos="11"   name="VK_FORMAT_FEATURE_2_BLIT_DST_BIT"/>
         <enum bitpos="12"   name="VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT"/>
-            <comment>bitpos 13 is an extension interaction with VK_EXT_filter_cubic"</comment>
+            <comment>bitpos 13 is an extension interaction with VK_EXT_filter_cubic</comment>
         <enum bitpos="14"   name="VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT"/>
         <enum bitpos="15"   name="VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"/>
         <enum bitpos="16"   name="VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT"/>


### PR DESCRIPTION
I imagine this was just a copy-paste issue with any of the other places that have `VK_EXT_filter_cubic` quoted.

This was confusing some tokenizing code when hitting `VkFormatFeatureFlagBits2`, where it started parsing double-quoted strings after the end of the "bitpos 13..." comment, generally messing up the parsing of the whole file after that.

Parsers that don't let double-quoted strings go outside the XML tags would be fine, but I had some internally that didn't, so proposing the change here to be merged if possible.

Thanks! 😄 