### PR TITLE
Scripts: add optional indentClosingBrace for function declarations

### DIFF
--- a/scripts/cgenerator.py
+++ b/scripts/cgenerator.py
@@ -41,6 +41,7 @@ class CGeneratorOptions(GeneratorOptions):
                  aliasMacro='',
                  misracstyle=False,
                  misracppstyle=False,
+                 indentClosingBrace=False,
                  **kwargs
                  ):
         """Constructor.
@@ -164,6 +165,8 @@ class CGeneratorOptions(GeneratorOptions):
 
         self.misracppstyle = misracppstyle
         """generate MISRA C++-friendly headers"""
+
+        self.indentClosingBrace = indentClosingBrace
 
         self.codeGenerator = True
         """True if this generator makes compilable code"""

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -192,6 +192,7 @@ class GeneratorOptions:
                  sortProcedure=regSortFeatures,
                  requireCommandAliases=False,
                  requireDepends=True,
+                 indentClosingBrace=False,
                 ):
         """Constructor.
 
@@ -332,6 +333,8 @@ class GeneratorOptions:
 
         self.requireDepends = requireDepends
         """True if dependencies of API tags are transitively required."""
+
+        self.indentClosingBrace = indentClosingBrace
 
     def emptyRegex(self, pat):
         """Substitute a regular expression which matches no version
@@ -1430,7 +1433,10 @@ class OutputGenerator:
             indentdecl = '(\n'
             indentdecl += ',\n'.join(self.makeCParamDecl(p, self.genOpts.alignFuncParam)
                                      for p in params)
-            indentdecl += ');'
+            if self.genOpts.indentClosingBrace:
+                indentdecl += '\n);'
+            else:
+                indentdecl += ');'
         else:
             indentdecl = '(void);'
         # Non-indented parameters

--- a/scripts/genvk.py
+++ b/scripts/genvk.py
@@ -584,7 +584,8 @@ def makeGenOpts(args):
             apientryp         = 'VKAPI_PTR *',
             alignFuncParam    = 48,
             misracstyle       = misracstyle,
-            misracppstyle     = misracppstyle)
+            misracppstyle     = misracppstyle,
+            indentClosingBrace  = False)
         ]
 
     genOpts['vulkan_base_core.h'] = [


### PR DESCRIPTION
## Description

I've added a new configuration option, `indentClosingBrace`, to the code generator. This is a preliminary step to potentially improve the structure and readability of function declarations, especially for complex API signatures.

### The Goal of This Change

1.  **Refpages Readability**: On the Vulkan Reference Pages, long parameter lists can make the trailing `);` difficult to spot. Moving it to a new line might make the signature block clearer for documentation.
2.  **IDE Visuals**: This would allow IDE indentation guides to "close" properly, which may assist developers in scanning the code structure.

###  Implementation Details

The toggle is added to the generator script and is currently **disabled by default** to ensure no immediate changes to the current headers.

* **File:** `scripts/genvk.py`
* **Line:** ~588
* **Default Setting:**
    ```python
    # scripts/genvk.py
    indentClosingBrace = False  # Set to True to enable new-line closing braces
    ```

### Considerations & Impact

* **Current Output:** With the option set to `False`, the generated output remains **exactly the same**. This ensures no existing workflows are affected by this PR.
* **Website Rendering:** I am **not entirely sure** if this change will automatically reflect as expected on the official documentation website (Refpages), as there might be additional CSS or post-processing involved. This PR simply provides the generator-level support to test that.
* **Future Flexibility:** If the community finds this style preferable and it renders correctly, we can consider enabling it globally in the future by updating this single line.

---
*Please let me know if this approach makes sense, or if you have any concerns about the implementation. Thanks!*
