### PR TITLE
Fix two typos in image view usage description (resources chapter)

### DIFF
--- a/chapters/resources.adoc
+++ b/chapters/resources.adoc
@@ -6395,7 +6395,7 @@ specified in slink:VkImageCreateInfo at image creation time.
 ifdef::VK_BASE_VERSION_1_1,VK_KHR_maintenance2[]
 The implicit pname:usage can: be overridden by adding a
 slink:VkImageViewUsageCreateInfo
-ifdef::VK_KHR_extended_flags[or slinnk:VkImageViewUsage2CreateInfoKHR]
+ifdef::VK_KHR_extended_flags[or slink:VkImageViewUsage2CreateInfoKHR]
 structure to the pname:pNext chain, but the view usage must: be a subset of
 the image usage.
 endif::VK_BASE_VERSION_1_1,VK_KHR_maintenance2[]

--- a/chapters/resources.adoc
+++ b/chapters/resources.adoc
@@ -6403,7 +6403,7 @@ ifdef::VK_GRAPHICS_VERSION_1_2,VK_EXT_separate_stencil_usage[]
 If pname:image has a depth-stencil format and was created with a
 slink:VkImageStencilUsageCreateInfo structure included in the pname:pNext
 chain of slink:VkImageCreateInfo, the usage is calculated based on the
-pname:subresource.aspectMask provided:
+pname:subresourceRange.aspectMask provided:
 
   * If pname:aspectMask includes only ename:VK_IMAGE_ASPECT_STENCIL_BIT, the
     implicit pname:usage is equal to


### PR DESCRIPTION
Two small fixes in `chapters/resources.adoc`, in the VkImageViewCreateInfo
image view usage description:

1. `slinnk:VkImageViewUsage2CreateInfoKHR` -> `slink:VkImageViewUsage2CreateInfoKHR`
   The `slink:` macro was misspelled with an extra `n`, so
   VkImageViewUsage2CreateInfoKHR rendered as literal text instead of a
   cross-reference link.

2. `pname:subresource.aspectMask` -> `pname:subresourceRange.aspectMask`
   VkImageViewCreateInfo has a `subresourceRange` member (of type
   VkImageSubresourceRange); there is no `subresource` member. The
   surrounding text in the same chapter consistently refers to
   `pname:subresourceRange.aspectMask`.