### PR TITLE
Add VK_EXT_ycbcr_3plane_16bit_lsb_formats extension

### DIFF
--- a/appendices/VK_EXT_ycbcr_3plane_16bit_lsb_formats.adoc
+++ b/appendices/VK_EXT_ycbcr_3plane_16bit_lsb_formats.adoc
@@ -1,0 +1,27 @@
+// Copyright 2026 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_EXT_ycbcr_3plane_16bit_lsb_formats.adoc[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2026-04-30
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Robert Mader, Collabora
+
+=== Description
+
+This extension adds some 10/12/14bit {YCbCr} formats that are in common use for
+video software encode and decode, but were not part of the
+`apiext:VK_KHR_sampler_ycbcr_conversion` extension.
+
+include::{generated}/interfaces/VK_EXT_ycbcr_3plane_16bit_lsb_formats.adoc[]
+
+=== Version History
+
+  * Revision 1, 2026-04-30 (Robert Mader)
+  ** Initial draft

--- a/chapters/descriptorbuffers.adoc
+++ b/chapters/descriptorbuffers.adoc
@@ -595,6 +595,22 @@ ifdef::VK_BASE_VERSION_1_3[Vulkan 1.3 is not supported and]
     ename:VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16, or
     ename:VK_FORMAT_G16_B16R16_2PLANE_444_UNORM
 endif::VK_EXT_ycbcr_2plane_444_formats[]
+ifdef::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+  * If the <<features-ycbcr3plane16BitLsbFormats,pname:ycbcr3plane16BitLsbFormats>>
+    feature is not enabled, pname:format must: not be
+    ename:VK_FORMAT_Z6R10_UNORM_EXT,
+    ename:VK_FORMAT_Z4R12_UNORM_EXT,
+    ename:VK_FORMAT_Z2R14_UNORM_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT or
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT
+endif::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
 ****
 
 include::{generated}/validity/structs/VkDescriptorAddressInfoEXT.adoc[]

--- a/chapters/features.adoc
+++ b/chapters/features.adoc
@@ -6173,6 +6173,42 @@ endif::VK_BASE_VERSION_1_3[]
 --
 endif::VK_EXT_ycbcr_2plane_444_formats[]
 
+ifdef::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+[open,refpage='VkPhysicalDeviceYcbcr3Plane16BitLsbFormatsFeaturesEXT',desc='Structure describing whether the implementation supports additional 3-plane 16bit LSB {YCbCr} formats',type='structs']
+--
+The sname:VkPhysicalDeviceYcbcr3Plane16BitLsbFormatsFeaturesEXT structure is
+defined as:
+
+include::{generated}/api/structs/VkPhysicalDeviceYcbcr3Plane16BitLsbFormatsFeaturesEXT.adoc[]
+
+This structure describes the following feature:
+
+  * pname:sType is a elink:VkStructureType value identifying this structure.
+  * pname:pNext is `NULL` or a pointer to a structure extending this
+    structure.
+  * [[features-ycbcr3plane16BitLsbFormats]] pname:ycbcr3plane16BitLsbFormats
+    indicates that the implementation supports querying format features for, and
+    using, the following  3-plane 16bit LSB {YCbCr} formats:
+  ** ename:VK_FORMAT_Z6R10_UNORM_EXT
+  ** ename:VK_FORMAT_Z4R12_UNORM_EXT
+  ** ename:VK_FORMAT_Z2R14_UNORM_EXT
+  ** ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT
+  ** ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT
+  ** ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT
+  ** ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT
+  ** ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT
+  ** ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT
+  ** ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT
+  ** ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT
+  ** ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT
+
+:refpage: VkPhysicalDeviceYcbcr3Plane16BitLsbFormatsFeaturesEXT
+include::{chapters}/features.adoc[tag=features]
+
+include::{generated}/validity/structs/VkPhysicalDeviceYcbcr3Plane16BitLsbFormatsFeaturesEXT.adoc[]
+--
+endif::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+
 ifdef::VK_EXT_color_write_enable[]
 [open,refpage='VkPhysicalDeviceColorWriteEnableFeaturesEXT',desc='Structure describing whether writes to color attachments can be enabled and disabled dynamically',type='structs']
 --

