### PR TITLE
Fix xref to <<SetAndBindingDecorations>>

### DIFF
--- a/chapters/descriptorheaps.adoc
+++ b/chapters/descriptorheaps.adoc
@@ -989,7 +989,7 @@ code:PushConstant {StorageClass}.
 Device addresses in push data are intended as the fast path for
 shader-constant data that does not fit into push data directly.
 These addresses can also be mapped to an existing buffer declaration in the
-shader using <<SetAndBindingDecorations>>, which will be the preferred path
+shader using <<descriptorheaps-bindings, set and binding decorations>>, which will be the preferred path
 for some implementations initially, though such implementations are expected
 to lean less on this mechanism over time.
 ====


### PR DESCRIPTION
This anchor is in the proposal document, not the specification. I'm not sure if this replacement xref is the right place, however.

@Tobski PTAL. I'd like to get this sorted before the next spec update.