### PR TITLE
Fix race condition in antora-prep.py 

### DIFF
--- a/scripts/antora-prep.py
+++ b/scripts/antora-prep.py
@@ -445,9 +445,14 @@ class DocFile:
                 raise RuntimeError(f'Will not overwrite {text}: {path}')
 
         dir = os.path.dirname(path)
-        if not os.path.exists(dir):
-            # print(f'Creating {text} directory {dir}')
-            os.makedirs(dir)
+        # This used to only create the directory if os.path.exists(dir)
+        # failed, but this seemed to encounter race conditions with
+        # os.makedirs(dir) FileExistsError exceptions, even though there's
+        # no apparent parallelism that might cause it.
+        # Instead, call makedirs with exist_ok=True.
+
+        # print(f'Creating {text} directory {dir}')
+        os.makedirs(dir, exist_ok=True)
 
     def rewriteFile(self, overwrite = True, pageHeaders = None):
         """Write source file to component directory. Images are just symlinked

--- a/scripts/antora-prep.py
+++ b/scripts/antora-prep.py
@@ -447,7 +447,7 @@ class DocFile:
         dir = os.path.dirname(path)
         # This used to only create the directory if os.path.exists(dir)
         # failed, but this seemed to encounter race conditions with
-        # os.makedirs(dir) FileExistsError exceptions, even though there's
+        # os.makedirs(dir) FileExistsError exceptions, even though there is
         # no apparent parallelism that might cause it.
         # Instead, call makedirs with exist_ok=True.
 


### PR DESCRIPTION
when creating target directory for generated files.
This seems to happen almost entirely in Vulkan-Site CI when building the docs site though I have seen it once or twice locally.