--- a/chapters/formats.adoc
+++ b/chapters/formats.adoc
@@ -1359,6 +1359,161 @@ ifdef::VK_BASE_VERSION_1_3,VK_EXT_ycbcr_2plane_444_formats[]
     ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane, and
     ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the BR plane.
 endif::VK_BASE_VERSION_1_3,VK_EXT_ycbcr_2plane_444_formats[]
+ifdef::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+  * ename:VK_FORMAT_Z6R10_UNORM_EXT specifies a one-component, 16-bit
+    unsigned normalized format that has a single 10-bit R component in the
+    bottom 10 bits of a 16-bit word, with the top 6 bits unused and required
+    to be set to zero.
+  * ename:VK_FORMAT_Z4R12_UNORM_EXT specifies a one-component, 16-bit
+    unsigned normalized format that has a single 12-bit R component in the
+    bottom 12 bits of a 16-bit word, with the top 4 bits unused and required
+    to be set to zero.
+  * ename:VK_FORMAT_Z2R14_UNORM_EXT specifies a one-component, 16-bit
+    unsigned normalized format that has a single 14-bit R component in the
+    bottom 14 bits of a 16-bit word, with the top 2 bits unused and required
+    to be set to zero.
+  * ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT specifies an
+    unsigned normalized _multi-planar format_ that has a 10-bit G component
+    in the bottom 10 bits of each 16-bit word of plane 0, a 10-bit B component
+    in the bottom 10 bits of each 16-bit word of plane 1, and a 10-bit R
+    component in the bottom 10 bits of each 16-bit word of plane 2, with the
+    top 6 bits of each word unused and required to be set to zero.
+    The horizontal and vertical dimensions of the R and B planes are halved
+    relative to the image dimensions, and each R and B component is shared
+    with the G components for which latexmath:[\left\lfloor i_G \times 0.5
+    \right\rfloor = i_B = i_R] and latexmath:[\left\lfloor j_G \times 0.5
+    \right\rfloor = j_B = j_R].
+    The location of each plane when this image is in linear layout can be
+    determined via flink:vkGetImageSubresourceLayout, using
+    ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane,
+    ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the B plane, and
+    ename:VK_IMAGE_ASPECT_PLANE_2_BIT for the R plane.
+    This format only supports images with a width and height that is a
+    multiple of two.
+  * ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT specifies an
+    unsigned normalized _multi-planar format_ that has a 10-bit G component
+    in the bottom 10 bits of each 16-bit word of plane 0, a 10-bit B component
+    in the bottom 10 bits of each 16-bit word of plane 1, and a 10-bit R
+    component in the bottom 10 bits of each 16-bit word of plane 2, with the
+    top 6 bits of each word unused and required to be set to zero.
+    The horizontal dimension of the R and B plane is halved relative to the
+    image dimensions, and each R and B value is shared with the G components
+    for which latexmath:[\left\lfloor i_G \times 0.5 \right\rfloor = i_B =
+    i_R].
+    The location of each plane when this image is in linear layout can be
+    determined via flink:vkGetImageSubresourceLayout, using
+    ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane,
+    ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the B plane, and
+    ename:VK_IMAGE_ASPECT_PLANE_2_BIT for the R plane.
+    This format only supports images with a width that is a multiple of two.
+  * ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT specifies an
+    unsigned normalized _multi-planar format_ that has a 10-bit G component
+    in the bottom 10 bits of each 16-bit word of plane 0, a 10-bit B component
+    in the bottom 10 bits of each 16-bit word of plane 1, and a 10-bit R
+    component in the bottom 10 bits of each 16-bit word of plane 2, with the
+    top 6 bits of each word unused and required to be set to zero.
+    Each plane has the same dimensions and each R, G, and B component
+    contributes to a single texel.
+    The location of each plane when this image is in linear layout can be
+    determined via flink:vkGetImageSubresourceLayout, using
+    ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane,
+    ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the B plane, and
+    ename:VK_IMAGE_ASPECT_PLANE_2_BIT for the R plane.
+  * ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT specifies an
+    unsigned normalized _multi-planar format_ that has a 12-bit G component
+    in the bottom 12 bits of each 16-bit word of plane 0, a 12-bit B component
+    in the bottom 12 bits of each 16-bit word of plane 1, and a 12-bit R
+    component in the bottom 12 bits of each 16-bit word of plane 2, with the
+    top 4 bits of each word unused and required to be set to zero.
+    The horizontal and vertical dimensions of the R and B planes are halved
+    relative to the image dimensions, and each R and B component is shared
+    with the G components for which latexmath:[\left\lfloor i_G \times 0.5
+    \right\rfloor = i_B = i_R] and latexmath:[\left\lfloor j_G \times 0.5
+    \right\rfloor = j_B = j_R].
+    The location of each plane when this image is in linear layout can be
+    determined via flink:vkGetImageSubresourceLayout, using
+    ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane,
+    ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the B plane, and
+    ename:VK_IMAGE_ASPECT_PLANE_2_BIT for the R plane.
+    This format only supports images with a width and height that is a
+    multiple of two.
+  * ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT specifies an
+    unsigned normalized _multi-planar format_ that has a 12-bit G component
+    in the bottom 12 bits of each 16-bit word of plane 0, a 12-bit B component
+    in the bottom 12 bits of each 16-bit word of plane 1, and a 12-bit R
+    component in the bottom 12 bits of each 16-bit word of plane 2, with the
+    top 4 bits of each word unused and required to be set to zero.
+    The horizontal dimension of the R and B plane is halved relative to the
+    image dimensions, and each R and B value is shared with the G components
+    for which latexmath:[\left\lfloor i_G \times 0.5 \right\rfloor = i_B =
+    i_R].
+    The location of each plane when this image is in linear layout can be
+    determined via flink:vkGetImageSubresourceLayout, using
+    ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane,
+    ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the B plane, and
+    ename:VK_IMAGE_ASPECT_PLANE_2_BIT for the R plane.
+    This format only supports images with a width that is a multiple of two.
+  * ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT specifies an
+    unsigned normalized _multi-planar format_ that has a 12-bit G component
+    in the bottom 12 bits of each 16-bit word of plane 0, a 12-bit B component
+    in the bottom 12 bits of each 16-bit word of plane 1, and a 12-bit R
+    component in the bottom 12 bits of each 16-bit word of plane 2, with the
+    top 4 bits of each word unused and required to be set to zero.
+    Each plane has the same dimensions and each R, G, and B component
+    contributes to a single texel.
+    The location of each plane when this image is in linear layout can be
+    determined via flink:vkGetImageSubresourceLayout, using
+    ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane,
+    ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the B plane, and
+    ename:VK_IMAGE_ASPECT_PLANE_2_BIT for the R plane.
+  * ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT specifies an
+    unsigned normalized _multi-planar format_ that has a 14-bit G component
+    in the bottom 14 bits of each 16-bit word of plane 0, a 14-bit B component
+    in the bottom 14 bits of each 16-bit word of plane 1, and a 14-bit R
+    component in the bottom 14 bits of each 16-bit word of plane 2, with the
+    top 2 bits of each word unused and required to be set to zero.
+    The horizontal and vertical dimensions of the R and B planes are halved
+    relative to the image dimensions, and each R and B component is shared
+    with the G components for which latexmath:[\left\lfloor i_G \times 0.5
+    \right\rfloor = i_B = i_R] and latexmath:[\left\lfloor j_G \times 0.5
+    \right\rfloor = j_B = j_R].
+    The location of each plane when this image is in linear layout can be
+    determined via flink:vkGetImageSubresourceLayout, using
+    ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane,
+    ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the B plane, and
+    ename:VK_IMAGE_ASPECT_PLANE_2_BIT for the R plane.
+    This format only supports images with a width and height that is a
+    multiple of two.
+  * ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT specifies an
+    unsigned normalized _multi-planar format_ that has a 14-bit G component
+    in the bottom 14 bits of each 16-bit word of plane 0, a 14-bit B component
+    in the bottom 14 bits of each 16-bit word of plane 1, and a 14-bit R
+    component in the bottom 14 bits of each 16-bit word of plane 2, with the
+    top 2 bits of each word unused and required to be set to zero.
+    The horizontal dimension of the R and B plane is halved relative to the
+    image dimensions, and each R and B value is shared with the G components
+    for which latexmath:[\left\lfloor i_G \times 0.5 \right\rfloor = i_B =
+    i_R].
+    The location of each plane when this image is in linear layout can be
+    determined via flink:vkGetImageSubresourceLayout, using
+    ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane,
+    ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the B plane, and
+    ename:VK_IMAGE_ASPECT_PLANE_2_BIT for the R plane.
+    This format only supports images with a width that is a multiple of two.
+  * ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT, specifies an
+    unsigned normalized _multi-planar format_ that has a 14-bit G component
+    in the bottom 14 bits of each 16-bit word of plane 0, a 14-bit B component
+    in the bottom 14 bits of each 16-bit word of plane 1, and a 14-bit R
+    component in the bottom 14 bits of each 16-bit word of plane 2, with the
+    top 2 bits of each word unused and required to be set to zero.
+    Each plane has the same dimensions and each R, G, and B component
+    contributes to a single texel.
+    The location of each plane when this image is in linear layout can be
+    determined via flink:vkGetImageSubresourceLayout, using
+    ename:VK_IMAGE_ASPECT_PLANE_0_BIT for the G plane,
+    ename:VK_IMAGE_ASPECT_PLANE_1_BIT for the B plane, and
+    ename:VK_IMAGE_ASPECT_PLANE_2_BIT for the R plane.
+endif::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
 ifdef::VK_IMG_format_pvrtc[]
   * ename:VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG specifies a four-component,
     PVRTC compressed format where each 64-bit compressed texel block encodes
