### PR TITLE
Add the VK_EXT_external_semaphore_drm_syncobj extension

### DIFF
--- a/appendices/VK_EXT_external_semaphore_drm_syncobj.adoc
+++ b/appendices/VK_EXT_external_semaphore_drm_syncobj.adoc
@@ -1,0 +1,30 @@
+// Copyright 2026 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_external_semaphore_drm_syncobj.adoc[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2026-03-02
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Julian Orth
+  - James Jones, NVIDIA
+  - Simon Ser
+  - Lisa Wu, Arm Ltd.
+  - Jon Leech, Khronos
+
+=== Description
+
+This extension adds the ability to import and export timeline semaphores as DRM
+synchronization objects (syncobj).
+
+include::{generated}/interfaces/VK_EXT_external_semaphore_drm_syncobj.adoc[]
+
+=== Version History
+
+  * Revision 1, 2026-03-02 (Julian Orth)
+  ** Initial revision

--- a/chapters/capabilities.adoc
+++ b/chapters/capabilities.adoc
@@ -1641,6 +1641,12 @@ ifdef::VK_NV_external_sci_sync[]
     hardware engines including the CPU and software (intra-process and
     inter-process) operating domains and perform signal and wait operations.
 endif::VK_NV_external_sci_sync[]
+ifdef::VK_EXT_external_semaphore_drm_syncobj[]
+  * ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT specifies a
+    file descriptor handle to a Linux DRM synchronization object (syncobj).
+    This type must be used with timeline semaphores and Vulkan timeline
+    semaphore values corresponding to syncobj points.
+endif::VK_EXT_external_semaphore_drm_syncobj[]
 
 [NOTE]
 ====
@@ -1674,6 +1680,9 @@ endif::VK_FUCHSIA_external_semaphore[]
 ifdef::VK_NV_external_sci_sync[]
 | ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SCI_SYNC_OBJ_BIT_NV | No restriction | No restriction
 endif::VK_NV_external_sci_sync[]
+ifdef::VK_EXT_external_semaphore_drm_syncobj[]
+| ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT | No restriction | No restriction
+endif::VK_EXT_external_semaphore_drm_syncobj[]
 |====
 --
 

--- a/chapters/features.adoc
+++ b/chapters/features.adoc
@@ -9933,6 +9933,30 @@ include::{generated}/validity/structs/VkPhysicalDeviceGpaFeaturesAMD.adoc[]
 --
 endif::VK_AMD_gpa_interface[]
 
+ifdef::VK_EXT_external_semaphore_drm_syncobj[]
+[open,refpage='VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT',desc='Structure describing the external semaphore DRM syncobj features supported by the implementation',type='structs']
+--
+The sname:VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT structure is defined
+as:
+
+include::{generated}/api/structs/VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT.adoc[]
+
+This structure describes the following feature:
+
+  * pname:sType is a elink:VkStructureType value identifying this structure.
+  * pname:pNext is `NULL` or a pointer to a structure extending this
+    structure.
+  * [[features-externalSemaphoreDrmSyncobj]] pname:externalSemaphoreDrmSyncobj
+    indicates whether the implementation has support for the
+    ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT external
+    semaphore handle type.
+
+:refpage: VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT
+include::{chapters}/features.adoc[tag=features]
+
+include::{generated}/validity/structs/VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT.adoc[]
+--
+endif::VK_EXT_external_semaphore_drm_syncobj[]
 
 ifdef::VK_KHR_device_address_commands[]
 [open,refpage='VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR',desc='Structure describing support for device address commands',type='structs']

--- a/chapters/synchronization.adoc
+++ b/chapters/synchronization.adoc
@@ -3746,6 +3746,17 @@ ifdef::VK_NV_external_sci_sync[]
     slink:VkPhysicalDeviceExternalSciSyncFeaturesNV::pname:sciSyncExport>>
     features must: be enabled
 endif::VK_NV_external_sci_sync[]
+ifdef::VK_EXT_external_semaphore_drm_syncobj[]
+  * If pname:handleTypes includes
+    ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT, the
+    <<features-externalSemaphoreDrmSyncobj,
+    slink:VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT::pname:externalSemaphoreDrmSyncobj>>
+    feature must: be enabled
+  * If pname:handleTypes includes
+    ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT, the
+    slink:VkSemaphoreTypeCreateInfo::pname:semaphoreType field must: be
+    ename:VK_SEMAPHORE_TYPE_TIMELINE
+endif::VK_EXT_external_semaphore_drm_syncobj[]
 ****
 
 include::{generated}/validity/structs/VkExportSemaphoreCreateInfo.adoc[]
@@ -5180,6 +5191,9 @@ The handle types supported by pname:handleType are:
 | Handle Type                                               | Transference | Permanence Supported
 | ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT | Reference    | Temporary,Permanent
 | ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT   | Copy         | Temporary
+ifdef::VK_EXT_external_semaphore_drm_syncobj[]
+| ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT | Reference | Permanent
+endif::VK_EXT_external_semaphore_drm_syncobj[]
 |====
 
 .Valid Usage
@@ -5213,6 +5227,17 @@ ifdef::VK_BASE_VERSION_1_2,VK_KHR_timeline_semaphore[]
     semaphore from which pname:fd was exported must: not be
     ename:VK_SEMAPHORE_TYPE_TIMELINE
 endif::VK_BASE_VERSION_1_2,VK_KHR_timeline_semaphore[]
