### PR TITLE
xml: Reserve MWS author ID for the Mercurius Window System

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -82,6 +82,7 @@ branch of the member gitlab server.
         <tag name="FREDEMMOTT" author="Frederick Emmott" contact="Fred Emmott @fredemmott" />
         <tag name="MTK" author="Mediatek, Inc." contact="Samuel Huang @shengwenhuang" />
         <tag name="OPENXR" author="OpenXR Working Group" contact="Ron Bessems @rbessems" />
+        <tag name="MWS" author="Mercurius Window System" contact="Christopher Ross, chris@tebibyte.org, mercurius@tebibyte.org" />
     </tags>
 
     <types comment="Vulkan type definitions">


### PR DESCRIPTION
Add a <tag> entry to vk.xml reserving the MWS author ID for the Mercurius Window System, an open-source zero-trust network-native window system (https://mercurius.tebibyte.org). The ID will be used for a future Mercurius Vulkan WSI extension.

This reserves the MWS author ID for the Mercurius Window System:

https://mercurius.tebibyte.org/

Mercurius is a zero-trust open-source, network-native window system currently developing its Vulkan presentation interface. The author ID will be used for a future Mercurius Vulkan WSI extension.

Contact: Christopher Ross <chris@tebibyte.org>, mercurius@tebibyte.org
