### PR TITLE
Reserve extension number 691 for VK_MESA_fragment_coverage_mask

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -31442,6 +31442,12 @@ endif::VK_KHR_internally_synchronized_queues[]
                 <enum value="&quot;VK_NV_extension_690&quot;"               name="VK_NV_EXTENSION_690_EXTENSION_NAME"/>
             </require>
         </extension>
+        <extension name="VK_MESA_fragment_coverage_mask" number="691" type="device" author="MESA" contact="Michal Krol @mjkrol" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_MESA_FRAGMENT_COVERAGE_MASK_SPEC_VERSION"/>
+                <enum value="&quot;VK_MESA_fragment_coverage_mask&quot;"    name="VK_MESA_FRAGMENT_COVERAGE_MASK_EXTENSION_NAME"/>
+            </require>
+        </extension>
     </extensions>
     <formats>
         <format name="VK_FORMAT_R4G4_UNORM_PACK8" class="8-bit" blockSize="1" texelsPerBlock="1" packed="8">


### PR DESCRIPTION
Add a disabled placeholder entry to vk.xml to reserve extension number for the upcoming VK_MESA_fragment_coverage_mask extension, which will expose the SPV_MESA_fragment_coverage_mask SPIR-V extension to Vulkan applications.