### PR TITLE
Remove incorrect returnedonly from VkSwapchainTimeDomainPropertiesEXT

### DIFF
--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -3728,7 +3728,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint64_t</type>                         <name>refreshDuration</name><comment>Number of nanoseconds from the start of one refresh cycle to the next</comment></member>
             <member><type>uint64_t</type>                         <name>refreshInterval</name><comment>Interval in nanoseconds between refresh cycles durations</comment></member>
         </type>
-        <type category="struct" name="VkSwapchainTimeDomainPropertiesEXT" returnedonly="true">
+        <type category="struct" name="VkSwapchainTimeDomainPropertiesEXT">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_TIME_DOMAIN_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                                  <name>pNext</name></member>
             <member><type>uint32_t</type>                                               <name>timeDomainCount</name></member>


### PR DESCRIPTION
The struct is used to provide timeDomainCount, and only the array members are written by the implementation.