### PR TITLE
cmdbuffers.adoc: correct ctrl+c/ctrl+v typo

### DIFF
--- a/chapters/cmdbuffers.adoc
+++ b/chapters/cmdbuffers.adoc
@@ -135,7 +135,7 @@ endif::VKSC_VERSION_1_0[]
     transition to the invalid state if any command buffer executed within it
     via flink:vkCmdExecuteCommands transitions to any state other than the
     pending or executable state.
-    Command buffers in the pending state that were recorded without the
+    Command buffers in the pending state that were recorded with the
     ename:VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT flag are immediately
     invalid as the final command in the command buffer completes all
     execution, which can be observed via <<synchronization, synchronization


### PR DESCRIPTION
The sentence was copied from description of executable state and needed to flip from `without` to `with` to be correct