### PR TITLE
Fix incorrect link

### DIFF
--- a/chapters/descriptors.adoc
+++ b/chapters/descriptors.adoc
@@ -15,7 +15,7 @@ ifdef::VK_EXT_descriptor_buffer[]
 <<descriptorbuffers,descriptor buffers>>,
 endif::VK_EXT_descriptor_buffer[]
 ifdef::VK_EXT_descriptor_heap,VK_EXT_descriptor_buffer[or]
-<<descriptors,descriptor sets>>.
+<<descriptorsets,descriptor sets>>.
 
 Shaders access descriptors via
 ifdef::VK_EXT_descriptor_heap[]

--- a/chapters/descriptors.adoc
+++ b/chapters/descriptors.adoc
@@ -15,7 +15,7 @@ ifdef::VK_EXT_descriptor_buffer[]
 <<descriptorbuffers,descriptor buffers>>,
 endif::VK_EXT_descriptor_buffer[]
 ifdef::VK_EXT_descriptor_heap,VK_EXT_descriptor_buffer[or]
-<<descriptorsets,descriptor sets>>.
+<<descriptors-sets, descriptor sets>>.
 
 Shaders access descriptors via
 ifdef::VK_EXT_descriptor_heap[]


### PR DESCRIPTION
Under the page for [`Resource Descriptors`](https://docs.vulkan.org/spec/latest/chapters/descriptors.html#descriptors), `descriptor sets` doesn't point to the page for [`Descriptor Sets`](https://docs.vulkan.org/spec/latest/chapters/descriptorsets.html), unlike `descriptor heaps` and `descriptor buffers`.