@@ -2062,9 +2217,9 @@ include::{generated}/api/protos/vkGetPhysicalDeviceFormatProperties.adoc[]
     structure in which physical device properties for pname:format are
     returned.
 
-ifdef::VK_EXT_ycbcr_2plane_444_formats[]
 .Valid Usage
 ****
+ifdef::VK_EXT_ycbcr_2plane_444_formats[]
   * [[VUID-vkGetPhysicalDeviceFormatProperties-None-12272]]
     If
 ifdef::VK_BASE_VERSION_1_3[Vulkan 1.3 is not supported,]
@@ -2079,8 +2234,24 @@ ifdef::VK_KHR_maintenance5,VK_BASE_VERSION_1_3[and]
     ename:VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16,
     ename:VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16, or
     ename:VK_FORMAT_G16_B16R16_2PLANE_444_UNORM
-****
 endif::VK_EXT_ycbcr_2plane_444_formats[]
+ifdef::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+  * If the <<features-ycbcr3plane16BitLsbFormats,pname:ycbcr3plane16BitLsbFormats>>
+    feature is not enabled, pname:format must: not be
+    ename:VK_FORMAT_Z6R10_UNORM_EXT,
+    ename:VK_FORMAT_Z4R12_UNORM_EXT,
+    ename:VK_FORMAT_Z2R14_UNORM_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT or
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT
+endif::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+****
 
 include::{generated}/validity/protos/vkGetPhysicalDeviceFormatProperties.adoc[]
 --
