### PR TITLE
Improved VK_EXT_descriptor_heap align limits

### DIFF
--- a/chapters/limits.adoc
+++ b/chapters/limits.adoc
@@ -7488,9 +7488,9 @@ ifdef::VK_EXT_descriptor_heap[]
 | pname:samplerDescriptorSize                 | - | 32                                                         | max
 | pname:imageDescriptorSize                   | - | 64                                                         | max
 | pname:bufferDescriptorSize                  | - | 128                                                        | max
-| pname:samplerDescriptorAlignment            | - | 32                                                         | max
-| pname:imageDescriptorAlignment              | - | 64                                                         | max
-| pname:bufferDescriptorAlignment             | - | 128                                                        | max
+| pname:samplerDescriptorAlignment            | - | [eq]#min(32, pname:samplerDescriptorSize)#                 | max
+| pname:imageDescriptorAlignment              | - | [eq]#min(64, pname:imageDescriptorSize)#                   | max
+| pname:bufferDescriptorAlignment             | - | [eq]#min(128, pname:bufferDescriptorSize)#                 | max
 | pname:maxPushDataSize                       | - | 256                                                        | min
 | pname:maxDescriptorHeapEmbeddedSamplers     | - | 2032                                                       | min
 | pname:samplerYcbcrConversionCount           | - | 3                                                          | max

--- a/proposals/VK_EXT_descriptor_heap.adoc
+++ b/proposals/VK_EXT_descriptor_heap.adoc
@@ -1018,9 +1018,9 @@ These properties have the following required values:
 | samplerDescriptorSize                 | 32                                                        | max   | Implementor request
 | imageDescriptorSize                   | 64                                                        | max   | Implementor request
 | bufferDescriptorSize                  | 128                                                       | max   | Implementor request
-| samplerDescriptorAlignment            | 32                                                        | max   | samplerDescriptorSize
-| imageDescriptorAlignment              | 64                                                        | max   | imageDescriptorSize
-| bufferDescriptorAlignment             | 128                                                       | max   | bufferDescriptorSize
+| samplerDescriptorAlignment            | min(32, samplerDescriptorSize)                            | max   | samplerDescriptorSize
+| imageDescriptorAlignment              | min(64, imageDescriptorSize)                              | max   | imageDescriptorSize
+| bufferDescriptorAlignment             | min(128, bufferDescriptorSize)                            | max   | bufferDescriptorSize
 | maxPushDataSize                       | 256                                                       | min   | Matches DirectX 12 requirements for root parameters
 | maxDescriptorHeapEmbeddedSamplers     | 2032                                                      | min   | DirectX 12 static sampler limit
 | samplerYcbcrConversionCount           | 3                                                         | max   | xref:{refpages}VkSamplerYcbcrConversionImageFormatProperties.html[combinedImageSamplerDescriptorCount]


### PR DESCRIPTION
The alignment limits must be less than or equal to the corresponding maximum size limits.
This is now represented by `min`.