### PR TITLE
Use links to github instead of internal gitlab

### DIFF
--- a/proposals/VK_EXT_frame_boundary.adoc
+++ b/proposals/VK_EXT_frame_boundary.adoc
@@ -1,5 +1,4 @@
 // Copyright 2022-2026 The Khronos Group Inc.
-//
 // SPDX-License-Identifier: CC-BY-4.0
 
 = VK_EXT_frame_boundary
@@ -12,7 +11,7 @@
 debuggers) to group queue submissions per frames in non-trivial scenarios,
 typically when `vkQueuePresentKHR` is not a relevant frame boundary delimiter.
 
-See also the discussion in https://gitlab.khronos.org/vulkan/vulkan/-/issues/2436
+Also see the discussion in internal gitlab issue 2436.
 
 == Problem Statement
 

--- a/proposals/VK_KHR_shader_constant_data.adoc
+++ b/proposals/VK_KHR_shader_constant_data.adoc
@@ -1,11 +1,11 @@
 // Copyright 2021-2026 The Khronos Group Inc.
-//
 // SPDX-License-Identifier: CC-BY-4.0
 
 = VK_KHR_shader_constant_data
 :toc: left
 :docs: https://docs.vulkan.org/spec/latest/
 :extensions: {docs}appendices/extensions.html#
+:spirvextensions: https://github.khronos.org/SPIRV-Registry/extensions/
 :sectnums:
 // Required so images render in github
 ifndef::images[:images: ../images]
@@ -14,8 +14,9 @@ This extension allows applications to specify large constant data arrays in thei
 
 == Problem Statement
 
-https://gitlab.khronos.org/spirv/spirv-extensions/-/blob/SPV_KHR_large_constants/SPV_KHR_constant_data.asciidoc[`SPV_KHR_constant_data`] added the capability to specify arrayed data as constants in SPIR-V, to enable the specification of strings as data, or other chunks of data, in a more compact manner than previously available.
-A detailed problem statement on why this was added to SPIR-V is provided in the https://gitlab.khronos.org/spirv/spirv-extensions/-/blob/SPV_KHR_large_constants/SPV_KHR_constant_data.asciidoc[`SPV_KHR_constant_data` specification].
+{spirvextensions}/KHR/SPV_KHR_constant_data.asciidoc[`SPV_KHR_constant_data`] added the capability to specify arrayed data as constants in SPIR-V, to enable the specification of strings as data, or other chunks of data, in a more compact manner than previously available.
+A detailed problem statement on why this was added to SPIR-V is provided in
+the `SPV_KHR_constant_data` specification.
 
 Support for this extension is required in Vulkan to add better string support to Vulkan, and particularly for link:{extensions}VK_KHR_shader_abort[VK_KHR_shader_abort].
 

--- a/registry.adoc
+++ b/registry.adoc
@@ -114,7 +114,7 @@ https://registry.khronos.org/vulkan/ .
 = Getting Started
 
 See
-https://gitlab.khronos.org/vulkan/vulkan/blob/main/xml/BUILD.adoc[`xml/BUILD.adoc`]
+https://github.com/KhronosGroup/Vulkan-Docs/blob/main/BUILD.adoc[`xml/BUILD.adoc`]
 in the `Vulkan-Docs` repository for information on required toolchain
 components such as Python 3, pass:[g++], and GNU make.
 


### PR DESCRIPTION
@tobski @r-potter I'll hold off on this until the SPV updates are published, so I can check the proposal link validity in github, then regenerate (or maybe more likely just patch the proposal HTML in the docs site, given the very long site build time). There are a couple other gitlab->github links fixed but they are not a problem so can wait for the next spec update.