@@ -2427,9 +2598,9 @@ fname:vkGetPhysicalDeviceFormatProperties2 behaves similarly to
 flink:vkGetPhysicalDeviceFormatProperties, with the ability to return
 extended information in a pname:pNext chain of output structures.
 
-ifdef::VK_EXT_ycbcr_2plane_444_formats[]
 .Valid Usage
 ****
+ifdef::VK_EXT_ycbcr_2plane_444_formats[]
   * [[VUID-vkGetPhysicalDeviceFormatProperties2-None-12273]]
     If
 ifdef::VK_BASE_VERSION_1_3[Vulkan 1.3 is not supported,]
@@ -2444,8 +2615,24 @@ ifdef::VK_KHR_maintenance5,VK_BASE_VERSION_1_3[and]
     ename:VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16,
     ename:VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16, or
     ename:VK_FORMAT_G16_B16R16_2PLANE_444_UNORM
-****
 endif::VK_EXT_ycbcr_2plane_444_formats[]
+ifdef::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+  * If the <<features-ycbcr3plane16BitLsbFormats,pname:ycbcr3plane16BitLsbFormats>>
+    feature is not enabled, pname:format must: not be
+    ename:VK_FORMAT_Z6R10_UNORM_EXT,
+    ename:VK_FORMAT_Z4R12_UNORM_EXT,
+    ename:VK_FORMAT_Z2R14_UNORM_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT or
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT
+endif::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+****
 
 include::{generated}/validity/protos/vkGetPhysicalDeviceFormatProperties2.adoc[]
 --

