### PR TITLE
Refer to extension feature struct from feature tags in extensions, rather than promoted struct

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -25167,8 +25167,8 @@ endif::VK_KHR_internally_synchronized_queues[]
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES"/>
                 <enum extends="VkPipelineShaderStageCreateFlagBits"         name="VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT" alias="VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT"/>
                 <enum extends="VkPipelineShaderStageCreateFlagBits"         name="VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT" alias="VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT"/>
-                <feature name="subgroupSizeControl" struct="VkPhysicalDeviceSubgroupSizeControlFeatures"/>
-                <feature name="computeFullSubgroups" struct="VkPhysicalDeviceSubgroupSizeControlFeatures"/>
+                <feature name="subgroupSizeControl" struct="VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"/>
+                <feature name="computeFullSubgroups" struct="VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"/>
             </require>
         </extension>
         <extension name="VK_KHR_fragment_shading_rate" number="227" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_create_renderpass2),VK_VERSION_1_2" author="KHR" contact="Tobias Hector @tobski" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
@@ -26212,7 +26212,7 @@ endif::VK_KHR_internally_synchronized_queues[]
                 <enum extends="VkPipelineCacheCreateFlagBits"               name="VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT" alias="VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT"/>
                 <type name="VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"/>
                 <type name="VkPipelineCacheCreateFlagBits"/>
-                <feature name="pipelineCreationCacheControl" struct="VkPhysicalDevicePipelineCreationCacheControlFeatures"/>
+                <feature name="pipelineCreationCacheControl" struct="VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"/>
             </require>
         </extension>
         <extension name="VK_KHR_extension_299" number="299" type="device" author="KHR" contact="Mark Bellamy @mark.bellamy_arm" supported="disabled">


### PR DESCRIPTION
Fixes #2722

Note: no change to generated files, but the change may affect downstream consumers of these tags.