### PR TITLE
Remove redundant `len="1"` attribute

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -15236,7 +15236,7 @@ endif::VK_KHR_internally_synchronized_queues[]
             <proto><type>VkResult</type> <name>vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkRenderPass</type> <name>renderpass</name></param>
-            <param len="1"><type>VkExtent2D</type>* <name>pMaxWorkgroupSize</name></param>
+            <param><type>VkExtent2D</type>* <name>pMaxWorkgroupSize</name></param>
         </command>
         <command export="vulkan,vulkansc">
             <proto><type>void</type> <name>vkDestroyPipeline</name></proto>


### PR DESCRIPTION
vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI::pMaxWorkgroupSize used `len="1"` attribute and was the only place where you could encounter such value. 1 is allowed value but itself is redundant and as mentioned in `registery.adoc` should be used for nested pointers like `len="<outer_len>,1` for array of pointers to single values

I would ping HUAWEI. But I don't know how 😅