--- a/chapters/resources.adoc
+++ b/chapters/resources.adoc
@@ -1355,6 +1355,22 @@ ifdef::VK_BASE_VERSION_1_3[Vulkan 1.3 is not supported and]
     ename:VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16, or
     ename:VK_FORMAT_G16_B16R16_2PLANE_444_UNORM
 endif::VK_EXT_ycbcr_2plane_444_formats[]
+ifdef::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+  * If the <<features-ycbcr3plane16BitLsbFormats,pname:ycbcr3plane16BitLsbFormats>>
+    feature is not enabled, pname:format must: not be
+    ename:VK_FORMAT_Z6R10_UNORM_EXT,
+    ename:VK_FORMAT_Z4R12_UNORM_EXT,
+    ename:VK_FORMAT_Z2R14_UNORM_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT or
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT
+endif::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
 ****
 
 include::{generated}/validity/structs/VkBufferViewCreateInfo.adoc[]
@@ -3144,6 +3160,22 @@ ifdef::VK_BASE_VERSION_1_3[Vulkan 1.3 is not supported and]
     ename:VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16, or
     ename:VK_FORMAT_G16_B16R16_2PLANE_444_UNORM
 endif::VK_EXT_ycbcr_2plane_444_formats[]
+ifdef::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+  * If the <<features-ycbcr3plane16BitLsbFormats,pname:ycbcr3plane16BitLsbFormats>>
+    feature is not enabled, pname:format must: not be
+    ename:VK_FORMAT_Z6R10_UNORM_EXT,
+    ename:VK_FORMAT_Z4R12_UNORM_EXT,
+    ename:VK_FORMAT_Z2R14_UNORM_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT or
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT
+endif::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
 ifdef::VK_EXT_descriptor_heap[]
   * [[VUID-VkImageCreateInfo-flags-11281]]
     If slink:VkOpaqueCaptureDataCreateInfoEXT::pname:pData is not `NULL`,
@@ -7313,6 +7345,22 @@ ifdef::VK_BASE_VERSION_1_3[Vulkan 1.3 is not supported and]
     ename:VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16, or
     ename:VK_FORMAT_G16_B16R16_2PLANE_444_UNORM
 endif::VK_EXT_ycbcr_2plane_444_formats[]
+ifdef::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
+  * If the <<features-ycbcr3plane16BitLsbFormats,pname:ycbcr3plane16BitLsbFormats>>
+    feature is not enabled, pname:format must: not be
+    ename:VK_FORMAT_Z6R10_UNORM_EXT,
+    ename:VK_FORMAT_Z4R12_UNORM_EXT,
+    ename:VK_FORMAT_Z2R14_UNORM_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT,
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT or
+    ename:VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT
+endif::VK_EXT_ycbcr_3plane_16bit_lsb_formats[]
 ****
 
 include::{generated}/validity/structs/VkImageViewCreateInfo.adoc[]

--- a/proposals/VK_EXT_ycbcr_3plane_16bit_lsb_formats.adoc
+++ b/proposals/VK_EXT_ycbcr_3plane_16bit_lsb_formats.adoc
@@ -1,0 +1,40 @@
+// Copyright 2026 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+= VK_EXT_ycbcr_3plane_16bit_lsb_formats
+:toc: left
+:docs: https://docs.vulkan.org/spec/latest/
+:extensions: {docs}appendices/extensions.html#
+:sectnums:
+
+This extension adds support for 10/12/14 bit {YCbCr} formats used by software
+decoders like ffmpeg, dav1d and libvpx.
+
+== Problem Statement
+
+Many popular software video decoders - such as ffmpeg/libav, dav1d and libvpx -
+use formats for 10, 12 and 14 bit content that are not yet supported in Vulkan,
+but are supported by Linux DRM and Mesa GLES (at least the 10 and 12 bit ones).
+These formats are long established and optimized for the given task and it would
+be very hard for decoders to switch to formats optimized for hardware video
+decoders such as P010.
+
+Supporting these formats directly in drivers has various advantages for apps
+and system compositors, as it allows to avoid unnecessary copies and/or quality
+loss. Further more it can also simplify code-sharing with code-paths for
+hardware decoders.
+
+Unfortunately it is not possible to use the existing 16 bit formats such as
+VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM as - unlike most formats used by hardware
+decoders - the alignment is LSB, not MSB. The bit-values thus need to get
+shifted by 6, 4 or 2 bits.
+
+== Proposal
+
+Add the formats in question. For any drivers already supporting YCbCr formats
+via shaders this should be straight forward. Values in the 0.0 - 1.0 range just
+need to get multiplied by 65535.0 / 1023.0 (for 10 bit), 65535.0 / 4095.0 (for
+12 bit) or 65535.0 / 16383.0 (for 14 bit).
+
+== Issues

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -8735,6 +8735,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                     <name>ycbcr2plane444Formats</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceYcbcr3Plane16BitLsbFormatsFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_3_PLANE_16BIT_LSB_FORMATS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>VkBool32</type>                     <name>ycbcr3plane16BitLsbFormats</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceProvokingVertexFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true" noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
@@ -31364,10 +31369,25 @@ endif::VK_KHR_internally_synchronized_queues[]
                 <enum value="&quot;VK_KHR_extension_625&quot;" name="VK_KHR_EXTENSION_625_EXTENSION_NAME" />
             </require>
         </extension>