+ifdef::VK_EXT_external_semaphore_drm_syncobj[]
+  * If pname:handleType is
+    ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT, the
+    <<features-externalSemaphoreDrmSyncobj,
+    slink:VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT::pname:externalSemaphoreDrmSyncobj>>
+    feature must: be enabled
+  * If pname:handleType is
+    ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT, the
+    slink:VkSemaphoreTypeCreateInfo::pname:semaphoreType field must: be
+    ename:VK_SEMAPHORE_TYPE_TIMELINE
+endif::VK_EXT_external_semaphore_drm_syncobj[]
 ****
 
 If pname:handleType is ename:VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT,

--- a/proposals/VK_EXT_external_semaphore_drm_syncobj.adoc
+++ b/proposals/VK_EXT_external_semaphore_drm_syncobj.adoc
@@ -1,0 +1,58 @@
+// Copyright 2021-2026 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+= VK_EXT_external_semaphore_drm_syncobj
+:toc: left
+:docs: https://docs.vulkan.org/spec/latest/
+:refpages: https://docs.vulkan.org/refpages/latest/refpages/source/
+:sectnums:
+
+This extension aims to add interoperability between timeline semaphores and
+Linux DRM synchronization objects (syncobjs).
+
+== Problem Statement
+
+Linux DRM synchronization objects (syncobjs) are a kernel primitive that can be
+used to implement timeline semaphores. Syncobjs can be represented as file
+descriptors and some implementations use them as the file type of
+`VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT`.
+
+Syncobjs are also used for inter-process synchronization. In some situations it
+might be useful to use the same syncobj both as a timeline semaphore and for
+inter-process synchronization.
+
+Syncobjs furthermore allow applications to asynchronously wait for individual
+timeline points by integrating with `poll(2)`. In some applications it might be
+preferable to use this mechanism to wait for signal operations.
+
+Currently, there is no official mechanism for applications to export syncobjs
+from timeline semaphores or to import syncobjs into timeline semaphores.
+Applications can detect whether the file descriptor used for
+`VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT` refers to a syncobj but this
+does not solve the issue on implementations that do not use syncobjs.
+
+== Proposal
+
+The `VK_EXT_external_semaphore_drm_syncobj` extension adds a new handle type
+`VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT`.
+
+This type can be used to import syncobjs into/export syncobjs from timeline
+semaphores with _reference_ transference and _permanent_ permanence.
+
+Existing VUs disallow _temporary_ permanence for timeline semaphores.
+
+The mapping between syncobj points and timeline semaphore points is unambiguous
+since both support `2^64 - 1` points for timeline operations.
+
+== Issues
+
+=== Should binary semaphores also be supported?
+
+Some implementations use syncobjs to implement binary semaphores. This was not
+explored as part of this proposal. If the need arises, the author believes that
+support could be added with a new revision of the extension.
+
+For now, binary semaphores already support interop via
+`VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT`, albeit without
+wait-before-signal support.

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -12107,6 +12107,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>VkDataGraphOpticalFlowExecuteFlagsARM</type>        <name>flags</name></member>
             <member optional="true"><type>uint32_t</type>                           <name>meanFlowL1NormHint</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+          <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_DRM_SYNCOBJ_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true" noautovalidity="true"><type>void</type>*      <name>pNext</name></member>
+          <member><type>VkBool32</type>                                         <name>externalSemaphoreDrmSyncobj</name></member>
+        </type>
     </types>
 
 
@@ -32150,10 +32155,14 @@ endif::VK_KHR_internally_synchronized_queues[]
                 <feature name="dataGraphNeuralAcceleratorStatistics" struct="VkPhysicalDeviceDataGraphNeuralAcceleratorStatisticsFeaturesARM" />
             </require>
         </extension>
-        <extension name="VK_EXT_extension_678" number="678" author="EXT" contact="Julian Orth @mahkoh" supported="disabled">
+        <extension name="VK_EXT_external_semaphore_drm_syncobj" number="678" type="device" depends="(VK_VERSION_1_2,VK_KHR_timeline_semaphore)" author="EXT" contact="Julian Orth @mahkoh" supported="vulkan">
             <require>
-                <enum value="0" name="VK_EXT_EXTENSION_678_SPEC_VERSION" />
-                <enum value="&quot;VK_EXT_extension_678&quot;" name="VK_EXT_EXTENSION_678_EXTENSION_NAME" />
+                <enum value="1" name="VK_EXT_EXTERNAL_SEMAPHORE_DRM_SYNCOBJ_SPEC_VERSION" />
+                <enum value="&quot;VK_EXT_external_semaphore_drm_syncobj&quot;" name="VK_EXT_EXTERNAL_SEMAPHORE_DRM_SYNCOBJ_EXTENSION_NAME" />
+                <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_DRM_SYNCOBJ_FEATURES_EXT" />
+                <enum bitpos="8" extends="VkExternalSemaphoreHandleTypeFlagBits" name="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_DRM_SYNCOBJ_BIT_EXT" />
+                <type name="VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT" />
+                <feature name="externalSemaphoreDrmSyncobj" struct="VkPhysicalDeviceExternalSemaphoreDrmSyncobjFeaturesEXT" />
             </require>
         </extension>
         <extension name="VK_EXT_primitive_restart_index" number="679" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Mike Blumenkrantz @zmike" supported="vulkan" ratified="vulkan" specialuse="glemulation">


### PR DESCRIPTION
This extension enables interop between timeline semaphores and Linux DRM synchronization objects (syncobj).

Closes #2473
