### PR TITLE
docs: Fix types tag example

### DIFF
--- a/registry.adoc
+++ b/registry.adoc
@@ -1010,8 +1010,8 @@ the following tags are supported:
     <type requires="stddef">typedef ptrdiff_t <name>VKlongint</name>;</type>
     <type name="VkEnum" category="enum"/>
     <type category="struct" name="VkStruct">
-        <member><type>VkEnum</type> <name>srcEnum</name></member>
         <member><type>VkEnum</type> <name>dstEnum</name></member>
+        <member><type>Vklongint</type> <name>dstVal</name></member>
     </type>
 </types>
 
@@ -1029,7 +1029,7 @@ generation, it will result in the following declarations:
 [source,c]
 --------------------------------------
 #include <stddef.h>
-typedef ptrdiff_t VKlongint.
+typedef ptrdiff_t VKlongint;
 
 typedef enum {
     VK_ENUM_ZERO = 0,
@@ -1038,7 +1038,7 @@ typedef enum {
 
 typedef struct {
     VkEnum    dstEnum;
-    VkLongint dstVal;
+    Vklongint dstVal;
 } VkStruct;
 --------------------------------------
 


### PR DESCRIPTION
- Changed the example XML to match the generated C code.
- Fixed generated C code:
    - Typo where dot should be semicolon.
    - Fixed the capitalization of Vklongint.