-        <extension name="VK_EXT_extension_626" number="626" author="EXT" contact="Robert Mader @rmader" supported="disabled">
+        <extension name="VK_EXT_ycbcr_3plane_16bit_lsb_formats" number="626" type="device" depends="VK_KHR_sampler_ycbcr_conversion,VK_VERSION_1_1" author="EXT" contact="Robert Mader @rmader" supported="vulkan">
             <require>
-                <enum value="0" name="VK_EXT_EXTENSION_626_SPEC_VERSION" />
-                <enum value="&quot;VK_EXT_extension_626&quot;" name="VK_EXT_EXTENSION_626_EXTENSION_NAME" />
+                <enum value="1" name="VK_EXT_YCBCR_3PLANE_16BIT_LSB_FORMATS_SPEC_VERSION" />
+                <enum value="&quot;VK_EXT_ycbcr_3plane_16bit_lsb_formats&quot;" name="VK_EXT_YCBCR_3PLANE_16BIT_LSB_FORMATS_EXTENSION_NAME" />
+                <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_3_PLANE_16BIT_LSB_FORMATS_FEATURES_EXT" />
+                <enum offset="0" extends="VkFormat" name="VK_FORMAT_Z6R10_UNORM_EXT" />
+                <enum offset="1" extends="VkFormat" name="VK_FORMAT_Z4R12_UNORM_EXT" />
+                <enum offset="2" extends="VkFormat" name="VK_FORMAT_Z2R14_UNORM_EXT" />
+                <enum offset="3" extends="VkFormat" name="VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT" />
+                <enum offset="4" extends="VkFormat" name="VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT" />
+                <enum offset="5" extends="VkFormat" name="VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT" />
+                <enum offset="6" extends="VkFormat" name="VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT" />
+                <enum offset="7" extends="VkFormat" name="VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT" />
+                <enum offset="8" extends="VkFormat" name="VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT" />
+                <enum offset="9" extends="VkFormat" name="VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT" />
+                <enum offset="10" extends="VkFormat" name="VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT" />
+                <enum offset="11" extends="VkFormat" name="VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT" />
+                <type name="VkPhysicalDeviceYcbcr3Plane16BitLsbFormatsFeaturesEXT" />
+                <feature name="ycbcr3plane16BitLsbFormats" struct="VkPhysicalDeviceYcbcr3Plane16BitLsbFormatsFeaturesEXT" />
             </require>
         </extension>
         <extension name="VK_NV_extension_627" number="627" author="NV" contact="Jeff Juliano @jjuliano" supported="disabled">
@@ -33869,6 +33889,87 @@ endif::VK_KHR_internally_synchronized_queues[]
         </format>
         <format name="VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E5M2_ARM" class="8-bit" blockSize="1" texelsPerBlock="1">
             <component name="R" bits="8" numericFormat="SFLOAT" />
