### PR TITLE
doc: clarify VkStructureType naming derivation to avoid double underscores

### DIFF
--- a/chapters/fundamentals.adoc
+++ b/chapters/fundamentals.adoc
@@ -1966,7 +1966,7 @@ Each value corresponds to a particular structure with a pname:sType member
 with a matching name.
 As a general rule, the name of each elink:VkStructureType value is obtained
 by taking the name of the structure, stripping the leading etext:Vk,
-prefixing each capital letter with etext:_, converting the entire resulting
+prefixing each capital letter except the first with etext:_, converting the entire resulting
 string to upper case, and prefixing it with etext:VK_STRUCTURE_TYPE_.
 For example, structures of type slink:VkImageCreateInfo correspond to a
 elink:VkStructureType value of ename:VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,


### PR DESCRIPTION
The current specification states that VkStructureType names are derived by "prefixing each capital letter with _". If followed literally, a structure like VkImageCreateInfo (after stripping Vk) would become _Image_Create_Info, leading to VK_STRUCTURE_TYPE__IMAGE_CREATE_INFO with a double underscore.

Updated the description to "prefixing each capital letter except the first with _". This aligns the text with the actual naming convention used throughout the Vulkan API and removes any ambiguity for developers.