+        </format>
+        <format name="VK_FORMAT_Z6R10_UNORM_EXT" class="16-bit" blockSize="2" texelsPerBlock="1">
+            <component name="R" bits="10" numericFormat="UNORM" />
+        </format>
+        <format name="VK_FORMAT_Z4R12_UNORM_EXT" class="16-bit" blockSize="2" texelsPerBlock="1">
+            <component name="R" bits="12" numericFormat="UNORM" />
+        </format>
+        <format name="VK_FORMAT_Z2R14_UNORM_EXT" class="16-bit" blockSize="2" texelsPerBlock="1">
+            <component name="R" bits="14" numericFormat="UNORM" />
+        </format>
+        <format name="VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_420_UNORM_3PACK16_EXT" class="10-bit 3-plane 420 LSB" blockSize="6" texelsPerBlock="1" chroma="420">
+            <component name="G" bits="10" numericFormat="UNORM" planeIndex="0" />
+            <component name="B" bits="10" numericFormat="UNORM" planeIndex="1" />
+            <component name="R" bits="10" numericFormat="UNORM" planeIndex="2" />
+            <plane index="0" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z6R10_UNORM_EXT" />
+            <plane index="1" widthDivisor="2" heightDivisor="2" compatible="VK_FORMAT_Z6R10_UNORM_EXT" />
+            <plane index="2" widthDivisor="2" heightDivisor="2" compatible="VK_FORMAT_Z6R10_UNORM_EXT" />
+        </format>
+        <format name="VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_422_UNORM_3PACK16_EXT" class="10-bit 3-plane 422 LSB" blockSize="6" texelsPerBlock="1" chroma="422">
+            <component name="G" bits="10" numericFormat="UNORM" planeIndex="0" />
+            <component name="B" bits="10" numericFormat="UNORM" planeIndex="1" />
+            <component name="R" bits="10" numericFormat="UNORM" planeIndex="2" />
+            <plane index="0" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z6R10_UNORM_EXT" />
+            <plane index="1" widthDivisor="2" heightDivisor="1" compatible="VK_FORMAT_Z6R10_UNORM_EXT" />
+            <plane index="2" widthDivisor="2" heightDivisor="1" compatible="VK_FORMAT_Z6R10_UNORM_EXT" />
+        </format>
+        <format name="VK_FORMAT_Z6G10_Z6B10_Z6R10_3PLANE_444_UNORM_3PACK16_EXT" class="10-bit 3-plane 444 LSB" blockSize="6" texelsPerBlock="1" chroma="444">
+            <component name="G" bits="10" numericFormat="UNORM" planeIndex="0" />
+            <component name="B" bits="10" numericFormat="UNORM" planeIndex="1" />
+            <component name="R" bits="10" numericFormat="UNORM" planeIndex="2" />
+            <plane index="0" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z6R10_UNORM_EXT" />
+            <plane index="1" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z6R10_UNORM_EXT" />
+            <plane index="2" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z6R10_UNORM_EXT" />
+        </format>
+        <format name="VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_420_UNORM_3PACK16_EXT" class="12-bit 3-plane 420 LSB" blockSize="6" texelsPerBlock="1" chroma="420">
+            <component name="G" bits="12" numericFormat="UNORM" planeIndex="0" />
+            <component name="B" bits="12" numericFormat="UNORM" planeIndex="1" />
+            <component name="R" bits="12" numericFormat="UNORM" planeIndex="2" />
+            <plane index="0" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z4R12_UNORM_EXT" />
+            <plane index="1" widthDivisor="2" heightDivisor="2" compatible="VK_FORMAT_Z4R12_UNORM_EXT" />
+            <plane index="2" widthDivisor="2" heightDivisor="2" compatible="VK_FORMAT_Z4R12_UNORM_EXT" />
+        </format>
+        <format name="VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_422_UNORM_3PACK16_EXT" class="12-bit 3-plane 422 LSB" blockSize="6" texelsPerBlock="1" chroma="422">
+            <component name="G" bits="12" numericFormat="UNORM" planeIndex="0" />
+            <component name="B" bits="12" numericFormat="UNORM" planeIndex="1" />
+            <component name="R" bits="12" numericFormat="UNORM" planeIndex="2" />
+            <plane index="0" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z4R12_UNORM_EXT" />
+            <plane index="1" widthDivisor="2" heightDivisor="1" compatible="VK_FORMAT_Z4R12_UNORM_EXT" />
+            <plane index="2" widthDivisor="2" heightDivisor="1" compatible="VK_FORMAT_Z4R12_UNORM_EXT" />
+        </format>
+        <format name="VK_FORMAT_Z4G12_Z4B12_Z4R12_3PLANE_444_UNORM_3PACK16_EXT" class="12-bit 3-plane 444 LSB" blockSize="6" texelsPerBlock="1" chroma="444">
+            <component name="G" bits="12" numericFormat="UNORM" planeIndex="0" />
+            <component name="B" bits="12" numericFormat="UNORM" planeIndex="1" />
+            <component name="R" bits="12" numericFormat="UNORM" planeIndex="2" />
+            <plane index="0" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z4R12_UNORM_EXT" />
+            <plane index="1" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z4R12_UNORM_EXT" />
+            <plane index="2" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z4R12_UNORM_EXT" />
+        </format>
+        <format name="VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_420_UNORM_3PACK16_EXT" class="14-bit 3-plane 420 LSB" blockSize="6" texelsPerBlock="1" chroma="420">
+            <component name="G" bits="14" numericFormat="UNORM" planeIndex="0" />
+            <component name="B" bits="14" numericFormat="UNORM" planeIndex="1" />
+            <component name="R" bits="14" numericFormat="UNORM" planeIndex="2" />
+            <plane index="0" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z2R14_UNORM_EXT" />
+            <plane index="1" widthDivisor="2" heightDivisor="2" compatible="VK_FORMAT_Z2R14_UNORM_EXT" />
+            <plane index="2" widthDivisor="2" heightDivisor="2" compatible="VK_FORMAT_Z2R14_UNORM_EXT" />
+        </format>
+        <format name="VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_422_UNORM_3PACK16_EXT" class="14-bit 3-plane 422 LSB" blockSize="6" texelsPerBlock="1" chroma="422">
+            <component name="G" bits="14" numericFormat="UNORM" planeIndex="0" />
+            <component name="B" bits="14" numericFormat="UNORM" planeIndex="1" />
+            <component name="R" bits="14" numericFormat="UNORM" planeIndex="2" />
+            <plane index="0" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z2R14_UNORM_EXT" />
+            <plane index="1" widthDivisor="2" heightDivisor="1" compatible="VK_FORMAT_Z2R14_UNORM_EXT" />
+            <plane index="2" widthDivisor="2" heightDivisor="1" compatible="VK_FORMAT_Z2R14_UNORM_EXT" />
+        </format>
+        <format name="VK_FORMAT_Z2G14_Z2B14_Z2R14_3PLANE_444_UNORM_3PACK16_EXT" class="14-bit 3-plane 444 LSB" blockSize="6" texelsPerBlock="1" chroma="444">
+            <component name="G" bits="14" numericFormat="UNORM" planeIndex="0" />
+            <component name="B" bits="14" numericFormat="UNORM" planeIndex="1" />
+            <component name="R" bits="14" numericFormat="UNORM" planeIndex="2" />
+            <plane index="0" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z2R14_UNORM_EXT" />
+            <plane index="1" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z2R14_UNORM_EXT" />
+            <plane index="2" widthDivisor="1" heightDivisor="1" compatible="VK_FORMAT_Z2R14_UNORM_EXT" />
         </format>
     </formats>
     <spirvextensions comment="SPIR-V Extensions allowed in Vulkan and what is required to use it">


### PR DESCRIPTION
This extension adds support for 10/12bit YCbCr formats used by software decoders like ffmpeg, dav1d and libvpx.

See also:
 - https://github.com/torvalds/linux/commit/2271e0a20ef795838527815e057f5af206b69c87
 - https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34303
 - https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/35576
 - https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/9251
 - https://www.ffmpeg.org/doxygen/1.0/pixfmt_8h.html

---

This branch as well as the related Mesa and GTK4 MRs have been in draft status for a while and already got a lot of testing. With the recent Gstreamer 1.28 release (shipped in distros like Fedora 44 and Ubuntu 26.04) they can be tested and used - e.g. the default Gnome Video player will make use of the new formats when playing HDR videos (for various codecs, including AV1, HEVC, H266, Pro-Res and DNxHR).

@gfxstrand I'd be super happy if you could have a look at this and, if you find time, help me get this over the line :sweat_smile: Most importantly point me to where I should elaborate more.